### PR TITLE
Support structures with optional fields

### DIFF
--- a/async-opcua-macros/src/encoding/attribute.rs
+++ b/async-opcua-macros/src/encoding/attribute.rs
@@ -7,7 +7,6 @@ pub(crate) struct EncodingFieldAttribute {
     pub rename: Option<String>,
     pub ignore: bool,
     pub no_default: bool,
-    #[allow(dead_code)]
     pub optional: bool,
 }
 

--- a/async-opcua-types/src/custom/json.rs
+++ b/async-opcua-types/src/custom/json.rs
@@ -411,9 +411,13 @@ impl JsonEncodable for DynamicStructure {
             }
             crate::StructureType::StructureWithOptionalFields => {
                 let mut encoding_mask = 0u32;
-                for (idx, (value, field)) in self.data.iter().zip(s.fields.iter()).enumerate() {
-                    if !field.is_optional || !matches!(value, Variant::Empty) {
-                        encoding_mask |= 1 << idx;
+                let mut optional_idx = 0;
+                for (value, field) in self.data.iter().zip(s.fields.iter()) {
+                    if field.is_optional {
+                        if !matches!(value, Variant::Empty) {
+                            encoding_mask |= 1 << optional_idx;
+                        }
+                        optional_idx += 1;
                     }
                 }
                 stream.name("EncodingMask")?;


### PR DESCRIPTION
Support in the encoding/decoding macros for StructureWithOptionalFields. This involves decoding/encoding an "EncodingMask", and using that to determine which fields to read.

It is meaningful for binary, less so for JSON, so we ignore it when decoding JSON objects. No reason to introduce unnecessary fragility.

There was also a bug in the way this was implemented in the custom struct, which I only discovered after more closely investigating the standard.