### PR TITLE
Support OPC-UA unions in the encoding macros

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ This is a list of things that are known to be missing, or ideas that could be im
 
  - Flesh out the server and client SDK with tooling for ease if use.
    - Make it even easier to implement custom node managers.
- - Support for StructureWithOptionalFields and Union in the encoding macros.
  - Implement Part 4 7.41.2.3, encrypted secrets. We currently only support legacy secrets. We should also support more encryption algorithms for secrets.
  - Write some form of support for IssuedToken based authentication on the client.
  - Implement a better framework for security checks on the server.

--- a/async-opcua-macros/src/encoding/unions.rs
+++ b/async-opcua-macros/src/encoding/unions.rs
@@ -1,0 +1,81 @@
+use syn::{Ident, Variant};
+
+use crate::utils::ItemAttr;
+
+use super::attribute::EncodingVariantAttribute;
+
+pub struct AdvancedEnumVariant {
+    pub name: Ident,
+    pub attr: EncodingVariantAttribute,
+    pub is_null: bool,
+}
+
+pub struct AdvancedEnum {
+    pub variants: Vec<AdvancedEnumVariant>,
+    pub ident: Ident,
+    pub null_variant: Option<Ident>,
+}
+
+impl AdvancedEnumVariant {
+    pub fn from_variant(variant: Variant) -> syn::Result<Self> {
+        let mut final_attr = EncodingVariantAttribute::default();
+        for attr in variant.attrs {
+            if attr.path().segments.len() == 1
+                && attr
+                    .path()
+                    .segments
+                    .first()
+                    .is_some_and(|s| s.ident == "opcua")
+            {
+                let data: EncodingVariantAttribute = attr.parse_args()?;
+                final_attr.combine(data);
+            }
+        }
+        if variant.fields.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                variant.fields,
+                "Macro only applicable to enums with a single field in each variant",
+            ));
+        }
+
+        let is_null = variant.fields.is_empty();
+
+        Ok(Self {
+            name: variant.ident,
+            attr: final_attr,
+            is_null,
+        })
+    }
+}
+
+impl AdvancedEnum {
+    pub fn from_input(
+        input: syn::DataEnum,
+        _attributes: Vec<syn::Attribute>,
+        ident: Ident,
+    ) -> syn::Result<Self> {
+        let variants = input
+            .variants
+            .into_iter()
+            .map(AdvancedEnumVariant::from_variant)
+            .collect::<syn::Result<Vec<_>>>()?;
+
+        let mut null_variant = None;
+        for vrt in &variants {
+            if vrt.is_null {
+                if null_variant.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &vrt.name,
+                        "Unions may only have one null variant",
+                    ));
+                }
+                null_variant = Some(vrt.name.clone());
+            }
+        }
+        Ok(Self {
+            variants,
+            ident,
+            null_variant,
+        })
+    }
+}

--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -298,7 +298,7 @@ impl BinaryEncodable for DynamicStructure {
                 }
             }
             StructureType::Union => {
-                write_u32(stream, self.discriminant)?;
+                write_u32(stream, self.discriminant + 1)?;
                 let (Some(value), Some(field)) =
                     (self.data.first(), s.fields.get(self.discriminant as usize))
                 else {
@@ -540,6 +540,13 @@ impl DynamicTypeLoader {
             }
             StructureType::Union => {
                 let discriminant = <u32 as BinaryDecodable>::decode(stream, ctx)?;
+                if discriminant < 1 {
+                    return Err(Error::decoding(format!(
+                        "Invalid discriminant: {}",
+                        discriminant
+                    )));
+                }
+                let discriminant = discriminant - 1;
                 let Some(field) = t.fields.get(discriminant as usize) else {
                     return Err(Error::decoding(format!(
                         "Invalid discriminant: {}",

--- a/async-opcua-types/src/tests/json.rs
+++ b/async-opcua-types/src/tests/json.rs
@@ -789,6 +789,8 @@ fn test_custom_struct_with_optional() {
             "Foo": 123,
         })
     );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
 
     let st = MyStructWithOptionalFields {
         foo: 123,
@@ -804,6 +806,8 @@ fn test_custom_struct_with_optional() {
             "MyOpt2": 321,
         })
     );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
 
     let st = MyStructWithOptionalFields {
         foo: 123,
@@ -823,4 +827,107 @@ fn test_custom_struct_with_optional() {
             }
         })
     );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
+}
+
+#[test]
+fn test_custom_union() {
+    mod opcua {
+        pub use crate as types;
+    }
+
+    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable)]
+    pub enum MyUnion {
+        Var1(i32),
+        #[opcua(rename = "EUInfo")]
+        Var2(EUInformation),
+        Var3(f64),
+    }
+
+    let st = MyUnion::Var1(123);
+    let v = to_value(&st).unwrap();
+    assert_eq!(
+        v,
+        json!({
+            "SwitchField": 1,
+            "Var1": 123
+        })
+    );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
+
+    let st = MyUnion::Var2(EUInformation {
+        namespace_uri: "test".into(),
+        unit_id: 123,
+        display_name: "test".into(),
+        description: "desc".into(),
+    });
+    let v = to_value(&st).unwrap();
+    assert_eq!(
+        v,
+        json!({
+            "SwitchField": 2,
+            "EUInfo": {
+                "NamespaceUri": "test",
+                "UnitId": 123,
+                "DisplayName": {
+                    "Text": "test",
+                },
+                "Description": {
+                    "Text": "desc",
+                }
+            }
+        })
+    );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
+
+    let st = MyUnion::Var3(123.123);
+    let v = to_value(&st).unwrap();
+    assert_eq!(
+        v,
+        json!({
+            "SwitchField": 3,
+            "Var3": 123.123
+        })
+    );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
+}
+
+#[test]
+fn test_custom_union_nullable() {
+    mod opcua {
+        pub use crate as types;
+    }
+
+    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable)]
+    pub enum MyUnion {
+        Var1(i32),
+        Null,
+    }
+
+    let st = MyUnion::Var1(123);
+    let v = to_value(&st).unwrap();
+    assert_eq!(
+        v,
+        json!({
+            "SwitchField": 1,
+            "Var1": 123
+        })
+    );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
+
+    let st = MyUnion::Null;
+    let v = to_value(&st).unwrap();
+    assert_eq!(
+        v,
+        json!({
+            "SwitchField": 0
+        })
+    );
+    let st_cmp = from_value(v).unwrap();
+    assert_eq!(st, st_cmp);
 }


### PR DESCRIPTION
This also fixes the way we did unions in the custom structs, which wasn't quite right.

Unions are a little fiddly, especially in JSON, but this should work.

OPC-UA as usual assumes that everything can be null, which means that OPC-UA unions need a special "Null" variant. I made it so that adding this variant is _technically_ optional, and ignored the name it is given.

No support for XML yet. It's doable, and we should probably add it, but I wanted to maybe look at migrating away from roxmltree first, producing _proper_ OPC-UA XML support, instead of the half-baked thing we currently have.

At some point I also want to look into building a system for encoding/decoding tests using the .NET SDK, but that's a bit too much for this PR.