### PR TITLE
Refactor FromXml to use same context and errors as binary and json

### DIFF
--- a/async-opcua-codegen/src/types/gen.rs
+++ b/async-opcua-codegen/src/types/gen.rs
@@ -367,8 +367,8 @@ impl CodeGenerator {
             impl opcua::types::xml::FromXml for #enum_ident {
                 fn from_xml(
                     element: &opcua::types::xml::XmlElement,
-                    ctx: &opcua::types::xml::XmlContext<'_>
-                ) -> Result<Self, opcua::types::xml::FromXmlError> {
+                    ctx: &opcua::types::Context<'_>
+                ) -> opcua::types::EncodingResult<Self> {
                     let val = #ty::from_xml(element, ctx)?;
                     Ok(Self::from_bits_truncate(val))
                 }

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -262,7 +262,7 @@ fn xml_loader_impl(ids: &[&(EncodingIds, String)], namespace: &str) -> (TokenStr
 
     let index_check = if namespace != BASE_NAMESPACE {
         quote! {
-            let idx = ctx.namespaces.namespaces().get_index(#namespace)?;
+            let idx = ctx.namespaces().get_index(#namespace)?;
             if idx != node_id.namespace {
                 return None;
             }
@@ -283,13 +283,13 @@ fn xml_loader_impl(ids: &[&(EncodingIds, String)], namespace: &str) -> (TokenStr
                 &self,
                 node_id: &opcua::types::NodeId,
                 stream: &opcua::types::xml::XmlElement,
-                ctx: &opcua::types::xml::XmlContext<'_>,
-            ) -> Option<Result<Box<dyn opcua::types::DynEncodable>, opcua::types::xml::FromXmlError>> {
+                ctx: &opcua::types::Context<'_>,
+            ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
                 #index_check
 
                 let Some(num_id) = node_id.as_u32() else {
-                    return Some(Err(opcua::types::xml::FromXmlError::Other(
-                        "Unsupported encoding ID, we only support numeric IDs".to_owned(),
+                    return Some(Err(opcua::types::Error::decoding(
+                        format!("Unsupported encoding ID {node_id}, we only support numeric IDs"),
                     )));
                 };
 

--- a/async-opcua-macros/src/encoding/xml.rs
+++ b/async-opcua-macros/src/encoding/xml.rs
@@ -26,8 +26,8 @@ pub fn generate_xml_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
         impl opcua::types::xml::FromXml for #ident {
             fn from_xml<'a>(
                 element: &opcua::types::xml::XmlElement,
-                ctx: &opcua::types::xml::XmlContext<'a>
-            ) -> Result<Self, opcua::types::xml::FromXmlError> {
+                ctx: &opcua::types::Context<'a>
+            ) -> Result<Self, opcua::types::Error> {
                 #body
                 Ok(Self {
                     #build
@@ -45,10 +45,10 @@ pub fn generate_simple_enum_xml_impl(en: SimpleEnum) -> syn::Result<TokenStream>
         impl opcua::types::xml::FromXml for #ident {
             fn from_xml<'a>(
                 element: &opcua::types::xml::XmlElement,
-                ctx: &opcua::types::xml::XmlContext<'a>
-            ) -> Result<Self, opcua::types::xml::FromXmlError> {
+                ctx: &opcua::types::Context<'a>
+            ) -> Result<Self, opcua::types::Error> {
                 let val = #repr::from_xml(element, ctx)?;
-                Ok(Self::try_from(val).map_err(|e| e.to_string())?)
+                Self::try_from(val).map_err(opcua::types::Error::decoding)
             }
         }
     })

--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -419,11 +419,9 @@ impl DynamicTypeLoader {
                     )?))
                 } else {
                     // Else, load the extension object body directly.
-                    Ok(Variant::from(ctx.load_from_binary(
-                        &field_ty.node_id,
-                        stream,
-                        ctx,
-                    )?))
+                    Ok(Variant::from(
+                        ctx.load_from_binary(&field_ty.node_id, stream)?,
+                    ))
                 }
             }
             crate::VariantScalarTypeId::DataValue => Ok(Variant::from(
@@ -597,8 +595,8 @@ impl TypeLoader for DynamicTypeLoader {
         &self,
         _node_id: &crate::NodeId,
         _body: &opcua_xml::XmlElement,
-        _ctx: &crate::xml::XmlContext<'_>,
-    ) -> Option<Result<Box<dyn crate::DynEncodable>, crate::xml::FromXmlError>> {
+        _ctx: &Context<'_>,
+    ) -> Option<crate::EncodingResult<Box<dyn crate::DynEncodable>>> {
         // TODO: Unimplemented.
         // This is a lot less useful than the others, since this method is currently only
         // used server-side, and server software will usually use codegen instead.

--- a/async-opcua-types/src/custom/json.rs
+++ b/async-opcua-types/src/custom/json.rs
@@ -184,11 +184,9 @@ impl DynamicTypeLoader {
                         stream, ctx,
                     )?))
                 } else {
-                    Ok(Variant::from(ctx.load_from_json(
-                        &field_ty.node_id,
-                        stream,
-                        ctx,
-                    )?))
+                    Ok(Variant::from(
+                        ctx.load_from_json(&field_ty.node_id, stream)?,
+                    ))
                 }
             }
             crate::VariantScalarTypeId::DataValue => Ok(Variant::from(

--- a/async-opcua-types/src/diagnostic_info.rs
+++ b/async-opcua-types/src/diagnostic_info.rs
@@ -64,10 +64,7 @@ bitflags! {
 
 #[cfg(feature = "xml")]
 impl crate::xml::FromXml for DiagnosticBits {
-    fn from_xml(
-        element: &opcua_xml::XmlElement,
-        ctx: &crate::xml::XmlContext<'_>,
-    ) -> Result<Self, crate::xml::FromXmlError> {
+    fn from_xml(element: &opcua_xml::XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
         let v = u32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(v))
     }

--- a/async-opcua-types/src/extension_object.rs
+++ b/async-opcua-types/src/extension_object.rs
@@ -245,7 +245,7 @@ mod json {
                                 )));
                             }
                             if let Some(type_id) = &type_id {
-                                body = Some(ctx.load_from_json(type_id, stream, ctx)?);
+                                body = Some(ctx.load_from_json(type_id, stream)?);
                             } else {
                                 raw_body = Some(consume_raw_value(stream)?);
                             }
@@ -282,7 +282,7 @@ mod json {
                 }
                 let mut cursor = Cursor::new(raw_body);
                 let mut inner_stream = JsonStreamReader::new(&mut cursor as &mut dyn Read);
-                Ok(ctx.load_from_json(&type_id, &mut inner_stream, ctx)?)
+                Ok(ctx.load_from_json(&type_id, &mut inner_stream)?)
             } else if let Some(binary_body) = raw_binary_body {
                 if encoding != 1 {
                     return Err(Error::decoding(format!("Unsupported extension object encoding, expected 1 for string, got {encoding}")));
@@ -291,7 +291,7 @@ mod json {
                     return Err(Error::decoding("Missing extension object body"));
                 };
                 let mut cursor = Cursor::new(raw);
-                Ok(ctx.load_from_binary(&type_id, &mut cursor as &mut dyn Read, ctx)?)
+                Ok(ctx.load_from_binary(&type_id, &mut cursor as &mut dyn Read)?)
             } else {
                 Err(Error::decoding("Missing extension object body"))
             }
@@ -380,7 +380,7 @@ impl BinaryDecodable for ExtensionObject {
                 if size <= 0 {
                     None
                 } else {
-                    Some(ctx.load_from_binary(&node_id, &mut stream, ctx)?)
+                    Some(ctx.load_from_binary(&node_id, &mut stream)?)
                 }
             }
             0x2 => {

--- a/async-opcua-types/src/generated/types/enums.rs
+++ b/async-opcua-types/src/generated/types/enums.rs
@@ -51,8 +51,8 @@ impl opcua::types::IntoVariant for AccessLevelExType {
 impl opcua::types::xml::FromXml for AccessLevelExType {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -119,8 +119,8 @@ impl opcua::types::IntoVariant for AccessLevelType {
 impl opcua::types::xml::FromXml for AccessLevelType {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = u8::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -186,8 +186,8 @@ impl opcua::types::IntoVariant for AccessRestrictionType {
 impl opcua::types::xml::FromXml for AccessRestrictionType {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i16::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -252,8 +252,8 @@ impl opcua::types::IntoVariant for AlarmMask {
 impl opcua::types::xml::FromXml for AlarmMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i16::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -350,8 +350,8 @@ impl opcua::types::IntoVariant for AttributeWriteMask {
 impl opcua::types::xml::FromXml for AttributeWriteMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -560,8 +560,8 @@ impl opcua::types::IntoVariant for DataSetFieldContentMask {
 impl opcua::types::xml::FromXml for DataSetFieldContentMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -626,8 +626,8 @@ impl opcua::types::IntoVariant for DataSetFieldFlags {
 impl opcua::types::xml::FromXml for DataSetFieldFlags {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i16::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -783,8 +783,8 @@ impl opcua::types::IntoVariant for EventNotifierType {
 impl opcua::types::xml::FromXml for EventNotifierType {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = u8::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1033,8 +1033,8 @@ impl opcua::types::IntoVariant for JsonDataSetMessageContentMask {
 impl opcua::types::xml::FromXml for JsonDataSetMessageContentMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1102,8 +1102,8 @@ impl opcua::types::IntoVariant for JsonNetworkMessageContentMask {
 impl opcua::types::xml::FromXml for JsonNetworkMessageContentMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1437,8 +1437,8 @@ impl opcua::types::IntoVariant for PasswordOptionsMask {
 impl opcua::types::xml::FromXml for PasswordOptionsMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1530,8 +1530,8 @@ impl opcua::types::IntoVariant for PermissionType {
 impl opcua::types::xml::FromXml for PermissionType {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1601,8 +1601,8 @@ impl opcua::types::IntoVariant for PubSubConfigurationRefMask {
 impl opcua::types::xml::FromXml for PubSubConfigurationRefMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -1885,8 +1885,8 @@ impl opcua::types::IntoVariant for TrustListValidationOptions {
 impl opcua::types::xml::FromXml for TrustListValidationOptions {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -2067,8 +2067,8 @@ impl opcua::types::IntoVariant for UadpDataSetMessageContentMask {
 impl opcua::types::xml::FromXml for UadpDataSetMessageContentMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -2137,8 +2137,8 @@ impl opcua::types::IntoVariant for UadpNetworkMessageContentMask {
 impl opcua::types::xml::FromXml for UadpNetworkMessageContentMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }
@@ -2204,8 +2204,8 @@ impl opcua::types::IntoVariant for UserConfigurationMask {
 impl opcua::types::xml::FromXml for UserConfigurationMask {
     fn from_xml(
         element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<Self> {
         let val = i32::from_xml(element, ctx)?;
         Ok(Self::from_bits_truncate(val))
     }

--- a/async-opcua-types/src/generated/types/mod.rs
+++ b/async-opcua-types/src/generated/types/mod.rs
@@ -5320,15 +5320,15 @@ impl opcua::types::TypeLoader for GeneratedTypeLoader {
         &self,
         node_id: &opcua::types::NodeId,
         stream: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Option<Result<Box<dyn opcua::types::DynEncodable>, opcua::types::xml::FromXmlError>> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
         if node_id.namespace != 0 {
             return None;
         }
         let Some(num_id) = node_id.as_u32() else {
-            return Some(Err(opcua::types::xml::FromXmlError::Other(
-                "Unsupported encoding ID, we only support numeric IDs".to_owned(),
-            )));
+            return Some(Err(opcua::types::Error::decoding(format!(
+                "Unsupported encoding ID {node_id}, we only support numeric IDs"
+            ))));
         };
         TYPES.decode_xml(num_id, stream, ctx)
     }

--- a/async-opcua-types/src/namespaces.rs
+++ b/async-opcua-types/src/namespaces.rs
@@ -122,4 +122,9 @@ impl<'a> NodeSetNamespaceMapper<'a> {
     pub fn namespaces(&'a self) -> &'a NamespaceMap {
         &*self.namespaces
     }
+
+    /// Return the inner index map.
+    pub fn index_map(&self) -> &HashMap<u16, u16> {
+        &self.index_map
+    }
 }

--- a/samples/custom-codegen/src/generated/types/mod.rs
+++ b/samples/custom-codegen/src/generated/types/mod.rs
@@ -96,19 +96,18 @@ impl opcua::types::TypeLoader for GeneratedTypeLoader {
         &self,
         node_id: &opcua::types::NodeId,
         stream: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Option<Result<Box<dyn opcua::types::DynEncodable>, opcua::types::xml::FromXmlError>> {
+        ctx: &opcua::types::Context<'_>,
+    ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
         let idx = ctx
-            .namespaces
             .namespaces()
             .get_index("http://opcfoundation.org/UA/PROFINET/")?;
         if idx != node_id.namespace {
             return None;
         }
         let Some(num_id) = node_id.as_u32() else {
-            return Some(Err(opcua::types::xml::FromXmlError::Other(
-                "Unsupported encoding ID, we only support numeric IDs".to_owned(),
-            )));
+            return Some(Err(opcua::types::Error::decoding(format!(
+                "Unsupported encoding ID {node_id}, we only support numeric IDs"
+            ))));
         };
         TYPES.decode_xml(num_id, stream, ctx)
     }


### PR DESCRIPTION
Required putting the Aliases table and IndexMap into Context, but that may make sense anyway, if we want to parse binary strings in XML schemas (yes this is, in theory, a thing...).

This is the first step to reworking FromXml into XmlDecodable and adding XmlEncodable, to make XML a proper first-class citizen like JSON and binary.

I did this first. The rework into XmlDecodable is going to be complicated enough without this refactor on top.

Next step is to build a generic XML stream deserializer, probably using quick-xml. We'll probably keep roxmltree for async-opcua-xml for the time being, since that library deals with much more complicated structures than what we find in OPC-UA XML.