### PR TITLE
Add some context to code gen errors

### DIFF
--- a/async-opcua-codegen/src/error.rs
+++ b/async-opcua-codegen/src/error.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     num::{ParseFloatError, ParseIntError},
     str::ParseBoolError,
 };
@@ -6,9 +7,9 @@ use std::{
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum CodeGenError {
+pub enum CodeGenErrorKind {
     #[error("Failed to load XML: {0}")]
-    XML(#[from] opcua_xml::XmlError),
+    Xml(#[from] opcua_xml::XmlError),
     #[error("Missing required field: {0}")]
     MissingRequiredValue(&'static str),
     #[error("Wrong format on field. Expected {0}, got {1}")]
@@ -27,26 +28,93 @@ pub enum CodeGenError {
     Io(String, std::io::Error),
 }
 
+#[derive(Error, Debug)]
+pub struct CodeGenError {
+    #[source]
+    pub kind: Box<CodeGenErrorKind>,
+    pub context: Option<String>,
+    pub file: Option<String>,
+}
+
+impl Display for CodeGenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Code generation failed: {}", self.kind)?;
+        if let Some(context) = &self.context {
+            write!(f, ", while {context}")?;
+        }
+        if let Some(file) = &self.file {
+            write!(f, ", while loading file {file}")?;
+        }
+        Ok(())
+    }
+}
+
 impl From<ParseIntError> for CodeGenError {
     fn from(value: ParseIntError) -> Self {
-        Self::ParseInt("content".to_owned(), value)
+        Self::new(CodeGenErrorKind::ParseInt("content".to_owned(), value))
     }
 }
 
 impl From<ParseBoolError> for CodeGenError {
     fn from(value: ParseBoolError) -> Self {
-        Self::ParseBool("content".to_owned(), value)
+        Self::new(CodeGenErrorKind::ParseBool("content".to_owned(), value))
     }
 }
 
 impl From<ParseFloatError> for CodeGenError {
     fn from(value: ParseFloatError) -> Self {
-        Self::ParseFloat("content".to_owned(), value)
+        Self::new(CodeGenErrorKind::ParseFloat("content".to_owned(), value))
+    }
+}
+
+impl From<opcua_xml::XmlError> for CodeGenError {
+    fn from(value: opcua_xml::XmlError) -> Self {
+        Self::new(value.into())
+    }
+}
+
+impl From<syn::Error> for CodeGenError {
+    fn from(value: syn::Error) -> Self {
+        Self::new(value.into())
     }
 }
 
 impl CodeGenError {
     pub fn io(msg: &str, e: std::io::Error) -> Self {
-        Self::Io(msg.to_owned(), e)
+        Self::new(CodeGenErrorKind::Io(msg.to_owned(), e))
+    }
+
+    pub fn other(msg: impl Into<String>) -> Self {
+        Self::new(CodeGenErrorKind::Other(msg.into()))
+    }
+
+    pub fn parse_int(field: impl Into<String>, error: ParseIntError) -> Self {
+        Self::new(CodeGenErrorKind::ParseInt(field.into(), error))
+    }
+
+    pub fn wrong_format(format: impl Into<String>, value: impl Into<String>) -> Self {
+        Self::new(CodeGenErrorKind::WrongFormat(format.into(), value.into()))
+    }
+
+    pub fn missing_required_value(name: &'static str) -> Self {
+        Self::new(CodeGenErrorKind::MissingRequiredValue(name))
+    }
+
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context = Some(context.into());
+        self
+    }
+
+    pub fn in_file(mut self, file: impl Into<String>) -> Self {
+        self.file = Some(file.into());
+        self
+    }
+
+    pub fn new(kind: CodeGenErrorKind) -> Self {
+        Self {
+            kind: Box::new(kind),
+            context: None,
+            file: None,
+        }
     }
 }

--- a/async-opcua-codegen/src/ids/gen.rs
+++ b/async-opcua-codegen/src/ids/gen.rs
@@ -35,7 +35,7 @@ pub fn parse(
         let vals: Vec<_> = line.split(",").collect();
         if vals.len() == 2 {
             let Some(type_name) = type_name else {
-                return Err(CodeGenError::Other(format!("CSV file {file_name} has only two columns, but no type name fallback was specified")));
+                return Err(CodeGenError::other(format!("CSV file {file_name} has only two columns, but no type name fallback was specified")));
             };
             types
                 .entry(type_name.to_owned())
@@ -50,7 +50,7 @@ pub fn parse(
                 .variants
                 .push((vals[1].parse()?, vals[0].to_owned()));
         } else {
-            return Err(CodeGenError::Other(format!(
+            return Err(CodeGenError::other(format!(
                 "CSV file {file_name} is on incorrect format. Expected two or three columns, got {}",
                 vals.len()
             )));

--- a/async-opcua-codegen/src/nodeset/render.rs
+++ b/async-opcua-codegen/src/nodeset/render.rs
@@ -28,11 +28,11 @@ fn nodeid_regex() -> &'static Regex {
 pub fn split_node_id(id: &str) -> Result<(&str, &str, u16), CodeGenError> {
     let captures = nodeid_regex()
         .captures(id)
-        .ok_or_else(|| CodeGenError::Other(format!("Invalid nodeId: {}", id)))?;
+        .ok_or_else(|| CodeGenError::other(format!("Invalid nodeId: {}", id)))?;
     let namespace = if let Some(ns) = captures.name("ns") {
         ns.as_str()
             .parse::<u16>()
-            .map_err(|_| CodeGenError::Other(format!("Invalid nodeId: {}", id)))?
+            .map_err(|_| CodeGenError::other(format!("Invalid nodeId: {}", id)))?
     } else {
         0
     };
@@ -40,7 +40,7 @@ pub fn split_node_id(id: &str) -> Result<(&str, &str, u16), CodeGenError> {
     let t = captures.name("t").unwrap();
     let idf = t.as_str();
     if idf.len() < 2 {
-        Err(CodeGenError::Other(format!("Invalid nodeId: {}", id)))?;
+        Err(CodeGenError::other(format!("Invalid nodeId: {}", id)))?;
     }
     let k = &idf[..2];
     let v = &idf[2..];
@@ -57,7 +57,7 @@ impl RenderExpr for NodeId {
             "i=" => {
                 let i = v
                     .parse::<u32>()
-                    .map_err(|_| CodeGenError::Other(format!("Invalid nodeId: {}", id)))?;
+                    .map_err(|_| CodeGenError::other(format!("Invalid nodeId: {}", id)))?;
                 parse_quote! { #i }
             }
             "s=" => {
@@ -65,17 +65,17 @@ impl RenderExpr for NodeId {
             }
             "g=" => {
                 let uuid = uuid::Uuid::parse_str(v)
-                    .map_err(|e| CodeGenError::Other(format!("Invalid nodeId: {}, {e}", id)))?;
+                    .map_err(|e| CodeGenError::other(format!("Invalid nodeId: {}, {e}", id)))?;
                 let bytes = uuid.as_bytes();
                 parse_quote! { opcua::types::Uuid::from_slice(&[#(#bytes)*,]).unwrap() }
             }
             "b=" => {
                 let bytes = base64::engine::general_purpose::STANDARD
                     .decode(v)
-                    .map_err(|e| CodeGenError::Other(format!("Invalid nodeId: {}, {e}", id)))?;
+                    .map_err(|e| CodeGenError::other(format!("Invalid nodeId: {}, {e}", id)))?;
                 parse_quote! { opcua::types::ByteString::from(vec![#(#bytes)*,]) }
             }
-            _ => return Err(CodeGenError::Other(format!("Invalid nodeId: {}", id))),
+            _ => return Err(CodeGenError::other(format!("Invalid nodeId: {}", id))),
         };
 
         let ns_item = if namespace == 0 {
@@ -101,12 +101,12 @@ fn qualified_name_regex() -> &'static Regex {
 pub fn split_qualified_name(name: &str) -> Result<(&str, u16), CodeGenError> {
     let captures = qualified_name_regex()
         .captures(name)
-        .ok_or_else(|| CodeGenError::Other(format!("Invalid qualifiedname: {}", name)))?;
+        .ok_or_else(|| CodeGenError::other(format!("Invalid qualifiedname: {}", name)))?;
 
     let namespace = if let Some(ns) = captures.name("ns") {
         ns.as_str()
             .parse::<u16>()
-            .map_err(|_| CodeGenError::Other(format!("Invalid nodeId: {}", name)))?
+            .map_err(|_| CodeGenError::other(format!("Invalid nodeId: {}", name)))?
     } else {
         0
     };

--- a/async-opcua-codegen/src/types/gen.rs
+++ b/async-opcua-codegen/src/types/gen.rs
@@ -268,7 +268,7 @@ impl CodeGenerator {
             let value_token = match item.typ {
                 EnumReprType::u8 => {
                     let value: u8 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to u8, {} is out of range",
                             value
                         ))
@@ -277,7 +277,7 @@ impl CodeGenerator {
                 }
                 EnumReprType::i16 => {
                     let value: i16 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to i16, {} is out of range",
                             value
                         ))
@@ -286,7 +286,7 @@ impl CodeGenerator {
                 }
                 EnumReprType::i32 => {
                     let value: i32 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to i32, {} is out of range",
                             value
                         ))
@@ -314,7 +314,7 @@ impl CodeGenerator {
 
         let mut impls = Vec::new();
         let size: usize = item.size.try_into().map_err(|_| {
-            CodeGenError::Other(format!("Value {} does not fit in a usize", item.size))
+            CodeGenError::other(format!("Value {} does not fit in a usize", item.size))
         })?;
         let write_method = Ident::new(&format!("write_{}", item.typ), Span::call_site());
 
@@ -455,7 +455,7 @@ impl CodeGenerator {
             let value_token = match item.typ {
                 EnumReprType::u8 => {
                     let value: u8 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to u8, {} is out of range",
                             value
                         ))
@@ -464,7 +464,7 @@ impl CodeGenerator {
                 }
                 EnumReprType::i16 => {
                     let value: i16 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to i16, {} is out of range",
                             value
                         ))
@@ -473,7 +473,7 @@ impl CodeGenerator {
                 }
                 EnumReprType::i32 => {
                     let value: i32 = value.try_into().map_err(|_| {
-                        CodeGenError::Other(format!(
+                        CodeGenError::other(format!(
                             "Unexpected error converting to i32, {} is out of range",
                             value
                         ))

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -52,6 +52,12 @@ pub fn generate_types(
 
     let generator = CodeGenerator::new(
         types_import_map,
+        [
+            "bool", "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "f32", "f64", "i32",
+        ]
+        .into_iter()
+        .map(|v| v.to_owned())
+        .collect(),
         types,
         target.default_excluded.clone(),
         CodeGenItemConfig {
@@ -65,6 +71,10 @@ pub fn generate_types(
 }
 
 pub fn type_loader_impl(ids: &[(EncodingIds, String)], namespace: &str) -> Vec<Item> {
+    if ids.is_empty() {
+        return Vec::new();
+    }
+
     let mut ids: Vec<_> = ids.iter().collect();
     ids.sort_by(|a, b| a.1.cmp(&b.1));
     let mut res = Vec::new();

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -23,7 +23,8 @@ pub fn generate_types(
     println!("Loading types from {}", target.file_path);
     let data = std::fs::read_to_string(format!("{}/{}", root_path, &target.file_path))
         .map_err(|e| CodeGenError::io(&format!("Failed to read file {}", target.file_path), e))?;
-    let type_dictionary = load_bsd_file(&data)?;
+    let type_dictionary =
+        load_bsd_file(&data).map_err(|e| CodeGenError::from(e).in_file(&target.file_path))?;
     println!(
         "Found {} raw elements in the type dictionary.",
         type_dictionary.elements.len()
@@ -39,7 +40,9 @@ pub fn generate_types(
         type_dictionary,
     )?;
     let target_namespace = type_loader.target_namespace();
-    let types = type_loader.from_bsd()?;
+    let types = type_loader
+        .from_bsd()
+        .map_err(|e| e.in_file(&target.file_path))?;
     println!("Generated code for {} types", types.len());
 
     let mut types_import_map = basic_types_import_map();

--- a/async-opcua-types/src/guid.rs
+++ b/async-opcua-types/src/guid.rs
@@ -137,4 +137,11 @@ impl Guid {
             uuid: Uuid::from_bytes(bytes),
         }
     }
+
+    /// Creates an UUID from a byte slice of exactly 16 bytes.
+    pub fn from_slice(bytes: &[u8]) -> Result<Guid, uuid::Error> {
+        Ok(Guid {
+            uuid: Uuid::from_slice(bytes)?,
+        })
+    }
 }


### PR DESCRIPTION
A bit of a rough way to do it, but it's relatively easy and not that intrusive. It's very nice to get some general context about where in the process an error occurred when generating code, so that you can CTRL-F into the offending XML file and find where the code gen gave up.

This adds some basic context to `CodeGenError` that lets us capture this information and pass it along. There's probably more that can be done, but this is a start.