### PR TITLE
Relax loading XML values using FromValue

### DIFF
--- a/async-opcua-xml/src/lib.rs
+++ b/async-opcua-xml/src/lib.rs
@@ -95,9 +95,9 @@ impl FromValue for bool {
 
 impl<'input, T> XmlLoad<'input> for T
 where
-    T: FromValue,
+    T: FromValue + Default,
 {
     fn load(node: &Node<'_, 'input>) -> Result<Self, XmlError> {
-        T::from_value(node, "content", node.try_contents()?)
+        T::from_value(node, "content", node.try_contents().unwrap_or_default())
     }
 }


### PR DESCRIPTION
All the ones we currently use it for implement Default, so we can just use unwrap_or_defualt. This handles the case of empty strings, and is probably fine for other types. It's a little weird for numbers, but 0 is a pretty reasonable way to interpret an empty <Int></Int> tag.