### PR TITLE
Fix bug where certain server capability parameters were cast to u32 instead of u16

### DIFF
--- a/async-opcua-server/src/node_manager/memory/core.rs
+++ b/async-opcua-server/src/node_manager/memory/core.rs
@@ -274,16 +274,16 @@ impl CoreNodeManagerImpl {
                 (limits.max_array_length as u32).into()
             }
             VariableId::Server_ServerCapabilities_MaxBrowseContinuationPoints => {
-                (limits.max_browse_continuation_points as u32).into()
+                (limits.max_browse_continuation_points as u16).into()
             }
             VariableId::Server_ServerCapabilities_MaxByteStringLength => {
                 (limits.max_byte_string_length as u32).into()
             }
             VariableId::Server_ServerCapabilities_MaxHistoryContinuationPoints => {
-                (limits.max_history_continuation_points as u32).into()
+                (limits.max_history_continuation_points as u16).into()
             }
             VariableId::Server_ServerCapabilities_MaxQueryContinuationPoints => {
-                (limits.max_query_continuation_points as u32).into()
+                (limits.max_query_continuation_points as u16).into()
             }
             VariableId::Server_ServerCapabilities_MaxStringLength => {
                 (limits.max_string_length as u32).into()


### PR DESCRIPTION
According to the OPC-UA standard (https://reference.opcfoundation.org/Core/Part5/v104/docs/6.3.2) the following parameters should have the type uint16:
- MaxBrowseContinuationPoints
- MaxHistoryContinuationPoints
- MaxQueryContinuationPoints
In the current implementation of the library, these parameters are cast to u32. This causes a type mismatch bug when connecting from an OPC-UA client on a B&R PLC to a server using the library. The fix was verified on that B&R PLC, but has not been tested on other PLCs.