### PR TITLE
Xml encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "chrono",
  "hashbrown 0.15.2",
  "log",
+ "percent-encoding-rfc3986",
  "regex",
  "serde_json",
  "struson",
@@ -1486,6 +1487,12 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "pico-args"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ name = "async-opcua-xml"
 version = "0.14.0"
 dependencies = [
  "chrono",
+ "quick-xml",
  "roxmltree",
  "thiserror",
  "uuid",
@@ -1583,6 +1584,15 @@ dependencies = [
  "syn 2.0.90",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "^0.4"
 parking_lot = { version = "^0.12", features = ["send_guard"] }
 postcard = { version = "^1", features = ["use-std"] }
 proc-macro2 = "^1"
+quick-xml = "0.37.2"
 quote = "^1"
 regex = "^1"
 roxmltree = "^0.20"

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,10 @@ This is a list of things that are known to be missing, or ideas that could be im
  - Implement a better framework for security checks on the server.
  - Write a sophisticated server example with a persistent store. This would be a great way to verify the flexibility of the server.
  - Write some "bad ideas" servers, it would be nice to showcase how flexible this is.
- - Re-implement XML. The current approach using roxmltree is easy to write, but not actually what we need if we really wanted to implement OPC-UA XML encoding. A stream-based low level XML parser like `quick-xml` would probably be a better option. An implementation could probably borrow a lot from the JSON implementation.
+ - Finish up XML implementation.
+   - Support for XML bodies in binary and JSON extension objects.
+   - Support for unions in derive macros.
+   - Support for XmlElement in Variant.
  - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
  - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.
  - Look into running certain services concurrently. Currently they are sequential because that makes everything much simpler, but the services that don't have any cross node-manager interaction could run on all node managers concurrently.

--- a/async-opcua-client/src/custom_types/mod.rs
+++ b/async-opcua-client/src/custom_types/mod.rs
@@ -52,6 +52,7 @@ struct RawTypeData {
     type_definition: Option<DataTypeDefinition>,
     is_abstract: bool,
     encoding_ids: Option<EncodingIds>,
+    name: String,
 }
 
 impl<T: FnMut(&NodeId) -> bool> DataTypeTreeBuilder<T> {
@@ -282,6 +283,7 @@ impl<T: FnMut(&NodeId) -> bool> DataTypeTreeBuilder<T> {
             if let Some(def) = type_data.type_definition {
                 let info = match TypeInfo::from_type_definition(
                     def,
+                    type_data.name,
                     type_data.encoding_ids,
                     type_data.is_abstract,
                     &id,

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -282,14 +282,14 @@ fn xml_loader_impl(ids: &[&(EncodingIds, String)], namespace: &str) -> (TokenStr
             fn load_from_xml(
                 &self,
                 node_id: &opcua::types::NodeId,
-                stream: &opcua::types::xml::XmlElement,
+                stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
                 ctx: &opcua::types::Context<'_>,
             ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
                 #index_check
 
                 let Some(num_id) = node_id.as_u32() else {
                     return Some(Err(opcua::types::Error::decoding(
-                        format!("Unsupported encoding ID {node_id}, we only support numeric IDs"),
+                        "Unsupported encoding ID. Only numeric encoding IDs are currently supported"
                     )));
                 };
 

--- a/async-opcua-macros/src/encoding/attribute.rs
+++ b/async-opcua-macros/src/encoding/attribute.rs
@@ -89,3 +89,38 @@ impl Parse for EncodingVariantAttribute {
         Ok(slf)
     }
 }
+
+#[derive(Debug, Default)]
+pub(crate) struct EncodingItemAttribute {
+    #[allow(unused)]
+    pub(crate) rename: Option<String>,
+}
+
+impl ItemAttr for EncodingItemAttribute {
+    fn combine(&mut self, other: Self) {
+        self.rename = other.rename;
+    }
+}
+
+impl Parse for EncodingItemAttribute {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut slf = Self::default();
+
+        loop {
+            let ident: Ident = input.parse()?;
+            match ident.to_string().as_str() {
+                "rename" => {
+                    input.parse::<Token![=]>()?;
+                    let val: LitStr = input.parse()?;
+                    slf.rename = Some(val.value());
+                }
+                _ => return Err(syn::Error::new_spanned(ident, "Unknown attribute value")),
+            }
+            if !input.peek(Token![,]) {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+        Ok(slf)
+    }
+}

--- a/async-opcua-macros/src/encoding/xml.rs
+++ b/async-opcua-macros/src/encoding/xml.rs
@@ -1,9 +1,10 @@
 use convert_case::{Case, Casing};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
+use syn::Ident;
 
 use quote::quote;
 
-use super::{enums::SimpleEnum, EncodingStruct};
+use super::{attribute::EncodingItemAttribute, enums::SimpleEnum, EncodingStruct};
 
 pub fn generate_xml_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
@@ -50,6 +51,229 @@ pub fn generate_simple_enum_xml_impl(en: SimpleEnum) -> syn::Result<TokenStream>
                 let val = #repr::from_xml(element, ctx)?;
                 Self::try_from(val).map_err(opcua::types::Error::decoding)
             }
+        }
+    })
+}
+
+pub fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+    let ident = strct.ident;
+    let mut body = quote! {
+        use opcua::types::xml::XmlWriteExt;
+    };
+
+    let any_optional = strct
+        .fields
+        .iter()
+        .any(|f| f.attr.optional && !f.attr.ignore);
+
+    if any_optional {
+        let mut optional_index = 0;
+        body.extend(quote! {
+            let mut encoding_mask = 0u32;
+        });
+        for field in &strct.fields {
+            if !field.attr.optional || field.attr.ignore {
+                continue;
+            }
+            let ident = &field.ident;
+            body.extend(quote! {
+                if self.#ident.as_ref().is_some() {
+                    encoding_mask |= 1 << #optional_index;
+                }
+            });
+            optional_index += 1;
+        }
+        body.extend(quote! {
+            stream.encode_child("EncodingMask", &encoding_mask, ctx)?;
+        });
+    }
+
+    for field in strct.fields {
+        if field.attr.ignore {
+            continue;
+        }
+
+        let name = field
+            .attr
+            .rename
+            .unwrap_or_else(|| field.ident.to_string().to_case(Case::Pascal));
+
+        let ident = field.ident;
+        if field.attr.optional {
+            body.extend(quote! {
+                if let Some(item) = &self.#ident {
+                    stream.encode_child(#name, item, ctx)?;
+                }
+            });
+        } else {
+            body.extend(quote! {
+                stream.encode_child(#name, &self.#ident, ctx)?;
+            });
+        }
+    }
+
+    Ok(quote! {
+        impl opcua::types::xml::XmlEncodable for #ident {
+            fn encode(
+                &self,
+                stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+                ctx: &opcua::types::Context<'_>,
+            ) -> opcua::types::EncodingResult<()> {
+                #body
+                Ok(())
+            }
+        }
+    })
+}
+
+pub fn generate_xml_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+    let ident = strct.ident;
+    let mut items = quote! {};
+    let mut items_match = quote! {};
+    let mut build = quote! {};
+
+    let has_header = strct.fields.iter().any(|i| {
+        matches!(
+            i.ident.to_string().as_str(),
+            "request_header" | "response_header"
+        )
+    });
+
+    if has_header {
+        items.extend(quote! {
+            let mut __request_handle = None;
+        });
+    }
+
+    for field in strct.fields {
+        if field.attr.ignore {
+            let ident = field.ident;
+
+            build.extend(quote! {
+                #ident: Default::default(),
+            });
+            continue;
+        }
+
+        let name = field
+            .attr
+            .rename
+            .unwrap_or_else(|| field.ident.to_string().to_case(Case::Pascal));
+        let is_header = matches!(name.as_str(), "RequestHeader" | "ResponseHeader");
+
+        let ident = field.ident;
+        items.extend(quote! {
+            let mut #ident = None;
+        });
+        if is_header {
+            let ty = Ident::new(&name, Span::call_site());
+            items_match.extend(quote! {
+                #name => {
+                    let __header: opcua::types::#ty = opcua::types::xml::XmlDecodable::decode(stream, ctx)?;
+                    __request_handle = Some(__header.request_handle);
+                }
+            });
+        } else if has_header {
+            items_match.extend(quote! {
+                #name => {
+                    #ident = Some(opcua::types::xml::XmlDecodable::decode(stream, ctx)
+                        .map_err(|e| e.maybe_with_request_handle(__request_handle))?);
+                }
+            });
+        } else {
+            items_match.extend(quote! {
+                #name => {
+                    #ident = Some(opcua::types::xml::XmlDecodable::decode(stream, ctx)?);
+                }
+            });
+        }
+
+        if field.attr.no_default {
+            let err = format!("Missing required field {name}");
+            let handle = if has_header {
+                quote! {
+                    .map_err(|e| e.maybe_with_request_handle(__request_handle))?
+                }
+            } else {
+                quote! {}
+            };
+            build.extend(quote! {
+                #ident: #ident.unwrap_or_else(|| {
+                    opcua::types::Error::decoding(#err)#handle
+                })?,
+            });
+        } else {
+            build.extend(quote! {
+                #ident: #ident.unwrap_or_default(),
+            });
+        }
+    }
+
+    Ok(quote! {
+        impl opcua::types::xml::XmlDecodable for #ident {
+            fn decode(
+                stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
+                ctx: &opcua::types::Context<'_>,
+            ) -> opcua::types::EncodingResult<Self> {
+                use opcua::types::xml::XmlReadExt;
+                #items
+                stream.iter_children(|__key, stream, ctx| {
+                    match __key.as_str() {
+                        #items_match
+                        _ => {
+                            stream.skip_value()?;
+                        }
+                    }
+                    Ok(())
+                }, ctx)?;
+
+                Ok(Self {
+                    #build
+                })
+            }
+        }
+    })
+}
+
+pub fn generate_simple_enum_xml_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+    let ident = en.ident;
+
+    Ok(quote! {
+        impl opcua::types::xml::XmlDecodable for #ident {
+            fn decode(
+                stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
+                ctx: &opcua::types::Context<'_>,
+            ) -> opcua::types::EncodingResult<Self> {
+                use std::str::FromStr;
+                let val = stream.consume_as_text()?;
+                opcua::types::UaEnum::from_str(&val)
+            }
+        }
+    })
+}
+
+pub fn generate_simple_enum_xml_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+    let ident = en.ident;
+
+    Ok(quote! {
+        impl opcua::types::xml::XmlEncodable for #ident {
+            fn encode(
+                &self,
+                stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+                _ctx: &opcua::types::Context<'_>,
+            ) -> opcua::types::EncodingResult<()> {
+                stream.write_text(opcua::types::UaEnum::as_str(self))?;
+                Ok(())
+            }
+        }
+    })
+}
+
+pub fn generate_xml_type_impl(idt: Ident, attr: EncodingItemAttribute) -> syn::Result<TokenStream> {
+    let name = attr.rename.unwrap_or_else(|| idt.to_string());
+    Ok(quote! {
+        impl opcua::types::xml::XmlType for #idt {
+            const TAG: &'static str = #name;
         }
     })
 }

--- a/async-opcua-macros/src/lib.rs
+++ b/async-opcua-macros/src/lib.rs
@@ -148,3 +148,40 @@ pub fn derive_ua_enum(item: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error().into(),
     }
 }
+
+#[cfg(feature = "xml")]
+#[proc_macro_derive(XmlEncodable, attributes(opcua))]
+/// Derive the `XmlEncodable` trait on this struct or enum, creating
+/// code to write the struct as OPC-UA XML.
+///
+/// All fields must be marked with `opcua(ignore)` or implement `XmlEncodable`.
+pub fn derive_xml_encodable(item: TokenStream) -> TokenStream {
+    match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::XmlEncode) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[cfg(feature = "xml")]
+#[proc_macro_derive(XmlDecodable, attributes(opcua))]
+/// Derive the `XmlDecodable` trait on this struct or enum, creating
+/// code to read the struct from an OPC-UA xml stream.
+///
+/// All fields must be marked with `opcua(ignore)` or implement `XmlDecodable`.
+pub fn derive_xml_decodable(item: TokenStream) -> TokenStream {
+    match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::XmlDecode) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[cfg(feature = "xml")]
+#[proc_macro_derive(XmlType, attributes(opcua))]
+/// Derive the `XmlType` trait on this struct or enum. This simply exposes
+/// the type name, which can be overridden with an item-level `opcua(rename = ...)` attribute.
+pub fn derive_xml_type(item: TokenStream) -> TokenStream {
+    match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::XmlType) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}

--- a/async-opcua-types/Cargo.toml
+++ b/async-opcua-types/Cargo.toml
@@ -34,6 +34,7 @@ struson = { workspace = true, optional = true }
 
 async-opcua-macros = { path = "../async-opcua-macros", version = "0.14.0" }
 async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.14.0" }
+percent-encoding-rfc3986 = "0.1.3"
 
 [dev-dependencies]
 async-opcua-types = { path = ".", features = ["xml", "json"] }

--- a/async-opcua-types/src/argument.rs
+++ b/async-opcua-types/src/argument.rs
@@ -33,7 +33,10 @@ mod opcua {
 
 #[derive(Clone, Debug, PartialEq, Default)]
 #[cfg_attr(feature = "json", derive(crate::JsonEncodable, crate::JsonDecodable))]
-#[cfg_attr(feature = "xml", derive(crate::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(crate::XmlEncodable, crate::XmlDecodable, crate::XmlType)
+)]
 /// OPC-UA method argument.
 pub struct Argument {
     /// Argument name.

--- a/async-opcua-types/src/byte_string.rs
+++ b/async-opcua-types/src/byte_string.rs
@@ -81,6 +81,10 @@ mod xml {
 
     use super::ByteString;
 
+    impl XmlType for ByteString {
+        const TAG: &'static str = "ByteString";
+    }
+
     impl XmlEncodable for ByteString {
         fn encode(
             &self,

--- a/async-opcua-types/src/custom/json.rs
+++ b/async-opcua-types/src/custom/json.rs
@@ -564,6 +564,7 @@ mod tests {
                         },
                     ]),
                 }),
+                "EUInformation".to_owned(),
                 Some(EncodingIds {
                     binary_id: NodeId::new(1, 6),
                     json_id: NodeId::new(1, 7),

--- a/async-opcua-types/src/custom/mod.rs
+++ b/async-opcua-types/src/custom/mod.rs
@@ -5,6 +5,8 @@ mod custom_struct;
 #[cfg(feature = "json")]
 mod json;
 mod type_tree;
+#[cfg(feature = "xml")]
+mod xml;
 
 pub use custom_struct::{DynamicStructure, DynamicTypeLoader};
 pub use type_tree::{

--- a/async-opcua-types/src/custom/type_tree.rs
+++ b/async-opcua-types/src/custom/type_tree.rs
@@ -98,6 +98,8 @@ pub struct StructTypeInfo {
     pub is_abstract: bool,
     /// Structure node ID.
     pub node_id: NodeId,
+    /// Structure name.
+    pub name: String,
 }
 
 impl StructTypeInfo {
@@ -308,6 +310,7 @@ impl TypeInfo {
     /// Build a TypeInfo from the data type definition of the data type.
     pub fn from_type_definition(
         value: DataTypeDefinition,
+        name: String,
         encoding_ids: Option<EncodingIds>,
         is_abstract: bool,
         node_id: &NodeId,
@@ -340,6 +343,7 @@ impl TypeInfo {
                     is_abstract,
                     node_id: node_id.clone(),
                     index_by_name: fields_by_name,
+                    name,
                 })))
             }
             DataTypeDefinition::Enum(d) => Ok(Self::Enum(Arc::new(EnumTypeInfo {

--- a/async-opcua-types/src/custom/xml.rs
+++ b/async-opcua-types/src/custom/xml.rs
@@ -1,0 +1,443 @@
+use std::{collections::HashMap, io::Write, sync::Arc};
+
+use crate::{
+    xml::*, Array, ByteString, DataValue, DateTime, DiagnosticInfo, DynEncodable, ExpandedNodeId,
+    ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, StructureType,
+    UAString, Variant, VariantScalarTypeId, XmlElement,
+};
+
+use super::{DynamicStructure, DynamicTypeLoader, ParsedStructureField, StructTypeInfo};
+
+impl XmlType for DynamicStructure {
+    // Should never be used, kept as a fallback.
+    const TAG: &'static str = "Unknown";
+    fn tag(&self) -> &str {
+        &self.type_def.name
+    }
+}
+
+impl DynamicStructure {
+    fn xml_encode_field(
+        &self,
+        stream: &mut XmlStreamWriter<&mut dyn Write>,
+        f: &Variant,
+        field: &ParsedStructureField,
+        ctx: &Context<'_>,
+    ) -> EncodingResult<()> {
+        stream.write_start(&field.name)?;
+        match f {
+            Variant::ExtensionObject(o) => {
+                let Some(field_ty) = self.type_tree.get_struct_type(&field.type_id) else {
+                    return Err(Error::encoding(format!(
+                        "Dynamic type field missing from type tree: {}",
+                        field.type_id
+                    )));
+                };
+                if field_ty.is_abstract {
+                    o.encode(stream, ctx)
+                } else {
+                    let Some(body) = &o.body else {
+                        return Err(Error::encoding(
+                            "Dynamic type field is missing extension object body",
+                        ));
+                    };
+                    body.encode_xml(stream, ctx)
+                }
+            }
+            Variant::Array(a) => {
+                if field.value_rank > 1 {
+                    let Some(dims) = &a.dimensions else {
+                        return Err(Error::encoding(
+                            "ArrayDimensions are required for fields with value rank > 1",
+                        ));
+                    };
+                    if dims.len() as i32 != field.value_rank {
+                        return Err(Error::encoding(
+                            "ArrayDimensions must have length equal to field valuerank",
+                        ));
+                    }
+                    // For some incredibly annoying reason, OPC-UA insists that dimensions be
+                    // encoded as _signed_ integers. For other encoders it's irrelevant,
+                    // but it matters for XML.
+                    let dims: Vec<_> = dims.iter().map(|d| *d as i32).collect();
+                    stream.encode_child("Dimensions", &dims, ctx)?;
+
+                    stream.write_start("Elements")?;
+                    for item in &a.values {
+                        item.encode(stream, ctx)?;
+                    }
+                    stream.write_end("Elements")?;
+                } else {
+                    for item in &a.values {
+                        item.encode(stream, ctx)?;
+                    }
+                }
+                Ok(())
+            }
+            Variant::Empty => Ok(()),
+            Variant::Boolean(v) => v.encode(stream, ctx),
+            Variant::SByte(v) => v.encode(stream, ctx),
+            Variant::Byte(v) => v.encode(stream, ctx),
+            Variant::Int16(v) => v.encode(stream, ctx),
+            Variant::UInt16(v) => v.encode(stream, ctx),
+            Variant::Int32(v) => v.encode(stream, ctx),
+            Variant::UInt32(v) => v.encode(stream, ctx),
+            Variant::Int64(v) => v.encode(stream, ctx),
+            Variant::UInt64(v) => v.encode(stream, ctx),
+            Variant::Float(v) => v.encode(stream, ctx),
+            Variant::Double(v) => v.encode(stream, ctx),
+            Variant::String(v) => v.encode(stream, ctx),
+            Variant::DateTime(v) => v.encode(stream, ctx),
+            Variant::Guid(v) => v.encode(stream, ctx),
+            Variant::StatusCode(v) => v.encode(stream, ctx),
+            Variant::ByteString(v) => v.encode(stream, ctx),
+            Variant::XmlElement(v) => v.encode(stream, ctx),
+            Variant::QualifiedName(v) => v.encode(stream, ctx),
+            Variant::LocalizedText(v) => v.encode(stream, ctx),
+            Variant::NodeId(v) => v.encode(stream, ctx),
+            Variant::ExpandedNodeId(v) => v.encode(stream, ctx),
+            Variant::Variant(v) => v.encode(stream, ctx),
+            Variant::DataValue(v) => v.encode(stream, ctx),
+            Variant::DiagnosticInfo(v) => v.encode(stream, ctx),
+        }?;
+        stream.write_end(&field.name)?;
+        Ok(())
+    }
+}
+
+impl DynamicTypeLoader {
+    fn xml_decode_field_value(
+        &self,
+        field: &ParsedStructureField,
+        stream: &mut crate::xml::XmlStreamReader<&mut dyn std::io::Read>,
+        ctx: &Context<'_>,
+    ) -> EncodingResult<Variant> {
+        match field.scalar_type {
+            VariantScalarTypeId::Boolean => {
+                Ok(Variant::from(<bool as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::SByte => {
+                Ok(Variant::from(<i8 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Byte => {
+                Ok(Variant::from(<u8 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Int16 => {
+                Ok(Variant::from(<i16 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::UInt16 => {
+                Ok(Variant::from(<u16 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Int32 => {
+                Ok(Variant::from(<i32 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::UInt32 => {
+                Ok(Variant::from(<u32 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Int64 => {
+                Ok(Variant::from(<i64 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::UInt64 => {
+                Ok(Variant::from(<u64 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Float => {
+                Ok(Variant::from(<f32 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::Double => {
+                Ok(Variant::from(<f64 as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::String => Ok(Variant::from(<UAString as XmlDecodable>::decode(
+                stream, ctx,
+            )?)),
+            VariantScalarTypeId::DateTime => Ok(Variant::from(<DateTime as XmlDecodable>::decode(
+                stream, ctx,
+            )?)),
+            VariantScalarTypeId::Guid => {
+                Ok(Variant::from(<Guid as XmlDecodable>::decode(stream, ctx)?))
+            }
+            VariantScalarTypeId::ByteString => Ok(Variant::from(
+                <ByteString as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::XmlElement => Ok(Variant::from(
+                <XmlElement as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::NodeId => Ok(Variant::from(<NodeId as XmlDecodable>::decode(
+                stream, ctx,
+            )?)),
+            VariantScalarTypeId::ExpandedNodeId => Ok(Variant::from(
+                <ExpandedNodeId as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::StatusCode => Ok(Variant::from(
+                <StatusCode as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::QualifiedName => Ok(Variant::from(
+                <QualifiedName as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::LocalizedText => Ok(Variant::from(
+                <LocalizedText as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::ExtensionObject => {
+                let Some(field_ty) = self.type_tree.get_struct_type(&field.type_id) else {
+                    return Err(Error::decoding(format!(
+                        "Dynamic type field missing from type tree: {}",
+                        field.type_id
+                    )));
+                };
+
+                if field_ty.is_abstract {
+                    Ok(Variant::from(<ExtensionObject as XmlDecodable>::decode(
+                        stream, ctx,
+                    )?))
+                } else {
+                    Ok(Variant::from(ctx.load_from_xml(&field_ty.node_id, stream)?))
+                }
+            }
+            VariantScalarTypeId::DataValue => Ok(Variant::from(
+                <DataValue as XmlDecodable>::decode(stream, ctx)?,
+            )),
+            VariantScalarTypeId::Variant => Ok(Variant::Variant(Box::new(
+                <Variant as XmlDecodable>::decode(stream, ctx)?,
+            ))),
+            VariantScalarTypeId::DiagnosticInfo => Ok(Variant::from(
+                <DiagnosticInfo as XmlDecodable>::decode(stream, ctx)?,
+            )),
+        }
+    }
+
+    fn xml_decode_field(
+        &self,
+        field: &ParsedStructureField,
+        stream: &mut crate::xml::XmlStreamReader<&mut dyn std::io::Read>,
+        ctx: &Context<'_>,
+    ) -> EncodingResult<Variant> {
+        if field.value_rank > 1 {
+            let mut values = Vec::new();
+            let mut dims = Vec::new();
+            stream.iter_children(
+                |key, stream, ctx| {
+                    match key.as_str() {
+                        "Dimensions" => {
+                            dims = Vec::<i32>::decode(stream, ctx)?;
+                        }
+                        "Elements" => stream.iter_children_include_empty(
+                            |_, stream, ctx| {
+                                let Some(stream) = stream else {
+                                    values.push(Variant::get_variant_default(field.scalar_type));
+                                    return Ok(());
+                                };
+                                let r = self.xml_decode_field_value(field, stream, ctx)?;
+                                values.push(r);
+                                Ok(())
+                            },
+                            ctx,
+                        )?,
+                        r => {
+                            return Err(Error::decoding(format!(
+                                "Invalid field in Matrix content: {r}"
+                            )))
+                        }
+                    }
+                    Ok(())
+                },
+                ctx,
+            )?;
+            Ok(Variant::Array(Box::new(
+                Array::new_multi(
+                    field.scalar_type,
+                    values,
+                    dims.into_iter()
+                        .map(|d| d.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(|_| {
+                            Error::decoding("Invalid array dimensions, must all be non-negative")
+                        })?,
+                )
+                .map_err(Error::decoding)?,
+            )))
+        } else if field.value_rank > 0 {
+            let mut values = Vec::new();
+            stream.iter_children_include_empty(
+                |_, stream, ctx| {
+                    let Some(stream) = stream else {
+                        values.push(Variant::get_variant_default(field.scalar_type));
+                        return Ok(());
+                    };
+                    let r = self.xml_decode_field_value(field, stream, ctx)?;
+                    values.push(r);
+                    Ok(())
+                },
+                ctx,
+            )?;
+            Ok(Variant::Array(Box::new(
+                Array::new(field.scalar_type, values).map_err(Error::decoding)?,
+            )))
+        } else {
+            self.xml_decode_field_value(field, stream, ctx)
+        }
+    }
+
+    pub(super) fn xml_decode_type_inner(
+        &self,
+        stream: &mut crate::xml::XmlStreamReader<&mut dyn std::io::Read>,
+        ctx: &Context<'_>,
+        t: &Arc<StructTypeInfo>,
+    ) -> EncodingResult<Box<dyn DynEncodable>> {
+        match t.structure_type {
+            StructureType::Structure | StructureType::StructureWithOptionalFields => {
+                let mut by_name = HashMap::new();
+                stream.iter_children(
+                    |key, stream, ctx| {
+                        let Some(field) = t.get_field_by_name(&key) else {
+                            stream.skip_value()?;
+                            return Ok(());
+                        };
+                        by_name.insert(
+                            field.name.as_str(),
+                            self.xml_decode_field(field, stream, ctx)?,
+                        );
+                        Ok(())
+                    },
+                    ctx,
+                )?;
+
+                let mut data = Vec::with_capacity(by_name.len());
+                for field in &t.fields {
+                    let Some(f) = by_name.remove(field.name.as_str()) else {
+                        if field.is_optional {
+                            data.push(Variant::Empty);
+                            continue;
+                        }
+                        return Err(Error::decoding(format!(
+                            "Missing required field {}",
+                            field.name
+                        )));
+                    };
+                    data.push(f);
+                }
+
+                Ok(Box::new(DynamicStructure {
+                    type_def: t.clone(),
+                    discriminant: 0,
+                    type_tree: self.type_tree.clone(),
+                    data,
+                }))
+            }
+            StructureType::Union => {
+                let mut value: Option<Variant> = None;
+                let mut discriminant: Option<u32> = None;
+
+                stream.iter_children(
+                    |key, stream, ctx| {
+                        match key.as_str() {
+                            "SwitchField" => {
+                                discriminant = Some(u32::decode(stream, ctx)?);
+                            }
+                            r => {
+                                let Some((idx, value_field)) =
+                                    t.fields.iter().enumerate().find(|(_, f)| f.name == r)
+                                else {
+                                    stream.skip_value()?;
+                                    return Ok(());
+                                };
+
+                                // If we've read the discriminant, double check that it matches the field name.
+                                // OPC-UA unions are really only allowed to have two fields, but we can try to handle
+                                // weird payloads anyway.
+                                // Technically doesn't handle cases where there are multiple options _and_ the discriminant
+                                // is late, but that violates the standard so it's probably fine.
+                                if discriminant.is_some_and(|d| d != (idx + 1) as u32) {
+                                    stream.skip_value()?;
+                                } else {
+                                    value =
+                                        Some(self.xml_decode_field(value_field, stream, ctx)?);
+                                    discriminant = Some((idx + 1) as u32);
+                                }
+                            }
+                        }
+                        Ok(())
+                    },
+                    ctx,
+                )?;
+
+                let Some(value) = value else {
+                    return Err(Error::decoding("Missing union value"));
+                };
+
+                let Some(discriminant) = discriminant else {
+                    return Err(Error::decoding("Missing discriminant"));
+                };
+
+                if discriminant == 0 {
+                    return Err(Error::decoding("Discriminant must be non-zero"));
+                }
+
+                Ok(Box::new(DynamicStructure {
+                    type_def: t.clone(),
+                    discriminant: discriminant - 1,
+                    type_tree: self.type_tree.clone(),
+                    data: vec![value],
+                }))
+            }
+            StructureType::StructureWithSubtypedValues => {
+                todo!("StructureWithSubtypedValues is unsupported")
+            }
+            StructureType::UnionWithSubtypedValues => {
+                todo!("UnionWithSubtypedValues is unsupported")
+            }
+        }
+    }
+}
+
+impl XmlEncodable for DynamicStructure {
+    fn encode(
+        &self,
+        stream: &mut XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &Context<'_>,
+    ) -> EncodingResult<()> {
+        let s = &self.type_def;
+        match s.structure_type {
+            StructureType::Structure => {
+                for (value, field) in self.data.iter().zip(s.fields.iter()) {
+                    self.xml_encode_field(stream, value, field, ctx)?;
+                }
+            }
+            StructureType::StructureWithOptionalFields => {
+                let mut encoding_mask = 0u32;
+                let mut optional_idx = 0;
+                for (value, field) in self.data.iter().zip(s.fields.iter()) {
+                    if field.is_optional {
+                        if !matches!(value, Variant::Empty) {
+                            encoding_mask |= 1 << optional_idx;
+                        }
+                        optional_idx += 1;
+                    }
+                }
+                stream.encode_child("EncodingMask", &encoding_mask, ctx)?;
+                for (value, field) in self.data.iter().zip(s.fields.iter()) {
+                    if !field.is_optional || !matches!(value, Variant::Empty) {
+                        self.xml_encode_field(stream, value, field, ctx)?;
+                    }
+                }
+            }
+            StructureType::Union => {
+                stream.encode_child("SwitchField", &self.discriminant, ctx)?;
+                let (Some(value), Some(field)) =
+                    (self.data.first(), s.fields.get(self.discriminant as usize))
+                else {
+                    return Err(Error::encoding(
+                        "Discriminant was out of range of known fields",
+                    ));
+                };
+                self.xml_encode_field(stream, value, field, ctx)?;
+            }
+            StructureType::StructureWithSubtypedValues => {
+                todo!("StructureWithSubtypedValues is unsupported")
+            }
+            StructureType::UnionWithSubtypedValues => {
+                todo!("UnionWithSubtypedValues is unsupported")
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/async-opcua-types/src/date_time.rs
+++ b/async-opcua-types/src/date_time.rs
@@ -57,7 +57,7 @@ mod json {
         ) -> super::EncodingResult<Self> {
             let v = stream.next_str()?;
             let dt = DateTime::parse_from_rfc3339(v)
-                .map_err(|e| Error::decoding(format!("Cannot parse date time: {e}")))?;
+                .map_err(|e| Error::decoding(format!("Cannot parse date time \"{v}\": {e}")))?;
             Ok(dt)
         }
     }
@@ -69,6 +69,10 @@ mod xml {
     use std::io::{Read, Write};
 
     use super::DateTime;
+
+    impl XmlType for DateTime {
+        const TAG: &'static str = "DateTime";
+    }
 
     impl XmlEncodable for DateTime {
         fn encode(
@@ -87,7 +91,7 @@ mod xml {
         ) -> Result<Self, Error> {
             let v = read.consume_as_text()?;
             let dt = DateTime::parse_from_rfc3339(&v)
-                .map_err(|e| Error::decoding(format!("Cannot parse date time: {e}")))?;
+                .map_err(|e| Error::decoding(format!("Cannot parse date time \"{v}\": {e}")))?;
             Ok(dt)
         }
     }

--- a/async-opcua-types/src/date_time.rs
+++ b/async-opcua-types/src/date_time.rs
@@ -63,6 +63,36 @@ mod json {
     }
 }
 
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+    use std::io::{Read, Write};
+
+    use super::DateTime;
+
+    impl XmlEncodable for DateTime {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn Write>,
+            context: &Context<'_>,
+        ) -> EncodingResult<()> {
+            self.to_rfc3339().encode(writer, context)
+        }
+    }
+
+    impl XmlDecodable for DateTime {
+        fn decode(
+            read: &mut XmlStreamReader<&mut dyn Read>,
+            _context: &Context<'_>,
+        ) -> Result<Self, Error> {
+            let v = read.consume_as_text()?;
+            let dt = DateTime::parse_from_rfc3339(&v)
+                .map_err(|e| Error::decoding(format!("Cannot parse date time: {e}")))?;
+            Ok(dt)
+        }
+    }
+}
+
 /// DateTime encoded as 64-bit signed int
 impl BinaryEncodable for DateTime {
     fn byte_len(&self, _ctx: &Context<'_>) -> usize {

--- a/async-opcua-types/src/diagnostic_info.rs
+++ b/async-opcua-types/src/diagnostic_info.rs
@@ -97,6 +97,34 @@ mod json {
     }
 }
 
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+    use std::io::{Read, Write};
+
+    use super::DiagnosticBits;
+
+    impl XmlEncodable for DiagnosticBits {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn Write>,
+            context: &Context<'_>,
+        ) -> EncodingResult<()> {
+            self.bits().encode(writer, context)
+        }
+    }
+
+    impl XmlDecodable for DiagnosticBits {
+        fn decode(
+            reader: &mut XmlStreamReader<&mut dyn Read>,
+            context: &Context<'_>,
+        ) -> EncodingResult<Self> {
+            let v = u32::decode(reader, context)?;
+            Ok(Self::from_bits_truncate(v))
+        }
+    }
+}
+
 #[allow(unused)]
 mod opcua {
     pub use crate as types;

--- a/async-opcua-types/src/diagnostic_info.rs
+++ b/async-opcua-types/src/diagnostic_info.rs
@@ -62,14 +62,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "xml")]
-impl crate::xml::FromXml for DiagnosticBits {
-    fn from_xml(element: &opcua_xml::XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let v = u32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(v))
-    }
-}
-
 #[cfg(feature = "json")]
 mod json {
     use crate::json::*;
@@ -104,6 +96,10 @@ mod xml {
 
     use super::DiagnosticBits;
 
+    impl XmlType for DiagnosticBits {
+        const TAG: &'static str = u32::TAG;
+    }
+
     impl XmlEncodable for DiagnosticBits {
         fn encode(
             &self,
@@ -136,7 +132,10 @@ mod opcua {
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(crate::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(crate::XmlEncodable, crate::XmlDecodable, crate::XmlType)
+)]
 pub struct DiagnosticInfo {
     /// A symbolic name for the status code.
     pub symbolic_id: Option<i32>,

--- a/async-opcua-types/src/expanded_node_id.rs
+++ b/async-opcua-types/src/expanded_node_id.rs
@@ -246,6 +246,10 @@ mod xml {
 
     use super::ExpandedNodeId;
 
+    impl XmlType for ExpandedNodeId {
+        const TAG: &'static str = "ExpandedNodeId";
+    }
+
     impl XmlEncodable for ExpandedNodeId {
         fn encode(
             &self,

--- a/async-opcua-types/src/generated/types/activate_session_request.rs
+++ b/async-opcua-types/src/generated/types/activate_session_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ActivateSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/activate_session_response.rs
+++ b/async-opcua-types/src/generated/types/activate_session_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ActivateSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/add_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_item.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddNodesItem {
     pub parent_node_id: opcua::types::expanded_node_id::ExpandedNodeId,

--- a/async-opcua-types/src/generated/types/add_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/add_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/add_nodes_result.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddNodesResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/add_references_item.rs
+++ b/async-opcua-types/src/generated/types/add_references_item.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddReferencesItem {
     pub source_node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/add_references_request.rs
+++ b/async-opcua-types/src/generated/types/add_references_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddReferencesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/add_references_response.rs
+++ b/async-opcua-types/src/generated/types/add_references_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AddReferencesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/additional_parameters_type.rs
+++ b/async-opcua-types/src/generated/types/additional_parameters_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AdditionalParametersType {
     pub parameters: Option<Vec<super::key_value_pair::KeyValuePair>>,

--- a/async-opcua-types/src/generated/types/aggregate_configuration.rs
+++ b/async-opcua-types/src/generated/types/aggregate_configuration.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AggregateConfiguration {
     pub use_server_capabilities_defaults: bool,

--- a/async-opcua-types/src/generated/types/aggregate_filter.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AggregateFilter {
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/aggregate_filter_result.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AggregateFilterResult {
     pub revised_start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/alias_name_data_type.rs
+++ b/async-opcua-types/src/generated/types/alias_name_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AliasNameDataType {
     pub alias_name: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/annotation.rs
+++ b/async-opcua-types/src/generated/types/annotation.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct Annotation {
     pub message: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/annotation_data_type.rs
+++ b/async-opcua-types/src/generated/types/annotation_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AnnotationDataType {
     pub annotation: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/anonymous_identity_token.rs
+++ b/async-opcua-types/src/generated/types/anonymous_identity_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 pub struct AnonymousIdentityToken {
     pub policy_id: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/application_description.rs
+++ b/async-opcua-types/src/generated/types/application_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ApplicationDescription {
     pub application_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/attribute_operand.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AttributeOperand {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/axis_information.rs
+++ b/async-opcua-types/src/generated/types/axis_information.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct AxisInformation {
     pub engineering_units: super::eu_information::EUInformation,

--- a/async-opcua-types/src/generated/types/bit_field_definition.rs
+++ b/async-opcua-types/src/generated/types/bit_field_definition.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BitFieldDefinition {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrokerConnectionTransportDataType {
     pub resource_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrokerDataSetReaderTransportDataType {
     pub queue_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrokerDataSetWriterTransportDataType {
     pub queue_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrokerWriterGroupTransportDataType {
     pub queue_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/browse_description.rs
+++ b/async-opcua-types/src/generated/types/browse_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseDescription {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/browse_next_request.rs
+++ b/async-opcua-types/src/generated/types/browse_next_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseNextRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/browse_next_response.rs
+++ b/async-opcua-types/src/generated/types/browse_next_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseNextResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/browse_path.rs
+++ b/async-opcua-types/src/generated/types/browse_path.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowsePath {
     pub starting_node: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/browse_path_result.rs
+++ b/async-opcua-types/src/generated/types/browse_path_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowsePathResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/browse_path_target.rs
+++ b/async-opcua-types/src/generated/types/browse_path_target.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowsePathTarget {
     pub target_id: opcua::types::expanded_node_id::ExpandedNodeId,

--- a/async-opcua-types/src/generated/types/browse_request.rs
+++ b/async-opcua-types/src/generated/types/browse_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/browse_response.rs
+++ b/async-opcua-types/src/generated/types/browse_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/browse_result.rs
+++ b/async-opcua-types/src/generated/types/browse_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BrowseResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/build_info.rs
+++ b/async-opcua-types/src/generated/types/build_info.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct BuildInfo {
     pub product_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/call_method_request.rs
+++ b/async-opcua-types/src/generated/types/call_method_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CallMethodRequest {
     pub object_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/call_method_result.rs
+++ b/async-opcua-types/src/generated/types/call_method_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CallMethodResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/call_request.rs
+++ b/async-opcua-types/src/generated/types/call_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CallRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/call_response.rs
+++ b/async-opcua-types/src/generated/types/call_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CallResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/cancel_request.rs
+++ b/async-opcua-types/src/generated/types/cancel_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CancelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/cancel_response.rs
+++ b/async-opcua-types/src/generated/types/cancel_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CancelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/cartesian_coordinates.rs
+++ b/async-opcua-types/src/generated/types/cartesian_coordinates.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CartesianCoordinates {}
 impl opcua::types::MessageInfo for CartesianCoordinates {

--- a/async-opcua-types/src/generated/types/channel_security_token.rs
+++ b/async-opcua-types/src/generated/types/channel_security_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ChannelSecurityToken {
     pub channel_id: u32,

--- a/async-opcua-types/src/generated/types/close_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CloseSecureChannelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/close_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CloseSecureChannelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/close_session_request.rs
+++ b/async-opcua-types/src/generated/types/close_session_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CloseSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/close_session_response.rs
+++ b/async-opcua-types/src/generated/types/close_session_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CloseSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/complex_number_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ComplexNumberType {
     pub real: f32,

--- a/async-opcua-types/src/generated/types/configuration_version_data_type.rs
+++ b/async-opcua-types/src/generated/types/configuration_version_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ConfigurationVersionDataType {
     pub major_version: u32,

--- a/async-opcua-types/src/generated/types/connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/connection_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ConnectionTransportDataType {}
 impl opcua::types::MessageInfo for ConnectionTransportDataType {

--- a/async-opcua-types/src/generated/types/content_filter.rs
+++ b/async-opcua-types/src/generated/types/content_filter.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ContentFilter {
     pub elements: Option<Vec<super::content_filter_element::ContentFilterElement>>,

--- a/async-opcua-types/src/generated/types/content_filter_element.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ContentFilterElement {
     pub filter_operator: super::enums::FilterOperator,

--- a/async-opcua-types/src/generated/types/content_filter_element_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ContentFilterElementResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/content_filter_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ContentFilterResult {
     pub element_results:

--- a/async-opcua-types/src/generated/types/create_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/create_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/create_session_request.rs
+++ b/async-opcua-types/src/generated/types/create_session_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/create_session_response.rs
+++ b/async-opcua-types/src/generated/types/create_session_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/create_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateSubscriptionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/create_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CreateSubscriptionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/currency_unit_type.rs
+++ b/async-opcua-types/src/generated/types/currency_unit_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct CurrencyUnitType {
     pub numeric_code: i16,

--- a/async-opcua-types/src/generated/types/data_change_filter.rs
+++ b/async-opcua-types/src/generated/types/data_change_filter.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataChangeFilter {
     pub trigger: super::enums::DataChangeTrigger,

--- a/async-opcua-types/src/generated/types/data_change_notification.rs
+++ b/async-opcua-types/src/generated/types/data_change_notification.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataChangeNotification {
     pub monitored_items: Option<Vec<super::monitored_item_notification::MonitoredItemNotification>>,

--- a/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetMetaDataType {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetReaderDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetReaderMessageDataType {}
 impl opcua::types::MessageInfo for DataSetReaderMessageDataType {

--- a/async-opcua-types/src/generated/types/data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetReaderTransportDataType {}
 impl opcua::types::MessageInfo for DataSetReaderTransportDataType {

--- a/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetWriterDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetWriterMessageDataType {}
 impl opcua::types::MessageInfo for DataSetWriterMessageDataType {

--- a/async-opcua-types/src/generated/types/data_set_writer_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataSetWriterTransportDataType {}
 impl opcua::types::MessageInfo for DataSetWriterTransportDataType {

--- a/async-opcua-types/src/generated/types/data_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/data_type_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataTypeAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/data_type_description.rs
+++ b/async-opcua-types/src/generated/types/data_type_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataTypeDescription {
     pub data_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/data_type_schema_header.rs
+++ b/async-opcua-types/src/generated/types/data_type_schema_header.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DataTypeSchemaHeader {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DatagramConnectionTransport2DataType {
     pub discovery_address: opcua::types::extension_object::ExtensionObject,

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DatagramConnectionTransportDataType {
     pub discovery_address: opcua::types::extension_object::ExtensionObject,

--- a/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DatagramDataSetReaderTransportDataType {
     pub address: opcua::types::extension_object::ExtensionObject,

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DatagramWriterGroupTransport2DataType {
     pub message_repeat_count: u8,

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DatagramWriterGroupTransportDataType {
     pub message_repeat_count: u8,

--- a/async-opcua-types/src/generated/types/delete_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/delete_at_time_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteAtTimeDetails {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_event_details.rs
+++ b/async-opcua-types/src/generated/types/delete_event_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteEventDetails {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/delete_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_item.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteNodesItem {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/delete_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteRawModifiedDetails {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_references_item.rs
+++ b/async-opcua-types/src/generated/types/delete_references_item.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteReferencesItem {
     pub source_node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_references_request.rs
+++ b/async-opcua-types/src/generated/types/delete_references_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteReferencesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/delete_references_response.rs
+++ b/async-opcua-types/src/generated/types/delete_references_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteReferencesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteSubscriptionsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DeleteSubscriptionsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/discovery_configuration.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DiscoveryConfiguration {}
 impl opcua::types::MessageInfo for DiscoveryConfiguration {

--- a/async-opcua-types/src/generated/types/double_complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/double_complex_number_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct DoubleComplexNumberType {
     pub real: f64,

--- a/async-opcua-types/src/generated/types/element_operand.rs
+++ b/async-opcua-types/src/generated/types/element_operand.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ElementOperand {
     pub index: u32,

--- a/async-opcua-types/src/generated/types/endpoint_configuration.rs
+++ b/async-opcua-types/src/generated/types/endpoint_configuration.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EndpointConfiguration {
     pub operation_timeout: i32,

--- a/async-opcua-types/src/generated/types/endpoint_description.rs
+++ b/async-opcua-types/src/generated/types/endpoint_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EndpointDescription {
     pub endpoint_url: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/endpoint_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EndpointType {
     pub endpoint_url: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EndpointUrlListDataType {
     pub endpoint_url_list: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/enum_definition.rs
+++ b/async-opcua-types/src/generated/types/enum_definition.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EnumDefinition {
     pub fields: Option<Vec<super::enum_field::EnumField>>,

--- a/async-opcua-types/src/generated/types/enum_description.rs
+++ b/async-opcua-types/src/generated/types/enum_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EnumDescription {
     pub data_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/enum_field.rs
+++ b/async-opcua-types/src/generated/types/enum_field.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EnumField {
     pub value: i64,

--- a/async-opcua-types/src/generated/types/enum_value_type.rs
+++ b/async-opcua-types/src/generated/types/enum_value_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EnumValueType {
     pub value: i64,

--- a/async-opcua-types/src/generated/types/enums.rs
+++ b/async-opcua-types/src/generated/types/enums.rs
@@ -48,14 +48,27 @@ impl opcua::types::IntoVariant for AccessLevelExType {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AccessLevelExType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for AccessLevelExType {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for AccessLevelExType {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for AccessLevelExType {
+    const TAG: &'static str = "AccessLevelExType";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for AccessLevelExType {
@@ -116,14 +129,27 @@ impl opcua::types::IntoVariant for AccessLevelType {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AccessLevelType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for AccessLevelType {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = u8::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(u8::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for AccessLevelType {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for AccessLevelType {
+    const TAG: &'static str = "AccessLevelType";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for AccessLevelType {
@@ -183,14 +209,27 @@ impl opcua::types::IntoVariant for AccessRestrictionType {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AccessRestrictionType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for AccessRestrictionType {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i16::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i16::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for AccessRestrictionType {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for AccessRestrictionType {
+    const TAG: &'static str = "AccessRestrictionType";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for AccessRestrictionType {
@@ -249,14 +288,27 @@ impl opcua::types::IntoVariant for AlarmMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AlarmMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for AlarmMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i16::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i16::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for AlarmMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for AlarmMask {
+    const TAG: &'static str = "AlarmMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for AlarmMask {
@@ -294,7 +346,14 @@ impl opcua::types::json::JsonEncodable for AlarmMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum ApplicationType {
     #[opcua(default)]
@@ -347,14 +406,27 @@ impl opcua::types::IntoVariant for AttributeWriteMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AttributeWriteMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for AttributeWriteMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for AttributeWriteMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for AttributeWriteMask {
+    const TAG: &'static str = "AttributeWriteMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for AttributeWriteMask {
@@ -392,7 +464,14 @@ impl opcua::types::json::JsonEncodable for AttributeWriteMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum AxisScaleEnumeration {
     #[opcua(default)]
@@ -414,7 +493,14 @@ pub enum AxisScaleEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum BrokerTransportQualityOfService {
     #[opcua(default)]
@@ -438,7 +524,14 @@ pub enum BrokerTransportQualityOfService {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum BrowseDirection {
     #[opcua(default)]
@@ -461,7 +554,14 @@ pub enum BrowseDirection {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum BrowseResultMask {
     #[opcua(default)]
@@ -490,7 +590,14 @@ pub enum BrowseResultMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum ConversionLimitEnum {
     #[opcua(default)]
@@ -512,7 +619,14 @@ pub enum ConversionLimitEnum {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum DataChangeTrigger {
     #[opcua(default)]
@@ -557,14 +671,27 @@ impl opcua::types::IntoVariant for DataSetFieldContentMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DataSetFieldContentMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for DataSetFieldContentMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for DataSetFieldContentMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for DataSetFieldContentMask {
+    const TAG: &'static str = "DataSetFieldContentMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for DataSetFieldContentMask {
@@ -623,14 +750,27 @@ impl opcua::types::IntoVariant for DataSetFieldFlags {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DataSetFieldFlags {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for DataSetFieldFlags {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i16::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i16::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for DataSetFieldFlags {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for DataSetFieldFlags {
+    const TAG: &'static str = "DataSetFieldFlags";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for DataSetFieldFlags {
@@ -668,7 +808,14 @@ impl opcua::types::json::JsonEncodable for DataSetFieldFlags {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum DataSetOrderingType {
     #[opcua(default)]
@@ -690,7 +837,14 @@ pub enum DataSetOrderingType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum DeadbandType {
     #[opcua(default)]
@@ -712,7 +866,14 @@ pub enum DeadbandType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum DiagnosticsLevel {
     #[opcua(default)]
@@ -736,7 +897,14 @@ pub enum DiagnosticsLevel {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum Duplex {
     #[opcua(default)]
@@ -780,14 +948,27 @@ impl opcua::types::IntoVariant for EventNotifierType {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for EventNotifierType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for EventNotifierType {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = u8::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(u8::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for EventNotifierType {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for EventNotifierType {
+    const TAG: &'static str = "EventNotifierType";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for EventNotifierType {
@@ -825,7 +1006,14 @@ impl opcua::types::json::JsonEncodable for EventNotifierType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum ExceptionDeviationFormat {
     #[opcua(default)]
@@ -849,7 +1037,14 @@ pub enum ExceptionDeviationFormat {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum FilterOperator {
     #[opcua(default)]
@@ -886,7 +1081,14 @@ pub enum FilterOperator {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum HistoryUpdateType {
     Insert = 1i32,
@@ -908,7 +1110,14 @@ pub enum HistoryUpdateType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum IdentityCriteriaType {
     UserName = 1i32,
@@ -934,7 +1143,14 @@ pub enum IdentityCriteriaType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum IdType {
     #[opcua(default)]
@@ -957,7 +1173,14 @@ pub enum IdType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum InterfaceAdminStatus {
     #[opcua(default)]
@@ -979,7 +1202,14 @@ pub enum InterfaceAdminStatus {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum InterfaceOperStatus {
     #[opcua(default)]
@@ -1030,14 +1260,27 @@ impl opcua::types::IntoVariant for JsonDataSetMessageContentMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for JsonDataSetMessageContentMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for JsonDataSetMessageContentMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for JsonDataSetMessageContentMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for JsonDataSetMessageContentMask {
+    const TAG: &'static str = "JsonDataSetMessageContentMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for JsonDataSetMessageContentMask {
@@ -1099,14 +1342,27 @@ impl opcua::types::IntoVariant for JsonNetworkMessageContentMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for JsonNetworkMessageContentMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for JsonNetworkMessageContentMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for JsonNetworkMessageContentMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for JsonNetworkMessageContentMask {
+    const TAG: &'static str = "JsonNetworkMessageContentMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for JsonNetworkMessageContentMask {
@@ -1144,7 +1400,14 @@ impl opcua::types::json::JsonEncodable for JsonNetworkMessageContentMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum MessageSecurityMode {
     #[opcua(default)]
@@ -1167,7 +1430,14 @@ pub enum MessageSecurityMode {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum ModelChangeStructureVerbMask {
     NodeAdded = 1i32,
@@ -1190,7 +1460,14 @@ pub enum ModelChangeStructureVerbMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum MonitoringMode {
     #[opcua(default)]
@@ -1212,7 +1489,14 @@ pub enum MonitoringMode {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum NamingRuleType {
     Mandatory = 1i32,
@@ -1233,7 +1517,14 @@ pub enum NamingRuleType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum NegotiationStatus {
     #[opcua(default)]
@@ -1257,7 +1548,14 @@ pub enum NegotiationStatus {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum NodeAttributesMask {
     #[opcua(default)]
@@ -1311,7 +1609,14 @@ pub enum NodeAttributesMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum NodeClass {
     #[opcua(default)]
@@ -1340,7 +1645,14 @@ pub enum NodeClass {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(u8)]
 pub enum NodeIdType {
     #[opcua(default)]
@@ -1365,7 +1677,14 @@ pub enum NodeIdType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum OpenFileMode {
     Read = 1i32,
@@ -1387,7 +1706,14 @@ pub enum OpenFileMode {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum OverrideValueHandling {
     #[opcua(default)]
@@ -1434,14 +1760,27 @@ impl opcua::types::IntoVariant for PasswordOptionsMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PasswordOptionsMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for PasswordOptionsMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for PasswordOptionsMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for PasswordOptionsMask {
+    const TAG: &'static str = "PasswordOptionsMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for PasswordOptionsMask {
@@ -1479,7 +1818,14 @@ impl opcua::types::json::JsonEncodable for PasswordOptionsMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PerformUpdateType {
     Insert = 1i32,
@@ -1527,14 +1873,27 @@ impl opcua::types::IntoVariant for PermissionType {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PermissionType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for PermissionType {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for PermissionType {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for PermissionType {
+    const TAG: &'static str = "PermissionType";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for PermissionType {
@@ -1598,14 +1957,27 @@ impl opcua::types::IntoVariant for PubSubConfigurationRefMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PubSubConfigurationRefMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for PubSubConfigurationRefMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for PubSubConfigurationRefMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for PubSubConfigurationRefMask {
+    const TAG: &'static str = "PubSubConfigurationRefMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for PubSubConfigurationRefMask {
@@ -1643,7 +2015,14 @@ impl opcua::types::json::JsonEncodable for PubSubConfigurationRefMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PubSubDiagnosticsCounterClassification {
     #[opcua(default)]
@@ -1664,7 +2043,14 @@ pub enum PubSubDiagnosticsCounterClassification {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PubSubState {
     #[opcua(default)]
@@ -1688,7 +2074,14 @@ pub enum PubSubState {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum RedundancySupport {
     #[opcua(default)]
@@ -1713,7 +2106,14 @@ pub enum RedundancySupport {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum RedundantServerMode {
     #[opcua(default)]
@@ -1736,7 +2136,14 @@ pub enum RedundantServerMode {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum SecurityTokenRequestType {
     #[opcua(default)]
@@ -1757,7 +2164,14 @@ pub enum SecurityTokenRequestType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum ServerState {
     #[opcua(default)]
@@ -1784,7 +2198,14 @@ pub enum ServerState {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum StructureType {
     #[opcua(default)]
@@ -1808,7 +2229,14 @@ pub enum StructureType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TimestampsToReturn {
     #[opcua(default)]
@@ -1832,7 +2260,14 @@ pub enum TimestampsToReturn {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TrustListMasks {
     #[opcua(default)]
@@ -1882,14 +2317,27 @@ impl opcua::types::IntoVariant for TrustListValidationOptions {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TrustListValidationOptions {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for TrustListValidationOptions {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for TrustListValidationOptions {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for TrustListValidationOptions {
+    const TAG: &'static str = "TrustListValidationOptions";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for TrustListValidationOptions {
@@ -1927,7 +2375,14 @@ impl opcua::types::json::JsonEncodable for TrustListValidationOptions {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TsnFailureCode {
     #[opcua(default)]
@@ -1972,7 +2427,14 @@ pub enum TsnFailureCode {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TsnListenerStatus {
     #[opcua(default)]
@@ -1995,7 +2457,14 @@ pub enum TsnListenerStatus {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TsnStreamState {
     #[opcua(default)]
@@ -2019,7 +2488,14 @@ pub enum TsnStreamState {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum TsnTalkerStatus {
     #[opcua(default)]
@@ -2064,14 +2540,27 @@ impl opcua::types::IntoVariant for UadpDataSetMessageContentMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for UadpDataSetMessageContentMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for UadpDataSetMessageContentMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for UadpDataSetMessageContentMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for UadpDataSetMessageContentMask {
+    const TAG: &'static str = "UadpDataSetMessageContentMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for UadpDataSetMessageContentMask {
@@ -2134,14 +2623,27 @@ impl opcua::types::IntoVariant for UadpNetworkMessageContentMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for UadpNetworkMessageContentMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for UadpNetworkMessageContentMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for UadpNetworkMessageContentMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for UadpNetworkMessageContentMask {
+    const TAG: &'static str = "UadpNetworkMessageContentMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for UadpNetworkMessageContentMask {
@@ -2201,14 +2703,27 @@ impl opcua::types::IntoVariant for UserConfigurationMask {
     }
 }
 #[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for UserConfigurationMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
+impl opcua::types::xml::XmlDecodable for UserConfigurationMask {
+    fn decode(
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> opcua::types::EncodingResult<Self> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::from_bits_truncate(val))
+        Ok(Self::from_bits_truncate(i32::decode(stream, ctx)?))
     }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlEncodable for UserConfigurationMask {
+    fn encode(
+        &self,
+        stream: &mut opcua::types::xml::XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &opcua::types::Context<'_>,
+    ) -> opcua::types::EncodingResult<()> {
+        self.bits().encode(stream, ctx)
+    }
+}
+#[cfg(feature = "xml")]
+impl opcua::types::xml::XmlType for UserConfigurationMask {
+    const TAG: &'static str = "UserConfigurationMask";
 }
 #[cfg(feature = "json")]
 impl opcua::types::json::JsonDecodable for UserConfigurationMask {
@@ -2246,7 +2761,14 @@ impl opcua::types::json::JsonEncodable for UserConfigurationMask {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum UserTokenType {
     #[opcua(default)]

--- a/async-opcua-types/src/generated/types/ephemeral_key_type.rs
+++ b/async-opcua-types/src/generated/types/ephemeral_key_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EphemeralKeyType {
     pub public_key: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/eu_information.rs
+++ b/async-opcua-types/src/generated/types/eu_information.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EUInformation {
     pub namespace_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/event_field_list.rs
+++ b/async-opcua-types/src/generated/types/event_field_list.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EventFieldList {
     pub client_handle: u32,

--- a/async-opcua-types/src/generated/types/event_filter.rs
+++ b/async-opcua-types/src/generated/types/event_filter.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EventFilter {
     pub select_clauses: Option<Vec<super::simple_attribute_operand::SimpleAttributeOperand>>,

--- a/async-opcua-types/src/generated/types/event_filter_result.rs
+++ b/async-opcua-types/src/generated/types/event_filter_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EventFilterResult {
     pub select_clause_results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/event_notification_list.rs
+++ b/async-opcua-types/src/generated/types/event_notification_list.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct EventNotificationList {
     pub events: Option<Vec<super::event_field_list::EventFieldList>>,

--- a/async-opcua-types/src/generated/types/field_meta_data.rs
+++ b/async-opcua-types/src/generated/types/field_meta_data.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FieldMetaData {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/field_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/field_target_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FieldTargetDataType {
     pub data_set_field_id: opcua::types::guid::Guid,

--- a/async-opcua-types/src/generated/types/filter_operand.rs
+++ b/async-opcua-types/src/generated/types/filter_operand.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FilterOperand {}
 impl opcua::types::MessageInfo for FilterOperand {

--- a/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FindServersOnNetworkRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FindServersOnNetworkResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/find_servers_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FindServersRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/find_servers_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct FindServersResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/frame.rs
+++ b/async-opcua-types/src/generated/types/frame.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct Frame {}
 impl opcua::types::MessageInfo for Frame {

--- a/async-opcua-types/src/generated/types/generic_attribute_value.rs
+++ b/async-opcua-types/src/generated/types/generic_attribute_value.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct GenericAttributeValue {
     pub attribute_id: u32,

--- a/async-opcua-types/src/generated/types/generic_attributes.rs
+++ b/async-opcua-types/src/generated/types/generic_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct GenericAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/get_endpoints_request.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct GetEndpointsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/get_endpoints_response.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct GetEndpointsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/history_data.rs
+++ b/async-opcua-types/src/generated/types/history_data.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryData {
     pub data_values: Option<Vec<opcua::types::data_value::DataValue>>,

--- a/async-opcua-types/src/generated/types/history_event.rs
+++ b/async-opcua-types/src/generated/types/history_event.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryEvent {
     pub events: Option<Vec<super::history_event_field_list::HistoryEventFieldList>>,

--- a/async-opcua-types/src/generated/types/history_event_field_list.rs
+++ b/async-opcua-types/src/generated/types/history_event_field_list.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryEventFieldList {
     pub event_fields: Option<Vec<opcua::types::variant::Variant>>,

--- a/async-opcua-types/src/generated/types/history_modified_data.rs
+++ b/async-opcua-types/src/generated/types/history_modified_data.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryModifiedData {
     pub data_values: Option<Vec<opcua::types::data_value::DataValue>>,

--- a/async-opcua-types/src/generated/types/history_modified_event.rs
+++ b/async-opcua-types/src/generated/types/history_modified_event.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryModifiedEvent {
     pub events: Option<Vec<super::history_event_field_list::HistoryEventFieldList>>,

--- a/async-opcua-types/src/generated/types/history_read_details.rs
+++ b/async-opcua-types/src/generated/types/history_read_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryReadDetails {}
 impl opcua::types::MessageInfo for HistoryReadDetails {

--- a/async-opcua-types/src/generated/types/history_read_request.rs
+++ b/async-opcua-types/src/generated/types/history_read_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryReadRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/history_read_response.rs
+++ b/async-opcua-types/src/generated/types/history_read_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryReadResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/history_read_result.rs
+++ b/async-opcua-types/src/generated/types/history_read_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryReadResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/history_read_value_id.rs
+++ b/async-opcua-types/src/generated/types/history_read_value_id.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryReadValueId {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/history_update_details.rs
+++ b/async-opcua-types/src/generated/types/history_update_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryUpdateDetails {}
 impl opcua::types::MessageInfo for HistoryUpdateDetails {

--- a/async-opcua-types/src/generated/types/history_update_request.rs
+++ b/async-opcua-types/src/generated/types/history_update_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryUpdateRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/history_update_response.rs
+++ b/async-opcua-types/src/generated/types/history_update_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryUpdateResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/history_update_result.rs
+++ b/async-opcua-types/src/generated/types/history_update_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct HistoryUpdateResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
+++ b/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 pub struct IdentityMappingRuleType {
     pub criteria_type: super::enums::IdentityCriteriaType,
     pub criteria: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/issued_identity_token.rs
+++ b/async-opcua-types/src/generated/types/issued_identity_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct IssuedIdentityToken {
     pub policy_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct JsonDataSetReaderMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,

--- a/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct JsonDataSetWriterMessageDataType {
     pub data_set_message_content_mask: super::enums::JsonDataSetMessageContentMask,

--- a/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct JsonWriterGroupMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,

--- a/async-opcua-types/src/generated/types/key_value_pair.rs
+++ b/async-opcua-types/src/generated/types/key_value_pair.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct KeyValuePair {
     pub key: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
+++ b/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct LinearConversionDataType {
     pub initial_addend: f32,

--- a/async-opcua-types/src/generated/types/literal_operand.rs
+++ b/async-opcua-types/src/generated/types/literal_operand.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct LiteralOperand {
     pub value: opcua::types::variant::Variant,

--- a/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MdnsDiscoveryConfiguration {
     pub mdns_server_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/method_attributes.rs
+++ b/async-opcua-types/src/generated/types/method_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MethodAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/mod.rs
+++ b/async-opcua-types/src/generated/types/mod.rs
@@ -5319,16 +5319,16 @@ impl opcua::types::TypeLoader for GeneratedTypeLoader {
     fn load_from_xml(
         &self,
         node_id: &opcua::types::NodeId,
-        stream: &opcua::types::xml::XmlElement,
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
         if node_id.namespace != 0 {
             return None;
         }
         let Some(num_id) = node_id.as_u32() else {
-            return Some(Err(opcua::types::Error::decoding(format!(
-                "Unsupported encoding ID {node_id}, we only support numeric IDs"
-            ))));
+            return Some(Err(opcua::types::Error::decoding(
+                "Unsupported encoding ID. Only numeric encoding IDs are currently supported",
+            )));
         };
         TYPES.decode_xml(num_id, stream, ctx)
     }

--- a/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ModelChangeStructureDataType {
     pub affected: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/modification_info.rs
+++ b/async-opcua-types/src/generated/types/modification_info.rs
@@ -14,7 +14,15 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
+#[derive(Default)]
 pub struct ModificationInfo {
     pub modification_time: opcua::types::date_time::DateTime,
     pub update_type: super::enums::HistoryUpdateType,

--- a/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ModifyMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ModifyMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/modify_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ModifySubscriptionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/modify_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ModifySubscriptionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/monitored_item_create_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoredItemCreateRequest {
     pub item_to_monitor: super::read_value_id::ReadValueId,

--- a/async-opcua-types/src/generated/types/monitored_item_create_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoredItemCreateResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoredItemModifyRequest {
     pub monitored_item_id: u32,

--- a/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoredItemModifyResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/monitored_item_notification.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_notification.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoredItemNotification {
     pub client_handle: u32,

--- a/async-opcua-types/src/generated/types/monitoring_filter.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoringFilter {}
 impl opcua::types::MessageInfo for MonitoringFilter {

--- a/async-opcua-types/src/generated/types/monitoring_filter_result.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoringFilterResult {}
 impl opcua::types::MessageInfo for MonitoringFilterResult {

--- a/async-opcua-types/src/generated/types/monitoring_parameters.rs
+++ b/async-opcua-types/src/generated/types/monitoring_parameters.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct MonitoringParameters {
     pub client_handle: u32,

--- a/async-opcua-types/src/generated/types/network_address_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_address_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NetworkAddressDataType {
     pub network_interface: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/network_address_url_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_address_url_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NetworkAddressUrlDataType {
     pub network_interface: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/network_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_group_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NetworkGroupDataType {
     pub server_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/node_attributes.rs
+++ b/async-opcua-types/src/generated/types/node_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NodeAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/node_reference.rs
+++ b/async-opcua-types/src/generated/types/node_reference.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NodeReference {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/node_type_description.rs
+++ b/async-opcua-types/src/generated/types/node_type_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NodeTypeDescription {
     pub type_definition_node: opcua::types::expanded_node_id::ExpandedNodeId,

--- a/async-opcua-types/src/generated/types/notification_data.rs
+++ b/async-opcua-types/src/generated/types/notification_data.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NotificationData {}
 impl opcua::types::MessageInfo for NotificationData {

--- a/async-opcua-types/src/generated/types/notification_message.rs
+++ b/async-opcua-types/src/generated/types/notification_message.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct NotificationMessage {
     pub sequence_number: u32,

--- a/async-opcua-types/src/generated/types/object_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ObjectAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/object_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_type_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ObjectTypeAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/open_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct OpenSecureChannelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/open_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct OpenSecureChannelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/option_set.rs
+++ b/async-opcua-types/src/generated/types/option_set.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct OptionSet {
     pub value: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/orientation.rs
+++ b/async-opcua-types/src/generated/types/orientation.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct Orientation {}
 impl opcua::types::MessageInfo for Orientation {

--- a/async-opcua-types/src/generated/types/parsing_result.rs
+++ b/async-opcua-types/src/generated/types/parsing_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ParsingResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/portable_node_id.rs
+++ b/async-opcua-types/src/generated/types/portable_node_id.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PortableNodeId {
     pub namespace_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/portable_qualified_name.rs
+++ b/async-opcua-types/src/generated/types/portable_qualified_name.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PortableQualifiedName {
     pub namespace_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
+++ b/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PriorityMappingEntryType {
     pub mapping_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ProgramDiagnostic2DataType {
     pub create_session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ProgramDiagnosticDataType {
     pub create_session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubConfiguration2DataType {
     pub published_data_sets:

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubConfigurationDataType {
     pub published_data_sets:

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubConfigurationRefDataType {
     pub configuration_mask: super::enums::PubSubConfigurationRefMask,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubConfigurationValueDataType {
     pub configuration_element:

--- a/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubConnectionDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/pub_sub_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_group_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubGroupDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PubSubKeyPushTargetDataType {
     pub application_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/publish_request.rs
+++ b/async-opcua-types/src/generated/types/publish_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/publish_response.rs
+++ b/async-opcua-types/src/generated/types/publish_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/published_data_items_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_items_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedDataItemsDataType {
     pub published_data: Option<Vec<super::published_variable_data_type::PublishedVariableDataType>>,

--- a/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedDataSetCustomSourceDataType {
     pub cyclic_data_set: bool,

--- a/async-opcua-types/src/generated/types/published_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedDataSetDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/published_data_set_source_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_source_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedDataSetSourceDataType {}
 impl opcua::types::MessageInfo for PublishedDataSetSourceDataType {

--- a/async-opcua-types/src/generated/types/published_events_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_events_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedEventsDataType {
     pub event_notifier: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/published_variable_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_variable_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PublishedVariableDataType {
     pub published_variable: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/qos_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QosDataType {}
 impl opcua::types::MessageInfo for QosDataType {

--- a/async-opcua-types/src/generated/types/quantity_dimension.rs
+++ b/async-opcua-types/src/generated/types/quantity_dimension.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QuantityDimension {
     pub mass_exponent: i8,

--- a/async-opcua-types/src/generated/types/query_data_description.rs
+++ b/async-opcua-types/src/generated/types/query_data_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryDataDescription {
     pub relative_path: super::relative_path::RelativePath,

--- a/async-opcua-types/src/generated/types/query_data_set.rs
+++ b/async-opcua-types/src/generated/types/query_data_set.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryDataSet {
     pub node_id: opcua::types::expanded_node_id::ExpandedNodeId,

--- a/async-opcua-types/src/generated/types/query_first_request.rs
+++ b/async-opcua-types/src/generated/types/query_first_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryFirstRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/query_first_response.rs
+++ b/async-opcua-types/src/generated/types/query_first_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryFirstResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/query_next_request.rs
+++ b/async-opcua-types/src/generated/types/query_next_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryNextRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/query_next_response.rs
+++ b/async-opcua-types/src/generated/types/query_next_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct QueryNextResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/range.rs
+++ b/async-opcua-types/src/generated/types/range.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct Range {
     pub low: f64,

--- a/async-opcua-types/src/generated/types/rational_number.rs
+++ b/async-opcua-types/src/generated/types/rational_number.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RationalNumber {
     pub numerator: i32,

--- a/async-opcua-types/src/generated/types/read_annotation_data_details.rs
+++ b/async-opcua-types/src/generated/types/read_annotation_data_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadAnnotationDataDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,

--- a/async-opcua-types/src/generated/types/read_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/read_at_time_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadAtTimeDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,

--- a/async-opcua-types/src/generated/types/read_event_details.rs
+++ b/async-opcua-types/src/generated/types/read_event_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadEventDetails {
     pub num_values_per_node: u32,

--- a/async-opcua-types/src/generated/types/read_event_details_2.rs
+++ b/async-opcua-types/src/generated/types/read_event_details_2.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadEventDetails2 {
     pub num_values_per_node: u32,

--- a/async-opcua-types/src/generated/types/read_processed_details.rs
+++ b/async-opcua-types/src/generated/types/read_processed_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadProcessedDetails {
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/read_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/read_raw_modified_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadRawModifiedDetails {
     pub is_read_modified: bool,

--- a/async-opcua-types/src/generated/types/read_request.rs
+++ b/async-opcua-types/src/generated/types/read_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/read_response.rs
+++ b/async-opcua-types/src/generated/types/read_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/read_value_id.rs
+++ b/async-opcua-types/src/generated/types/read_value_id.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReadValueId {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/reader_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReaderGroupDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/reader_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReaderGroupMessageDataType {}
 impl opcua::types::MessageInfo for ReaderGroupMessageDataType {

--- a/async-opcua-types/src/generated/types/reader_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReaderGroupTransportDataType {}
 impl opcua::types::MessageInfo for ReaderGroupTransportDataType {

--- a/async-opcua-types/src/generated/types/receive_qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/receive_qos_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReceiveQosDataType {}
 impl opcua::types::MessageInfo for ReceiveQosDataType {

--- a/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReceiveQosPriorityDataType {
     pub priority_label: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/redundant_server_data_type.rs
+++ b/async-opcua-types/src/generated/types/redundant_server_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RedundantServerDataType {
     pub server_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/reference_description.rs
+++ b/async-opcua-types/src/generated/types/reference_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReferenceDescription {
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/reference_description_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_description_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReferenceDescriptionDataType {
     pub source_node: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReferenceListEntryDataType {
     pub reference_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/reference_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/reference_type_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ReferenceTypeAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/register_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/register_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/register_server_2_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterServer2Request {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/register_server_2_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterServer2Response {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/register_server_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterServerRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/register_server_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisterServerResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/registered_server.rs
+++ b/async-opcua-types/src/generated/types/registered_server.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RegisteredServer {
     pub server_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/relative_path.rs
+++ b/async-opcua-types/src/generated/types/relative_path.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RelativePath {
     pub elements: Option<Vec<super::relative_path_element::RelativePathElement>>,

--- a/async-opcua-types/src/generated/types/relative_path_element.rs
+++ b/async-opcua-types/src/generated/types/relative_path_element.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RelativePathElement {
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/republish_request.rs
+++ b/async-opcua-types/src/generated/types/republish_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RepublishRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/republish_response.rs
+++ b/async-opcua-types/src/generated/types/republish_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RepublishResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/role_permission_type.rs
+++ b/async-opcua-types/src/generated/types/role_permission_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct RolePermissionType {
     pub role_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SamplingIntervalDiagnosticsDataType {
     pub sampling_interval: f64,

--- a/async-opcua-types/src/generated/types/security_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/security_group_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SecurityGroupDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SemanticChangeStructureDataType {
     pub affected: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ServerDiagnosticsSummaryDataType {
     pub server_view_count: u32,

--- a/async-opcua-types/src/generated/types/server_on_network.rs
+++ b/async-opcua-types/src/generated/types/server_on_network.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ServerOnNetwork {
     pub record_id: u32,

--- a/async-opcua-types/src/generated/types/server_status_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_status_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ServerStatusDataType {
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/service_counter_data_type.rs
+++ b/async-opcua-types/src/generated/types/service_counter_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ServiceCounterDataType {
     pub total_count: u32,

--- a/async-opcua-types/src/generated/types/service_fault.rs
+++ b/async-opcua-types/src/generated/types/service_fault.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ServiceFault {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SessionDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SessionSecurityDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SessionlessInvokeRequestType {
     pub uris_version: u32,

--- a/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SessionlessInvokeResponseType {
     pub namespace_uris: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetMonitoringModeRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetMonitoringModeResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetPublishingModeRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetPublishingModeResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/set_triggering_request.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetTriggeringRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/set_triggering_response.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SetTriggeringResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/signature_data.rs
+++ b/async-opcua-types/src/generated/types/signature_data.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SignatureData {
     pub algorithm: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/signed_software_certificate.rs
+++ b/async-opcua-types/src/generated/types/signed_software_certificate.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SignedSoftwareCertificate {
     pub certificate_data: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/simple_attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/simple_attribute_operand.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SimpleAttributeOperand {
     pub type_definition_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/simple_type_description.rs
+++ b/async-opcua-types/src/generated/types/simple_type_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SimpleTypeDescription {
     pub data_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StandaloneSubscribedDataSetDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StandaloneSubscribedDataSetRefDataType {
     pub data_set_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/status_change_notification.rs
+++ b/async-opcua-types/src/generated/types/status_change_notification.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StatusChangeNotification {
     pub status: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/status_result.rs
+++ b/async-opcua-types/src/generated/types/status_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StatusResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/structure_definition.rs
+++ b/async-opcua-types/src/generated/types/structure_definition.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StructureDefinition {
     pub default_encoding_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/structure_description.rs
+++ b/async-opcua-types/src/generated/types/structure_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StructureDescription {
     pub data_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/structure_field.rs
+++ b/async-opcua-types/src/generated/types/structure_field.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct StructureField {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/subscribed_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscribed_data_set_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SubscribedDataSetDataType {}
 impl opcua::types::MessageInfo for SubscribedDataSetDataType {

--- a/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SubscribedDataSetMirrorDataType {
     pub parent_node_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
+++ b/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SubscriptionAcknowledgement {
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct SubscriptionDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/target_variables_data_type.rs
+++ b/async-opcua-types/src/generated/types/target_variables_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TargetVariablesDataType {
     pub target_variables: Option<Vec<super::field_target_data_type::FieldTargetDataType>>,

--- a/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
+++ b/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ThreeDCartesianCoordinates {
     pub x: f64,

--- a/async-opcua-types/src/generated/types/three_d_frame.rs
+++ b/async-opcua-types/src/generated/types/three_d_frame.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ThreeDFrame {
     pub cartesian_coordinates: super::three_d_cartesian_coordinates::ThreeDCartesianCoordinates,

--- a/async-opcua-types/src/generated/types/three_d_orientation.rs
+++ b/async-opcua-types/src/generated/types/three_d_orientation.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ThreeDOrientation {
     pub a: f64,

--- a/async-opcua-types/src/generated/types/three_d_vector.rs
+++ b/async-opcua-types/src/generated/types/three_d_vector.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ThreeDVector {
     pub x: f64,

--- a/async-opcua-types/src/generated/types/time_zone_data_type.rs
+++ b/async-opcua-types/src/generated/types/time_zone_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TimeZoneDataType {
     pub offset: i16,

--- a/async-opcua-types/src/generated/types/transaction_error_type.rs
+++ b/async-opcua-types/src/generated/types/transaction_error_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransactionErrorType {
     pub target_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/transfer_result.rs
+++ b/async-opcua-types/src/generated/types/transfer_result.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransferResult {
     pub status_code: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransferSubscriptionsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransferSubscriptionsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TranslateBrowsePathsToNodeIdsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TranslateBrowsePathsToNodeIdsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/transmit_qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/transmit_qos_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransmitQosDataType {}
 impl opcua::types::MessageInfo for TransmitQosDataType {

--- a/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TransmitQosPriorityDataType {
     pub priority_label: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/trust_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/trust_list_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct TrustListDataType {
     pub specified_lists: u32,

--- a/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
+++ b/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UABinaryFileDataType {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UadpDataSetReaderMessageDataType {
     pub group_version: u32,

--- a/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UadpDataSetWriterMessageDataType {
     pub data_set_message_content_mask: super::enums::UadpDataSetMessageContentMask,

--- a/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UadpWriterGroupMessageDataType {
     pub group_version: u32,

--- a/async-opcua-types/src/generated/types/unregister_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UnregisterNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/unregister_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UnregisterNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/unsigned_rational_number.rs
+++ b/async-opcua-types/src/generated/types/unsigned_rational_number.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UnsignedRationalNumber {
     pub numerator: u32,

--- a/async-opcua-types/src/generated/types/update_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_data_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 pub struct UpdateDataDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/update_event_details.rs
+++ b/async-opcua-types/src/generated/types/update_event_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 pub struct UpdateEventDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/update_structure_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_structure_data_details.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 pub struct UpdateStructureDataDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/user_identity_token.rs
+++ b/async-opcua-types/src/generated/types/user_identity_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UserIdentityToken {
     pub policy_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/user_management_data_type.rs
+++ b/async-opcua-types/src/generated/types/user_management_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UserManagementDataType {
     pub user_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/user_name_identity_token.rs
+++ b/async-opcua-types/src/generated/types/user_name_identity_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UserNameIdentityToken {
     pub policy_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/user_token_policy.rs
+++ b/async-opcua-types/src/generated/types/user_token_policy.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct UserTokenPolicy {
     pub policy_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/variable_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct VariableAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/variable_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_type_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct VariableTypeAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/vector.rs
+++ b/async-opcua-types/src/generated/types/vector.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct Vector {}
 impl opcua::types::MessageInfo for Vector {

--- a/async-opcua-types/src/generated/types/view_attributes.rs
+++ b/async-opcua-types/src/generated/types/view_attributes.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ViewAttributes {
     pub specified_attributes: u32,

--- a/async-opcua-types/src/generated/types/view_description.rs
+++ b/async-opcua-types/src/generated/types/view_description.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ViewDescription {
     pub view_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/write_request.rs
+++ b/async-opcua-types/src/generated/types/write_request.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriteRequest {
     pub request_header: opcua::types::request_header::RequestHeader,

--- a/async-opcua-types/src/generated/types/write_response.rs
+++ b/async-opcua-types/src/generated/types/write_response.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriteResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,

--- a/async-opcua-types/src/generated/types/write_value.rs
+++ b/async-opcua-types/src/generated/types/write_value.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriteValue {
     pub node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/writer_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriterGroupDataType {
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_message_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriterGroupMessageDataType {}
 impl opcua::types::MessageInfo for WriterGroupMessageDataType {

--- a/async-opcua-types/src/generated/types/writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_transport_data_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct WriterGroupTransportDataType {}
 impl opcua::types::MessageInfo for WriterGroupTransportDataType {

--- a/async-opcua-types/src/generated/types/x_509_identity_token.rs
+++ b/async-opcua-types/src/generated/types/x_509_identity_token.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct X509IdentityToken {
     pub policy_id: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/xv_type.rs
+++ b/async-opcua-types/src/generated/types/xv_type.rs
@@ -14,7 +14,14 @@ mod opcua {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct XVType {
     pub x: f64,

--- a/async-opcua-types/src/guid.rs
+++ b/async-opcua-types/src/guid.rs
@@ -57,6 +57,40 @@ mod json {
     }
 }
 
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+    use std::{
+        io::{Read, Write},
+        str::FromStr,
+    };
+
+    use super::Guid;
+
+    impl XmlEncodable for Guid {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn Write>,
+            ctx: &crate::xml::Context<'_>,
+        ) -> EncodingResult<()> {
+            writer.encode_child("String", &self.to_string(), ctx)
+        }
+    }
+
+    impl XmlDecodable for Guid {
+        fn decode(
+            reader: &mut XmlStreamReader<&mut dyn Read>,
+            ctx: &crate::xml::Context<'_>,
+        ) -> EncodingResult<Self> {
+            let val: Option<String> = reader.decode_single_child("String", ctx)?;
+            let Some(val) = val else {
+                return Ok(Guid::null());
+            };
+            Guid::from_str(&val).map_err(Error::decoding)
+        }
+    }
+}
+
 impl fmt::Display for Guid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.uuid)

--- a/async-opcua-types/src/guid.rs
+++ b/async-opcua-types/src/guid.rs
@@ -67,6 +67,10 @@ mod xml {
 
     use super::Guid;
 
+    impl XmlType for Guid {
+        const TAG: &'static str = "Guid";
+    }
+
     impl XmlEncodable for Guid {
         fn encode(
             &self,

--- a/async-opcua-types/src/lib.rs
+++ b/async-opcua-types/src/lib.rs
@@ -279,9 +279,10 @@ pub mod xml;
 pub use opcua_macros::FromXml;
 
 #[cfg(feature = "json")]
-pub use opcua_macros::JsonDecodable;
-#[cfg(feature = "json")]
-pub use opcua_macros::JsonEncodable;
+pub use opcua_macros::{JsonDecodable, JsonEncodable};
+
+#[cfg(feature = "xml")]
+pub use opcua_macros::{XmlDecodable, XmlEncodable, XmlType};
 
 pub use opcua_macros::BinaryDecodable;
 pub use opcua_macros::BinaryEncodable;

--- a/async-opcua-types/src/localized_text.rs
+++ b/async-opcua-types/src/localized_text.rs
@@ -23,6 +23,10 @@ mod opcua {
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)
 )]
+#[cfg_attr(
+    feature = "xml",
+    derive(crate::XmlEncodable, crate::XmlDecodable, crate::XmlType)
+)]
 pub struct LocalizedText {
     /// The locale. Omitted from stream if null or empty
     pub locale: UAString,

--- a/async-opcua-types/src/request_header.rs
+++ b/async-opcua-types/src/request_header.rs
@@ -31,7 +31,10 @@ mod opcua {
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(crate::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(crate::XmlEncodable, crate::XmlDecodable, crate::XmlType)
+)]
 pub struct RequestHeader {
     /// The secret Session identifier used to verify that the request is associated with
     /// the Session. The SessionAuthenticationToken type is defined in 7.31.

--- a/async-opcua-types/src/response_header.rs
+++ b/async-opcua-types/src/response_header.rs
@@ -32,7 +32,10 @@ mod opcua {
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(crate::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(crate::XmlEncodable, crate::XmlDecodable, crate::XmlType)
+)]
 pub struct ResponseHeader {
     /// Response timestamp.
     pub timestamp: UtcTime,

--- a/async-opcua-types/src/status_code.rs
+++ b/async-opcua-types/src/status_code.rs
@@ -44,6 +44,39 @@ mod json {
     }
 }
 
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+    use std::io::{Read, Write};
+
+    use super::StatusCode;
+
+    impl XmlEncodable for StatusCode {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn Write>,
+            context: &Context<'_>,
+        ) -> Result<(), Error> {
+            writer.encode_child("Code", &self.0, context)
+        }
+    }
+
+    impl XmlDecodable for StatusCode {
+        fn decode(
+            read: &mut XmlStreamReader<&mut dyn Read>,
+            context: &Context<'_>,
+        ) -> Result<Self, Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self::from(
+                read.decode_single_child::<u32>("Code", context)?
+                    .unwrap_or_default(),
+            ))
+        }
+    }
+}
+
 const SUBCODE_MASK: u32 = 0xffff_0000;
 const INFO_BITS_MASK: u32 = 0b0011_1111_1111;
 

--- a/async-opcua-types/src/status_code.rs
+++ b/async-opcua-types/src/status_code.rs
@@ -51,6 +51,10 @@ mod xml {
 
     use super::StatusCode;
 
+    impl XmlType for StatusCode {
+        const TAG: &'static str = "StatusCode";
+    }
+
     impl XmlEncodable for StatusCode {
         fn encode(
             &self,
@@ -175,7 +179,7 @@ impl StatusCode {
     /// Set the info type, this will clear the info bits if set to NotUsed.
     #[must_use = "Status code is copied, not modified in place."]
     pub fn set_info_type(mut self, value: StatusCodeInfoType) -> Self {
-        self.0 = self.0 & !(1 << 10) | ((value as u32) & 1) << 10;
+        self.0 = self.0 & !(1 << 10) | (((value as u32) & 1) << 10);
         // Clear the info bits if we are setting info type to not used.
         if matches!(value, StatusCodeInfoType::NotUsed) {
             self.0 &= !INFO_BITS_MASK;

--- a/async-opcua-types/src/string.rs
+++ b/async-opcua-types/src/string.rs
@@ -136,6 +136,37 @@ impl SimpleBinaryDecodable for UAString {
     }
 }
 
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+    use std::io::{Read, Write};
+
+    use super::UAString;
+
+    impl XmlEncodable for UAString {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn Write>,
+            _ctx: &Context<'_>,
+        ) -> Result<(), Error> {
+            if let Some(s) = self.value() {
+                writer.write_text(s)?;
+            }
+
+            Ok(())
+        }
+    }
+
+    impl XmlDecodable for UAString {
+        fn decode(
+            read: &mut XmlStreamReader<&mut dyn Read>,
+            _context: &Context<'_>,
+        ) -> Result<Self, Error> {
+            Ok(read.consume_as_text()?.into())
+        }
+    }
+}
+
 impl From<UAString> for String {
     fn from(value: UAString) -> Self {
         value.as_ref().to_string()

--- a/async-opcua-types/src/string.rs
+++ b/async-opcua-types/src/string.rs
@@ -143,6 +143,10 @@ mod xml {
 
     use super::UAString;
 
+    impl XmlType for UAString {
+        const TAG: &'static str = "String";
+    }
+
     impl XmlEncodable for UAString {
         fn encode(
             &self,

--- a/async-opcua-types/src/tests/json.rs
+++ b/async-opcua-types/src/tests/json.rs
@@ -287,11 +287,11 @@ fn serialize_localized_text() {
 fn serialize_qualified_name() {
     let v = QualifiedName::new(0, "Test");
     let json = to_value(&v).unwrap();
-    assert_eq!(json, json!({"Name": "Test"}));
+    assert_eq!(json, json!("Test"));
 
     let v = QualifiedName::new(2, "Test");
     let json = to_value(&v).unwrap();
-    assert_eq!(json, json!({"Uri": 2, "Name": "Test"}));
+    assert_eq!(json, json!("2:Test"));
 }
 
 /// Serializes and deserializes a variant. The input json should match
@@ -545,7 +545,7 @@ fn serialize_variant_qualified_name() {
     // QualifiedName (20)
     test_ser_de_variant(
         Variant::QualifiedName(Box::new(QualifiedName::null())),
-        json!({"Type": 20, "Body": {}}),
+        json!({"Type": 20, "Body": null}),
     );
 }
 

--- a/async-opcua-types/src/variant/mod.rs
+++ b/async-opcua-types/src/variant/mod.rs
@@ -10,6 +10,8 @@ mod into;
 #[cfg(feature = "json")]
 mod json;
 mod type_id;
+#[cfg(feature = "xml")]
+mod xml;
 
 pub use from::TryFromVariant;
 pub use into::IntoVariant;

--- a/async-opcua-types/src/variant/xml.rs
+++ b/async-opcua-types/src/variant/xml.rs
@@ -1,0 +1,296 @@
+use crate::{
+    xml::*, Array, ByteString, DataValue, DateTime, DiagnosticInfo, ExpandedNodeId,
+    ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, UAString,
+};
+
+use super::{Variant, VariantScalarTypeId};
+
+impl XmlType for Variant {
+    const TAG: &'static str = "Variant";
+}
+impl VariantScalarTypeId {
+    /// Get the XML name of a variant type.
+    pub fn xml_name(&self) -> &'static str {
+        match self {
+            VariantScalarTypeId::Boolean => "Boolean",
+            VariantScalarTypeId::SByte => "SByte",
+            VariantScalarTypeId::Byte => "Byte",
+            VariantScalarTypeId::Int16 => "Int16",
+            VariantScalarTypeId::UInt16 => "UInt16",
+            VariantScalarTypeId::Int32 => "Int32",
+            VariantScalarTypeId::UInt32 => "UInt32",
+            VariantScalarTypeId::Int64 => "Int64",
+            VariantScalarTypeId::UInt64 => "UInt64",
+            VariantScalarTypeId::Float => "Float",
+            VariantScalarTypeId::Double => "Double",
+            VariantScalarTypeId::String => "String",
+            VariantScalarTypeId::DateTime => "DateTime",
+            VariantScalarTypeId::Guid => "Guid",
+            VariantScalarTypeId::ByteString => "ByteString",
+            VariantScalarTypeId::XmlElement => "XmlElement",
+            VariantScalarTypeId::NodeId => "NodeId",
+            VariantScalarTypeId::ExpandedNodeId => "ExpandedNodeId",
+            VariantScalarTypeId::StatusCode => "StatusCode",
+            VariantScalarTypeId::QualifiedName => "QualifiedName",
+            VariantScalarTypeId::LocalizedText => "LocalizedText",
+            VariantScalarTypeId::ExtensionObject => "ExtensionObject",
+            VariantScalarTypeId::DataValue => "DataValue",
+            VariantScalarTypeId::Variant => "Variant",
+            VariantScalarTypeId::DiagnosticInfo => "DiagnosticInfo",
+        }
+    }
+
+    /// Get a variant type ID from the XML name of the variant type.
+    pub fn from_xml_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "Boolean" => VariantScalarTypeId::Boolean,
+            "SByte" => VariantScalarTypeId::SByte,
+            "Byte" => VariantScalarTypeId::Byte,
+            "Int16" => VariantScalarTypeId::Int16,
+            "UInt16" => VariantScalarTypeId::UInt16,
+            "Int32" => VariantScalarTypeId::Int32,
+            "UInt32" => VariantScalarTypeId::UInt32,
+            "Int64" => VariantScalarTypeId::Int64,
+            "UInt64" => VariantScalarTypeId::UInt64,
+            "Float" => VariantScalarTypeId::Float,
+            "Double" => VariantScalarTypeId::Double,
+            "String" => VariantScalarTypeId::String,
+            "DateTime" => VariantScalarTypeId::DateTime,
+            "Guid" => VariantScalarTypeId::Guid,
+            "ByteString" => VariantScalarTypeId::ByteString,
+            "XmlElement" => VariantScalarTypeId::XmlElement,
+            "NodeId" => VariantScalarTypeId::NodeId,
+            "ExpandedNodeId" => VariantScalarTypeId::ExpandedNodeId,
+            "StatusCode" => VariantScalarTypeId::StatusCode,
+            "QualifiedName" => VariantScalarTypeId::QualifiedName,
+            "LocalizedText" => VariantScalarTypeId::LocalizedText,
+            "ExtensionObject" => VariantScalarTypeId::ExtensionObject,
+            "DataValue" => VariantScalarTypeId::DataValue,
+            "Variant" => VariantScalarTypeId::Variant,
+            "DiagnosticInfo" => VariantScalarTypeId::DiagnosticInfo,
+            _ => return None,
+        })
+    }
+}
+
+impl Variant {
+    /// Get a default variant of the given type.
+    pub fn get_variant_default(ty: VariantScalarTypeId) -> Variant {
+        match ty {
+            VariantScalarTypeId::Boolean => Variant::Boolean(Default::default()),
+            VariantScalarTypeId::SByte => Variant::SByte(Default::default()),
+            VariantScalarTypeId::Byte => Variant::Byte(Default::default()),
+            VariantScalarTypeId::Int16 => Variant::Int16(Default::default()),
+            VariantScalarTypeId::UInt16 => Variant::UInt16(Default::default()),
+            VariantScalarTypeId::Int32 => Variant::Int32(Default::default()),
+            VariantScalarTypeId::UInt32 => Variant::UInt32(Default::default()),
+            VariantScalarTypeId::Int64 => Variant::Int64(Default::default()),
+            VariantScalarTypeId::UInt64 => Variant::UInt64(Default::default()),
+            VariantScalarTypeId::Float => Variant::Float(Default::default()),
+            VariantScalarTypeId::Double => Variant::Double(Default::default()),
+            VariantScalarTypeId::String => Variant::String(Default::default()),
+            VariantScalarTypeId::DateTime => Variant::DateTime(Default::default()),
+            VariantScalarTypeId::Guid => Variant::Guid(Default::default()),
+            VariantScalarTypeId::ByteString => Variant::ByteString(Default::default()),
+            VariantScalarTypeId::XmlElement => Variant::XmlElement(Default::default()),
+            VariantScalarTypeId::NodeId => Variant::NodeId(Default::default()),
+            VariantScalarTypeId::ExpandedNodeId => Variant::ExpandedNodeId(Default::default()),
+            VariantScalarTypeId::StatusCode => Variant::StatusCode(Default::default()),
+            VariantScalarTypeId::QualifiedName => Variant::QualifiedName(Default::default()),
+            VariantScalarTypeId::LocalizedText => Variant::LocalizedText(Default::default()),
+            VariantScalarTypeId::ExtensionObject => Variant::ExtensionObject(Default::default()),
+            VariantScalarTypeId::DataValue => Variant::DataValue(Default::default()),
+            VariantScalarTypeId::Variant => Variant::Variant(Default::default()),
+            VariantScalarTypeId::DiagnosticInfo => Variant::DiagnosticInfo(Default::default()),
+        }
+    }
+
+    /// Decode an XML variant value from stream, consuming the rest of the current element.
+    pub fn xml_decode_variant_value(
+        stream: &mut XmlStreamReader<&mut dyn std::io::Read>,
+        context: &Context<'_>,
+        key: &str,
+    ) -> EncodingResult<Self> {
+        if let Some(ty) = key.strip_prefix("ListOf") {
+            let ty = VariantScalarTypeId::from_xml_name(ty)
+                .ok_or_else(|| Error::decoding(format!("Invalid variant contents: {key}")))?;
+            let mut vec = Vec::new();
+            stream.iter_children_include_empty(
+                |key, stream, context| {
+                    let Some(stream) = stream else {
+                        let ty = VariantScalarTypeId::from_xml_name(&key).ok_or_else(|| {
+                            Error::decoding(format!("Invalid variant contents: {key}"))
+                        })?;
+                        vec.push(Self::get_variant_default(ty));
+                        return Ok(());
+                    };
+                    let r = Variant::xml_decode_variant_value(stream, context, &key)?;
+                    vec.push(r);
+                    Ok(())
+                },
+                context,
+            )?;
+            Ok(Self::Array(Box::new(
+                Array::new(ty, vec).map_err(Error::decoding)?,
+            )))
+        } else if key == "Matrix" {
+            let mut dims = Vec::new();
+            let mut elems = Vec::new();
+            stream.iter_children(
+                |key, stream, context| match key.as_str() {
+                    "Dimensions" => {
+                        dims = Vec::<i32>::decode(stream, context)?;
+                        Ok(())
+                    }
+                    "Elements" => stream.iter_children_include_empty(
+                        |key, stream, context| {
+                            let Some(stream) = stream else {
+                                let ty =
+                                    VariantScalarTypeId::from_xml_name(&key).ok_or_else(|| {
+                                        Error::decoding(format!("Invalid variant contents: {key}"))
+                                    })?;
+                                elems.push(Self::get_variant_default(ty));
+                                return Ok(());
+                            };
+                            let r = Variant::xml_decode_variant_value(stream, context, &key)?;
+                            elems.push(r);
+                            Ok(())
+                        },
+                        context,
+                    ),
+                    r => Err(Error::decoding(format!(
+                        "Invalid field in Matrix content: {r}"
+                    ))),
+                },
+                context,
+            )?;
+            // If you have an empty matrix there's no actual way to determine the type.
+            let scalar_type = elems
+                .first()
+                .and_then(|v| v.scalar_type_id())
+                .unwrap_or(VariantScalarTypeId::Int32);
+            Ok(Self::Array(Box::new(
+                Array::new_multi(
+                    scalar_type,
+                    elems,
+                    dims.into_iter()
+                        .map(|d| d.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(|_| {
+                            Error::decoding("Invalid array dimensions, must all be non-negative")
+                        })?,
+                )
+                .map_err(Error::decoding)?,
+            )))
+        } else {
+            Ok(match key {
+                "Boolean" => Self::Boolean(XmlDecodable::decode(stream, context)?),
+                "SByte" => Self::SByte(XmlDecodable::decode(stream, context)?),
+                "Byte" => Self::Byte(XmlDecodable::decode(stream, context)?),
+                "Int16" => Self::Int16(XmlDecodable::decode(stream, context)?),
+                "UInt16" => Self::UInt16(XmlDecodable::decode(stream, context)?),
+                "Int32" => Self::Int32(XmlDecodable::decode(stream, context)?),
+                "UInt32" => Self::UInt32(XmlDecodable::decode(stream, context)?),
+                "Int64" => Self::Int64(XmlDecodable::decode(stream, context)?),
+                "UInt64" => Self::UInt64(XmlDecodable::decode(stream, context)?),
+                "Float" => Self::Float(XmlDecodable::decode(stream, context)?),
+                "Double" => Self::Double(XmlDecodable::decode(stream, context)?),
+                "String" => Self::String(XmlDecodable::decode(stream, context)?),
+                "DateTime" => Self::DateTime(XmlDecodable::decode(stream, context)?),
+                "Guid" => Self::Guid(XmlDecodable::decode(stream, context)?),
+                "ByteString" => Self::ByteString(XmlDecodable::decode(stream, context)?),
+                "XmlElement" => Self::XmlElement(XmlDecodable::decode(stream, context)?),
+                "NodeId" => Self::NodeId(XmlDecodable::decode(stream, context)?),
+                "ExpandedNodeId" => Self::ExpandedNodeId(XmlDecodable::decode(stream, context)?),
+                "StatusCode" => Self::StatusCode(XmlDecodable::decode(stream, context)?),
+                "QualifiedName" => Self::QualifiedName(XmlDecodable::decode(stream, context)?),
+                "LocalizedText" => Self::LocalizedText(XmlDecodable::decode(stream, context)?),
+                "ExtensionObject" => Self::ExtensionObject(XmlDecodable::decode(stream, context)?),
+                "DataValue" => Self::DataValue(XmlDecodable::decode(stream, context)?),
+                "Variant" => Self::Variant(XmlDecodable::decode(stream, context)?),
+                "DiagnosticInfo" => Self::DiagnosticInfo(XmlDecodable::decode(stream, context)?),
+                r => return Err(Error::decoding(format!("Invalid variant type {r}"))),
+            })
+        }
+    }
+}
+
+impl XmlEncodable for Variant {
+    fn encode(
+        &self,
+        stream: &mut XmlStreamWriter<&mut dyn std::io::Write>,
+        ctx: &Context<'_>,
+    ) -> EncodingResult<()> {
+        match self {
+            Variant::Empty => return Ok(()),
+            Variant::Boolean(v) => stream.encode_child(bool::TAG, v, ctx)?,
+            Variant::SByte(v) => stream.encode_child(i8::TAG, v, ctx)?,
+            Variant::Byte(v) => stream.encode_child(u8::TAG, v, ctx)?,
+            Variant::Int16(v) => stream.encode_child(i16::TAG, v, ctx)?,
+            Variant::UInt16(v) => stream.encode_child(u16::TAG, v, ctx)?,
+            Variant::Int32(v) => stream.encode_child(i32::TAG, v, ctx)?,
+            Variant::UInt32(v) => stream.encode_child(u32::TAG, v, ctx)?,
+            Variant::Int64(v) => stream.encode_child(i64::TAG, v, ctx)?,
+            Variant::UInt64(v) => stream.encode_child(u64::TAG, v, ctx)?,
+            Variant::Float(v) => stream.encode_child(f32::TAG, v, ctx)?,
+            Variant::Double(v) => stream.encode_child(f64::TAG, v, ctx)?,
+            Variant::String(v) => stream.encode_child(UAString::TAG, v, ctx)?,
+            Variant::DateTime(v) => stream.encode_child(DateTime::TAG, v, ctx)?,
+            Variant::Guid(v) => stream.encode_child(Guid::TAG, v, ctx)?,
+            Variant::StatusCode(v) => stream.encode_child(StatusCode::TAG, v, ctx)?,
+            Variant::ByteString(v) => stream.encode_child(ByteString::TAG, v, ctx)?,
+            Variant::XmlElement(v) => stream.encode_child("XmlElement", v, ctx)?,
+            Variant::QualifiedName(v) => stream.encode_child(QualifiedName::TAG, v, ctx)?,
+            Variant::LocalizedText(v) => stream.encode_child(LocalizedText::TAG, v, ctx)?,
+            Variant::NodeId(v) => stream.encode_child(NodeId::TAG, v, ctx)?,
+            Variant::ExpandedNodeId(v) => stream.encode_child(ExpandedNodeId::TAG, v, ctx)?,
+            Variant::ExtensionObject(v) => stream.encode_child(ExtensionObject::TAG, v, ctx)?,
+            Variant::Variant(v) => stream.encode_child(Variant::TAG, v, ctx)?,
+            Variant::DataValue(v) => stream.encode_child(DataValue::TAG, v, ctx)?,
+            Variant::DiagnosticInfo(v) => stream.encode_child(DiagnosticInfo::TAG, v, ctx)?,
+            Variant::Array(v) => {
+                let xml_name = v.value_type.xml_name();
+                if let Some(dims) = v.dimensions.as_ref() {
+                    if dims.len() > 1 {
+                        stream.write_start("Matrix")?;
+                        // For some incredibly annoying reason, OPC-UA insists that dimensions be
+                        // encoded as _signed_ integers. For other encoders it's irrelevant,
+                        // but it matters for XML.
+                        let dims: Vec<_> = dims.iter().map(|d| *d as i32).collect();
+                        stream.encode_child("Dimensions", &dims, ctx)?;
+
+                        stream.write_start("Elements")?;
+                        for item in &v.values {
+                            item.encode(stream, ctx)?;
+                        }
+                        stream.write_end("Elements")?;
+                        stream.write_end("Matrix")?;
+                        return Ok(());
+                    }
+                }
+                let tag_name = format!("ListOf{}", xml_name);
+                stream.write_start(&tag_name)?;
+                for item in &v.values {
+                    item.encode(stream, ctx)?;
+                }
+                stream.write_end(&tag_name)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl XmlDecodable for Variant {
+    fn decode(
+        stream: &mut XmlStreamReader<&mut dyn std::io::Read>,
+        context: &Context<'_>,
+    ) -> Result<Self, Error> {
+        stream
+            .get_first_child(
+                |key, stream, ctx| Self::xml_decode_variant_value(stream, ctx, &key),
+                context,
+            )
+            .map(|v| v.unwrap_or(Variant::Empty))
+    }
+}

--- a/async-opcua-types/src/xml/builtins.rs
+++ b/async-opcua-types/src/xml/builtins.rs
@@ -1,0 +1,159 @@
+use super::encoding::{XmlDecodable, XmlEncodable};
+use crate::{Context, Error};
+use opcua_xml::{XmlStreamReader, XmlStreamWriter};
+use std::io::{Read, Write};
+
+macro_rules! xml_enc_number {
+    ($t:ty) => {
+        impl XmlEncodable for $t {
+            fn encode(
+                &self,
+                writer: &mut XmlStreamWriter<&mut dyn Write>,
+                _context: &Context<'_>,
+            ) -> Result<(), Error> {
+                writer.write_text(&self.to_string())?;
+                Ok(())
+            }
+        }
+
+        impl XmlDecodable for $t {
+            fn decode(
+                read: &mut XmlStreamReader<&mut dyn Read>,
+                _context: &Context<'_>,
+            ) -> Result<Self, Error> {
+                Ok(read.consume_content()?)
+            }
+        }
+    };
+}
+
+const VALUE_INFINITY: &str = "INF";
+const VALUE_NEG_INFINITY: &str = "-INF";
+const VALUE_NAN: &str = "NaN";
+
+macro_rules! xml_enc_float {
+    ($t:ty) => {
+        impl XmlEncodable for $t {
+            fn encode(
+                &self,
+                writer: &mut XmlStreamWriter<&mut dyn Write>,
+                _context: &Context<'_>,
+            ) -> Result<(), Error> {
+                if self.is_infinite() {
+                    if self.is_sign_positive() {
+                        writer.write_text(VALUE_INFINITY)?;
+                    } else {
+                        writer.write_text(VALUE_NEG_INFINITY)?;
+                    }
+                } else if self.is_nan() {
+                    writer.write_text(VALUE_NAN)?;
+                } else {
+                    writer.write_text(&self.to_string())?;
+                }
+                Ok(())
+            }
+        }
+
+        impl XmlDecodable for $t {
+            fn decode(
+                read: &mut XmlStreamReader<&mut dyn Read>,
+                _context: &Context<'_>,
+            ) -> Result<Self, Error> {
+                let val = read.consume_as_text()?;
+                match val.as_str() {
+                    VALUE_INFINITY => Ok(Self::INFINITY),
+                    VALUE_NEG_INFINITY => Ok(Self::NEG_INFINITY),
+                    VALUE_NAN => Ok(Self::NAN),
+                    _ => Ok(val.parse()?),
+                }
+            }
+        }
+    };
+}
+
+xml_enc_number!(u8);
+xml_enc_number!(u16);
+xml_enc_number!(u32);
+xml_enc_number!(u64);
+xml_enc_number!(i8);
+xml_enc_number!(i16);
+xml_enc_number!(i32);
+xml_enc_number!(i64);
+xml_enc_float!(f32);
+xml_enc_float!(f64);
+
+impl XmlDecodable for String {
+    fn decode(
+        read: &mut XmlStreamReader<&mut dyn Read>,
+        _context: &Context<'_>,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(read.consume_as_text()?)
+    }
+}
+
+impl XmlEncodable for String {
+    fn encode(
+        &self,
+        writer: &mut XmlStreamWriter<&mut dyn Write>,
+        _context: &Context<'_>,
+    ) -> Result<(), Error> {
+        writer.write_text(self)?;
+        Ok(())
+    }
+}
+
+impl XmlDecodable for bool {
+    fn decode(
+        read: &mut XmlStreamReader<&mut dyn Read>,
+        _context: &Context<'_>,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let val = read.consume_as_text()?;
+        match val.as_str() {
+            "true" | "1" => Ok(true),
+            "false" | "0" => Ok(false),
+            _ => Err(Error::decoding(format!("Invalid boolean value: {val}"))),
+        }
+    }
+}
+
+impl XmlEncodable for bool {
+    fn encode(
+        &self,
+        writer: &mut XmlStreamWriter<&mut dyn Write>,
+        _context: &Context<'_>,
+    ) -> Result<(), Error> {
+        writer.write_text(if *self { "true" } else { "false" })?;
+        Ok(())
+    }
+}
+
+impl<T> XmlDecodable for Box<T>
+where
+    T: XmlDecodable,
+{
+    fn decode(
+        read: &mut XmlStreamReader<&mut dyn Read>,
+        context: &Context<'_>,
+    ) -> Result<Self, Error> {
+        Ok(Box::new(T::decode(read, context)?))
+    }
+}
+
+impl<T> XmlEncodable for Box<T>
+where
+    T: XmlEncodable,
+{
+    fn encode(
+        &self,
+        writer: &mut XmlStreamWriter<&mut dyn Write>,
+        context: &Context<'_>,
+    ) -> Result<(), Error> {
+        self.as_ref().encode(writer, context)
+    }
+}

--- a/async-opcua-types/src/xml/builtins.rs
+++ b/async-opcua-types/src/xml/builtins.rs
@@ -105,6 +105,17 @@ impl XmlEncodable for String {
     }
 }
 
+impl XmlEncodable for str {
+    fn encode(
+        &self,
+        writer: &mut XmlStreamWriter<&mut dyn Write>,
+        _context: &Context<'_>,
+    ) -> Result<(), Error> {
+        writer.write_text(self)?;
+        Ok(())
+    }
+}
+
 impl XmlDecodable for bool {
     fn decode(
         read: &mut XmlStreamReader<&mut dyn Read>,

--- a/async-opcua-types/src/xml/encoding.rs
+++ b/async-opcua-types/src/xml/encoding.rs
@@ -1,8 +1,11 @@
-use std::io::{Read, Write};
+use std::{
+    io::{Read, Write},
+    str::{from_utf8, Utf8Error},
+};
 
 use opcua_xml::{XmlReadError, XmlStreamReader, XmlStreamWriter, XmlWriteError};
 
-use crate::{Context, Error};
+use crate::{Context, EncodingResult, Error};
 
 impl From<XmlReadError> for Error {
     fn from(value: XmlReadError) -> Self {
@@ -16,7 +19,15 @@ impl From<XmlWriteError> for Error {
     }
 }
 
+impl From<Utf8Error> for Error {
+    fn from(value: Utf8Error) -> Self {
+        Self::decoding(value)
+    }
+}
+
+/// Trait for types that can be decoded from XML.
 pub trait XmlDecodable {
+    /// Decode a value from an XML stream.
     fn decode(
         read: &mut XmlStreamReader<&mut dyn Read>,
         context: &Context<'_>,
@@ -25,10 +36,122 @@ pub trait XmlDecodable {
         Self: Sized;
 }
 
+/// Trait for types that can be encoded to XML.
 pub trait XmlEncodable {
+    /// Encode a value to an XML stream.
     fn encode(
         &self,
         writer: &mut XmlStreamWriter<&mut dyn Write>,
         context: &Context<'_>,
-    ) -> Result<(), Error>;
+    ) -> EncodingResult<()>;
+}
+
+/// Extensions for XmlStreamWriter.
+pub trait XmlWriteExt {
+    /// Encode a value as a child element.
+    fn encode_child<T: XmlEncodable + ?Sized>(
+        &mut self,
+        tag: &str,
+        value: &T,
+        context: &Context<'_>,
+    ) -> EncodingResult<()>;
+}
+
+impl XmlWriteExt for XmlStreamWriter<&mut dyn Write> {
+    fn encode_child<T: XmlEncodable + ?Sized>(
+        &mut self,
+        tag: &str,
+        value: &T,
+        context: &Context<'_>,
+    ) -> EncodingResult<()> {
+        self.write_start(tag)?;
+        value.encode(self, context)?;
+        self.write_end(tag)?;
+
+        Ok(())
+    }
+}
+
+/// Extensions for XmlStreamReader.
+pub trait XmlReadExt {
+    /// Iterate over children, calling the provided callback for each tag.
+    /// The callback must consume the tag.
+    fn iter_children(
+        &mut self,
+        cb: impl FnMut(String, &mut Self, &Context<'_>) -> EncodingResult<()>,
+        context: &Context<'_>,
+    ) -> EncodingResult<()>;
+
+    /// Call a callback for a single child element. This will consume the
+    /// current node.
+    fn get_single_child<T>(
+        &mut self,
+        tag: &str,
+        cb: impl FnMut(&mut Self, &Context<'_>) -> Result<T, Error>,
+        context: &Context<'_>,
+    ) -> EncodingResult<Option<T>>;
+
+    /// Decode a single child element. This will consume the
+    /// current node.
+    fn decode_single_child<T: XmlDecodable>(
+        &mut self,
+        tag: &str,
+        context: &Context<'_>,
+    ) -> Result<Option<T>, Error>;
+}
+
+impl XmlReadExt for XmlStreamReader<&mut dyn Read> {
+    fn iter_children(
+        &mut self,
+        mut process: impl FnMut(String, &mut Self, &Context<'_>) -> EncodingResult<()>,
+        context: &Context<'_>,
+    ) -> EncodingResult<()> {
+        loop {
+            match self.next_event()? {
+                opcua_xml::events::Event::Start(s) => {
+                    let name = from_utf8(s.name().0)?;
+                    process(name.to_owned(), self, context)?;
+                }
+                opcua_xml::events::Event::End(_) => {
+                    return Ok(());
+                }
+                opcua_xml::events::Event::Eof => {
+                    return Err(Error::decoding(XmlReadError::UnexpectedEof));
+                }
+                _ => (),
+            }
+        }
+    }
+
+    fn get_single_child<T>(
+        &mut self,
+        tag: &str,
+        cb: impl FnOnce(&mut Self, &Context<'_>) -> Result<T, Error>,
+        context: &Context<'_>,
+    ) -> EncodingResult<Option<T>> {
+        let mut cb = Some(cb);
+        let mut res = None;
+        self.iter_children(
+            |key, reader, ctx| {
+                if tag == key {
+                    if let Some(cb) = cb.take() {
+                        res = Some(cb(reader, ctx)?);
+                    }
+                } else {
+                    reader.skip_value()?;
+                }
+                Ok(())
+            },
+            context,
+        )?;
+        Ok(res)
+    }
+
+    fn decode_single_child<T: XmlDecodable>(
+        &mut self,
+        tag: &str,
+        context: &Context<'_>,
+    ) -> EncodingResult<Option<T>> {
+        self.get_single_child(tag, |reader, ctx| T::decode(reader, ctx), context)
+    }
 }

--- a/async-opcua-types/src/xml/encoding.rs
+++ b/async-opcua-types/src/xml/encoding.rs
@@ -25,8 +25,19 @@ impl From<Utf8Error> for Error {
     }
 }
 
+/// Trait for XML type name. Used by both XmlDecodable and XmlEncodable.
+pub trait XmlType {
+    /// The static fallback tag for this type.
+    /// Convenience feature, but also used in nested types.
+    const TAG: &'static str;
+    /// The XML tag name for this type.
+    fn tag(&self) -> &str {
+        Self::TAG
+    }
+}
+
 /// Trait for types that can be decoded from XML.
-pub trait XmlDecodable {
+pub trait XmlDecodable: XmlType {
     /// Decode a value from an XML stream.
     fn decode(
         read: &mut XmlStreamReader<&mut dyn Read>,
@@ -37,7 +48,7 @@ pub trait XmlDecodable {
 }
 
 /// Trait for types that can be encoded to XML.
-pub trait XmlEncodable {
+pub trait XmlEncodable: XmlType {
     /// Encode a value to an XML stream.
     fn encode(
         &self,
@@ -75,6 +86,14 @@ impl XmlWriteExt for XmlStreamWriter<&mut dyn Write> {
 /// Extensions for XmlStreamReader.
 pub trait XmlReadExt {
     /// Iterate over children, calling the provided callback for each tag.
+    /// The callback must consume the tag, unless no reader is provided,
+    /// in which case the tag is already closed.
+    fn iter_children_include_empty(
+        &mut self,
+        process: impl FnMut(String, Option<&mut Self>, &Context<'_>) -> EncodingResult<()>,
+        context: &Context<'_>,
+    ) -> EncodingResult<()>;
+    /// Iterate over children, calling the provided callback for each tag.
     /// The callback must consume the tag.
     fn iter_children(
         &mut self,
@@ -98,9 +117,42 @@ pub trait XmlReadExt {
         tag: &str,
         context: &Context<'_>,
     ) -> Result<Option<T>, Error>;
+
+    /// Call a callback for the first child element, then skip the rest. This will
+    /// consume the current node.
+    fn get_first_child<T>(
+        &mut self,
+        cb: impl FnOnce(String, &mut Self, &Context<'_>) -> Result<T, Error>,
+        context: &Context<'_>,
+    ) -> EncodingResult<Option<T>>;
 }
 
 impl XmlReadExt for XmlStreamReader<&mut dyn Read> {
+    fn iter_children_include_empty(
+        &mut self,
+        mut process: impl FnMut(String, Option<&mut Self>, &Context<'_>) -> EncodingResult<()>,
+        context: &Context<'_>,
+    ) -> EncodingResult<()> {
+        loop {
+            match self.next_event()? {
+                opcua_xml::events::Event::Start(s) => {
+                    let local_name = s.local_name();
+                    let name = from_utf8(local_name.as_ref())?;
+                    process(name.to_owned(), Some(self), context)?;
+                }
+                opcua_xml::events::Event::Empty(s) => {
+                    let local_name = s.local_name();
+                    let name = from_utf8(local_name.as_ref())?;
+                    process(name.to_owned(), None, context)?;
+                }
+                opcua_xml::events::Event::End(_) | opcua_xml::events::Event::Eof => {
+                    return Ok(());
+                }
+                _ => (),
+            }
+        }
+    }
+
     fn iter_children(
         &mut self,
         mut process: impl FnMut(String, &mut Self, &Context<'_>) -> EncodingResult<()>,
@@ -109,14 +161,12 @@ impl XmlReadExt for XmlStreamReader<&mut dyn Read> {
         loop {
             match self.next_event()? {
                 opcua_xml::events::Event::Start(s) => {
-                    let name = from_utf8(s.name().0)?;
+                    let local_name = s.local_name();
+                    let name = from_utf8(local_name.as_ref())?;
                     process(name.to_owned(), self, context)?;
                 }
-                opcua_xml::events::Event::End(_) => {
+                opcua_xml::events::Event::End(_) | opcua_xml::events::Event::Eof => {
                     return Ok(());
-                }
-                opcua_xml::events::Event::Eof => {
-                    return Err(Error::decoding(XmlReadError::UnexpectedEof));
                 }
                 _ => (),
             }
@@ -136,10 +186,10 @@ impl XmlReadExt for XmlStreamReader<&mut dyn Read> {
                 if tag == key {
                     if let Some(cb) = cb.take() {
                         res = Some(cb(reader, ctx)?);
+                        return Ok(());
                     }
-                } else {
-                    reader.skip_value()?;
                 }
+                reader.skip_value()?;
                 Ok(())
             },
             context,
@@ -153,5 +203,26 @@ impl XmlReadExt for XmlStreamReader<&mut dyn Read> {
         context: &Context<'_>,
     ) -> EncodingResult<Option<T>> {
         self.get_single_child(tag, |reader, ctx| T::decode(reader, ctx), context)
+    }
+
+    fn get_first_child<T>(
+        &mut self,
+        cb: impl FnOnce(String, &mut Self, &Context<'_>) -> Result<T, Error>,
+        context: &Context<'_>,
+    ) -> EncodingResult<Option<T>> {
+        let mut cb = Some(cb);
+        let mut res = None;
+        self.iter_children(
+            |key, reader, ctx| {
+                if let Some(cb) = cb.take() {
+                    res = Some(cb(key, reader, ctx)?);
+                    return Ok(());
+                }
+                reader.skip_value()?;
+                Ok(())
+            },
+            context,
+        )?;
+        Ok(res)
     }
 }

--- a/async-opcua-types/src/xml/encoding.rs
+++ b/async-opcua-types/src/xml/encoding.rs
@@ -1,0 +1,34 @@
+use std::io::{Read, Write};
+
+use opcua_xml::{XmlReadError, XmlStreamReader, XmlStreamWriter, XmlWriteError};
+
+use crate::{Context, Error};
+
+impl From<XmlReadError> for Error {
+    fn from(value: XmlReadError) -> Self {
+        Self::decoding(value)
+    }
+}
+
+impl From<XmlWriteError> for Error {
+    fn from(value: XmlWriteError) -> Self {
+        Self::encoding(value)
+    }
+}
+
+pub trait XmlDecodable {
+    fn decode(
+        read: &mut XmlStreamReader<&mut dyn Read>,
+        context: &Context<'_>,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+}
+
+pub trait XmlEncodable {
+    fn encode(
+        &self,
+        writer: &mut XmlStreamWriter<&mut dyn Write>,
+        context: &Context<'_>,
+    ) -> Result<(), Error>;
+}

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Core utilities for working with decoding OPC UA types from NodeSet2 XML files.
 
+mod builtins;
+mod encoding;
+
 use std::str::FromStr;
 
 use log::warn;

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -5,15 +5,18 @@
 mod builtins;
 mod encoding;
 
+pub use crate::{Context, EncodingResult, Error};
+pub use encoding::{XmlDecodable, XmlEncodable, XmlReadExt, XmlWriteExt};
+pub use opcua_xml::{XmlStreamReader, XmlStreamWriter};
+
 use std::str::FromStr;
 
 use log::warn;
 pub use opcua_xml::schema::opc_ua_types::XmlElement;
 
 use crate::{
-    Array, ByteString, Context, DataValue, DateTime, EncodingResult, Error, ExpandedNodeId,
-    ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, UAString,
-    UninitializedIndex, Variant, VariantScalarTypeId,
+    Array, ByteString, DataValue, DateTime, ExpandedNodeId, ExtensionObject, Guid, LocalizedText,
+    NodeId, QualifiedName, StatusCode, UAString, UninitializedIndex, Variant, VariantScalarTypeId,
 };
 
 impl From<UninitializedIndex> for Error {

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -6,423 +6,25 @@ mod builtins;
 mod encoding;
 
 pub use crate::{Context, EncodingResult, Error};
-pub use encoding::{XmlDecodable, XmlEncodable, XmlReadExt, XmlWriteExt};
+pub use encoding::{XmlDecodable, XmlEncodable, XmlReadExt, XmlType, XmlWriteExt};
 pub use opcua_xml::{XmlStreamReader, XmlStreamWriter};
 
-use std::str::FromStr;
+use std::{
+    io::{Cursor, Read},
+    str::FromStr,
+};
 
 use log::warn;
 pub use opcua_xml::schema::opc_ua_types::XmlElement;
 
 use crate::{
-    Array, ByteString, DataValue, DateTime, ExpandedNodeId, ExtensionObject, Guid, LocalizedText,
-    NodeId, QualifiedName, StatusCode, UAString, UninitializedIndex, Variant, VariantScalarTypeId,
+    Array, ByteString, ExpandedNodeId, ExtensionObject, LocalizedText, NodeId, QualifiedName,
+    StatusCode, UninitializedIndex, Variant, VariantScalarTypeId,
 };
 
 impl From<UninitializedIndex> for Error {
     fn from(value: UninitializedIndex) -> Self {
         Self::decoding(format!("Uninitialized index {}", value.0))
-    }
-}
-
-macro_rules! from_xml_number {
-    ($n:ty) => {
-        impl FromXml for $n {
-            fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-                let Some(c) = element.text.as_ref() else {
-                    return Ok(Self::default());
-                };
-                c.parse::<$n>().map_err(Error::decoding)
-            }
-        }
-    };
-}
-
-from_xml_number!(u8);
-from_xml_number!(i8);
-from_xml_number!(u16);
-from_xml_number!(i16);
-from_xml_number!(u32);
-from_xml_number!(i32);
-from_xml_number!(u64);
-from_xml_number!(i64);
-from_xml_number!(f32);
-from_xml_number!(f64);
-from_xml_number!(bool);
-
-/// `FromXml` is implemented by types that can be loaded from a NodeSet2 XML node.
-pub trait FromXml: Sized {
-    /// Attempt to load the type from the given XML node.
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self>;
-    /// Get the default value of the field, or fail with a `MissingRequired` error.
-    /// Workaround for specialization.
-    fn default_or_required(name: &'static str) -> EncodingResult<Self> {
-        Err(Error::decoding(format!("Missing required field: {name}")))
-    }
-}
-
-impl FromXml for UAString {
-    fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-        Ok(element.text.clone().into())
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for LocalizedText {
-    fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-        Ok(LocalizedText::new(
-            element.child_content("Locale").unwrap_or("").trim(),
-            element.child_content("Text").unwrap_or("").trim(),
-        ))
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for Guid {
-    fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-        if let Some(data) = element.child_content("String") {
-            Guid::from_str(data).map_err(Error::decoding)
-        } else {
-            Ok(Guid::null())
-        }
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for NodeId {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let Some(id) = element.child_content("Identifier") else {
-            return Ok(NodeId::null());
-        };
-        let id = ctx.resolve_alias(id);
-        let mut node_id = NodeId::from_str(id)
-            .map_err(|e| Error::new(e, format!("Failed to parse node ID from string {id}")))?;
-        // Update the namespace index, the index in the XML nodeset will probably not match the one
-        // in the server.
-        node_id.namespace = ctx.resolve_namespace_index(node_id.namespace)?;
-        Ok(node_id)
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for ExpandedNodeId {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        Ok(ExpandedNodeId::new(NodeId::from_xml(element, ctx)?))
-    }
-}
-
-impl FromXml for StatusCode {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let code = element
-            .first_child_with_name("Code")
-            .map(|v| u32::from_xml(v, ctx))
-            .transpose()?
-            .unwrap_or_default();
-        Ok(StatusCode::from(code))
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::Good)
-    }
-}
-
-impl FromXml for ExtensionObject {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let type_id = element
-            .first_child_with_name("TypeId")
-            .ok_or_else(|| Error::decoding("Missing required field TypeId"))?;
-        let type_id = NodeId::from_xml(type_id, ctx)?;
-        let body = element
-            .first_child_with_name("Body")
-            // Extension objects always contain the name of the type wrapping the actual type, we need to
-            // unwrap that to get to the type FromXml expects.
-            .and_then(|b| b.children.iter().next().and_then(|m| m.1.iter().next()));
-        let Some(body) = body else {
-            return Ok(ExtensionObject::null());
-        };
-        ctx.load_from_xml(&type_id, body)
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for DateTime {
-    fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-        DateTime::from_str(
-            element
-                .text
-                .as_deref()
-                .ok_or_else(|| Error::decoding("DateTime is missing required content"))?,
-        )
-        .map_err(Error::decoding)
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for ByteString {
-    fn from_xml(element: &XmlElement, _ctx: &Context<'_>) -> EncodingResult<Self> {
-        let Some(c) = element.text.as_ref() else {
-            return Ok(ByteString::null());
-        };
-        ByteString::from_base64(c)
-            .ok_or_else(|| Error::decoding("Failed to parse bytestring from string"))
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for QualifiedName {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let index = element.child_content("NamespaceIndex");
-        let index = if let Some(index) = index {
-            index.parse::<u16>().map_err(Error::decoding)?
-        } else {
-            0
-        };
-        let index = ctx.resolve_namespace_index(index)?;
-        let name = element.child_content("Name").unwrap_or("");
-        Ok(QualifiedName::new(index, name))
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-impl FromXml for DataValue {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let value = XmlField::get_xml_field(element, "Value", ctx)?;
-        let status = XmlField::get_xml_field(element, "StatusCode", ctx)?;
-        let source_timestamp = XmlField::get_xml_field(element, "SourceTimestamp", ctx)?;
-        let source_picoseconds = XmlField::get_xml_field(element, "SourcePicoseconds", ctx)?;
-        let server_timestamp = XmlField::get_xml_field(element, "ServerTimestamp", ctx)?;
-        let server_picoseconds = XmlField::get_xml_field(element, "ServerPicoseconds", ctx)?;
-        Ok(DataValue {
-            value,
-            status,
-            source_timestamp,
-            source_picoseconds,
-            server_timestamp,
-            server_picoseconds,
-        })
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::null())
-    }
-}
-
-fn children_with_name<T: FromXml>(
-    element: &XmlElement,
-    ctx: &Context<'_>,
-    name: &str,
-) -> Result<Vec<T>, Error> {
-    element
-        .children_with_name(name)
-        .map(|n| T::from_xml(n, ctx))
-        .collect()
-}
-
-impl FromXml for Variant {
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        let Some((_, body)) = element.children.iter().next() else {
-            return Ok(Variant::Empty);
-        };
-        let Some(body) = body.first() else {
-            return Ok(Variant::Empty);
-        };
-        Ok(match body.tag.as_str() {
-            "Boolean" => Variant::Boolean(FromXml::from_xml(body, ctx)?),
-            "ListOfBoolean" => Variant::from(children_with_name::<bool>(body, ctx, "Boolean")?),
-            "SByte" => Variant::SByte(FromXml::from_xml(body, ctx)?),
-            "ListOfSByte" => Variant::from(children_with_name::<i8>(body, ctx, "SByte")?),
-            "Byte" => Variant::Byte(FromXml::from_xml(body, ctx)?),
-            "ListOfByte" => Variant::from(children_with_name::<u8>(body, ctx, "Byte")?),
-            "Int16" => Variant::Int16(FromXml::from_xml(body, ctx)?),
-            "ListOfInt16" => Variant::from(children_with_name::<i16>(body, ctx, "Int16")?),
-            "UInt16" => Variant::UInt16(FromXml::from_xml(body, ctx)?),
-            "ListOfUInt16" => Variant::from(children_with_name::<u16>(body, ctx, "UInt16")?),
-            "Int32" => Variant::Int32(FromXml::from_xml(body, ctx)?),
-            "ListOfInt32" => Variant::from(children_with_name::<i32>(body, ctx, "Int32")?),
-            "UInt32" => Variant::UInt32(FromXml::from_xml(body, ctx)?),
-            "ListOfUInt32" => Variant::from(children_with_name::<u32>(body, ctx, "UInt32")?),
-            "Int64" => Variant::Int64(FromXml::from_xml(body, ctx)?),
-            "ListOfInt64" => Variant::from(children_with_name::<i64>(body, ctx, "Int64")?),
-            "UInt64" => Variant::UInt64(FromXml::from_xml(body, ctx)?),
-            "ListOfUInt64" => Variant::from(children_with_name::<u64>(body, ctx, "UInt64")?),
-            "Float" => Variant::Float(FromXml::from_xml(body, ctx)?),
-            "ListOfFloat" => Variant::from(children_with_name::<f32>(body, ctx, "Float")?),
-            "Double" => Variant::Double(FromXml::from_xml(body, ctx)?),
-            "ListOfDouble" => Variant::from(children_with_name::<f64>(body, ctx, "Double")?),
-            "String" => Variant::String(FromXml::from_xml(body, ctx)?),
-            "ListOfString" => Variant::from(children_with_name::<UAString>(body, ctx, "String")?),
-            "DateTime" => Variant::DateTime(FromXml::from_xml(body, ctx)?),
-            "ListOfDateTime" => {
-                Variant::from(children_with_name::<DateTime>(body, ctx, "DateTime")?)
-            }
-            "Guid" => Variant::Guid(FromXml::from_xml(body, ctx)?),
-            "ListOfGuid" => Variant::from(children_with_name::<Guid>(body, ctx, "Guid")?),
-            "ByteString" => Variant::ByteString(FromXml::from_xml(body, ctx)?),
-            "ListOfByteString" => {
-                Variant::from(children_with_name::<ByteString>(body, ctx, "ByteString")?)
-            }
-            "XmlElement" => Variant::XmlElement(body.to_string().into()),
-            "ListOfXmlElement" => Variant::from(
-                body.children_with_name("XmlElement")
-                    .map(|v| UAString::from(v.to_string()))
-                    .collect::<Vec<_>>(),
-            ),
-            "QualifiedName" => Variant::QualifiedName(FromXml::from_xml(body, ctx)?),
-            "ListOfQualifiedName" => Variant::from(children_with_name::<QualifiedName>(
-                body,
-                ctx,
-                "QualifiedName",
-            )?),
-            "LocalizedText" => Variant::LocalizedText(FromXml::from_xml(body, ctx)?),
-            "ListOfLocalizedText" => Variant::from(children_with_name::<LocalizedText>(
-                body,
-                ctx,
-                "LocalizedText",
-            )?),
-            "NodeId" => Variant::NodeId(FromXml::from_xml(body, ctx)?),
-            "ListOfNodeId" => Variant::from(children_with_name::<NodeId>(body, ctx, "NodeId")?),
-            "ExpandedNodeId" => Variant::ExpandedNodeId(FromXml::from_xml(body, ctx)?),
-            "ListOfExpandedNodeId" => Variant::from(children_with_name::<ExpandedNodeId>(
-                body,
-                ctx,
-                "ExpandedNodeId",
-            )?),
-            "ExtensionObject" => Variant::ExtensionObject(FromXml::from_xml(body, ctx)?),
-            "ListOfExtensionObject" => Variant::from(children_with_name::<ExtensionObject>(
-                body,
-                ctx,
-                "ExtensionObject",
-            )?),
-            "Variant" => Variant::Variant(FromXml::from_xml(body, ctx)?),
-            "ListOfVariant" => Variant::from(children_with_name::<Variant>(body, ctx, "Variant")?),
-            "StatusCode" => Variant::StatusCode(FromXml::from_xml(body, ctx)?),
-            "ListOfStatusCode" => {
-                Variant::from(children_with_name::<StatusCode>(body, ctx, "StatusCode")?)
-            }
-            r => return Err(Error::decoding(format!("Unexpected variant type: {r}"))),
-        })
-    }
-
-    fn default_or_required(_name: &'static str) -> EncodingResult<Self> {
-        Ok(Self::Empty)
-    }
-}
-
-impl<T> FromXml for Box<T>
-where
-    T: FromXml,
-{
-    fn from_xml(element: &XmlElement, ctx: &Context<'_>) -> EncodingResult<Self> {
-        Ok(Box::new(T::from_xml(element, ctx)?))
-    }
-
-    fn default_or_required(name: &'static str) -> EncodingResult<Self> {
-        Ok(Box::new(T::default_or_required(name)?))
-    }
-}
-
-/// `XmlField` is a convenience trait that wraps [`FromXml`] when the
-/// XML node to extract is one or more fields of a parent node.
-/// It is implemented for `T`, `Vec<T>`, `Option<T>`, and `Option<Vec<T>>`, notably.
-pub trait XmlField: Sized {
-    /// Get the child of `parent` with name `name` as `Self`.
-    fn get_xml_field(
-        parent: &XmlElement,
-        name: &'static str,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<Self>;
-}
-
-impl<T> XmlField for T
-where
-    T: FromXml,
-{
-    fn get_xml_field(
-        parent: &XmlElement,
-        name: &'static str,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<Self> {
-        let Some(own) = parent.first_child_with_name(name) else {
-            return T::default_or_required(name);
-        };
-        FromXml::from_xml(own, ctx)
-    }
-}
-
-impl<T> XmlField for Option<T>
-where
-    T: FromXml,
-{
-    fn get_xml_field(
-        parent: &XmlElement,
-        name: &'static str,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<Self> {
-        let Some(own) = parent.first_child_with_name(name) else {
-            return Ok(None);
-        };
-        Ok(Some(FromXml::from_xml(own, ctx)?))
-    }
-}
-
-impl<T> XmlField for Vec<T>
-where
-    T: FromXml,
-{
-    fn get_xml_field(
-        parent: &XmlElement,
-        name: &'static str,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<Self> {
-        parent
-            .children_with_name(name)
-            .map(|n| FromXml::from_xml(n, ctx))
-            .collect()
-    }
-}
-
-impl<T> XmlField for Option<Vec<T>>
-where
-    T: FromXml,
-{
-    fn get_xml_field(
-        parent: &XmlElement,
-        name: &'static str,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<Self> {
-        let v: Vec<T> = parent
-            .children_with_name(name)
-            .map(|n| <T as FromXml>::from_xml(n, ctx))
-            .collect::<Result<Vec<_>, _>>()?;
-        if v.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(v))
-        }
     }
 }
 
@@ -437,24 +39,39 @@ fn mk_node_id(node_id: &opc_ua_types::NodeId, ctx: &Context<'_>) -> Result<NodeI
     Ok(parsed)
 }
 
+use opcua_xml::{
+    events::Event,
+    schema::opc_ua_types::{self, Variant as XmlVariant},
+};
+
 fn mk_extension_object(
-    ext_obj: &opc_ua_types::ExtensionObject,
+    val: &opc_ua_types::ExtensionObject,
     ctx: &Context<'_>,
-) -> Result<ExtensionObject, Error> {
-    let Some(b) = ext_obj.body.as_ref() else {
+) -> EncodingResult<ExtensionObject> {
+    let Some(body) = &val.body else {
         return Ok(ExtensionObject::null());
     };
-
-    let Some(type_id) = ext_obj.type_id.as_ref() else {
+    let Some(data) = &body.data else {
         return Ok(ExtensionObject::null());
     };
-
+    let Some(type_id) = &val.type_id else {
+        return Err(Error::decoding("Extension object missing type ID"));
+    };
     let node_id = mk_node_id(type_id, ctx)?;
-
-    ctx.load_from_xml(&node_id, &b.data)
+    let mut cursor = Cursor::new(data.as_bytes());
+    let mut stream = XmlStreamReader::new(&mut cursor as &mut dyn Read);
+    // Read the entry tag, as this is how extension objects are parsed
+    loop {
+        match stream.next_event()? {
+            Event::Start(_) => break,
+            Event::End(_) | Event::Eof | Event::Empty(_) => {
+                return Ok(ExtensionObject::null());
+            }
+            _ => (),
+        }
+    }
+    ctx.load_from_xml(&node_id, &mut stream)
 }
-
-use opcua_xml::schema::opc_ua_types::{self, Variant as XmlVariant};
 
 impl Variant {
     /// Create a Variant value from a NodeSet2 variant object.

--- a/async-opcua-xml/Cargo.toml
+++ b/async-opcua-xml/Cargo.toml
@@ -19,3 +19,4 @@ chrono = { workspace = true }
 roxmltree = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+quick-xml = { workspace = true }

--- a/async-opcua-xml/src/encoding/mod.rs
+++ b/async-opcua-xml/src/encoding/mod.rs
@@ -1,0 +1,5 @@
+mod reader;
+mod writer;
+
+pub use reader::{XmlReadError, XmlStreamReader};
+pub use writer::{XmlStreamWriter, XmlWriteError};

--- a/async-opcua-xml/src/encoding/reader.rs
+++ b/async-opcua-xml/src/encoding/reader.rs
@@ -45,7 +45,10 @@ impl<T: Read> XmlStreamReader<T> {
     /// Get the next event from the stream.
     pub fn next_event(&mut self) -> Result<quick_xml::events::Event, XmlReadError> {
         self.buffer.clear();
-        Ok(self.reader.read_event_into(&mut self.buffer)?)
+        match self.reader.read_event_into(&mut self.buffer)? {
+            Event::Eof => Err(XmlReadError::UnexpectedEof),
+            e => Ok(e),
+        }
     }
 
     /// Skip the current value. This should be called after encountering a

--- a/async-opcua-xml/src/encoding/reader.rs
+++ b/async-opcua-xml/src/encoding/reader.rs
@@ -1,0 +1,186 @@
+use std::{
+    io::{BufReader, Read},
+    num::{ParseFloatError, ParseIntError},
+    str::FromStr,
+};
+
+use quick_xml::events::Event;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+/// Error produced when reading XML.
+pub enum XmlReadError {
+    #[error("{0}")]
+    /// Failed to parse XML.
+    Xml(#[from] quick_xml::Error),
+    #[error("Unexpected EOF")]
+    /// Unexpected EOF.
+    UnexpectedEof,
+    #[error("Failed to parse integer: {0}")]
+    /// Failed to parse value as integer.
+    ParseInt(#[from] ParseIntError),
+    #[error("Failed to parse float: {0}")]
+    /// Failed to parse value as float.
+    ParseFloat(#[from] ParseFloatError),
+    #[error("Failed to parse value: {0}")]
+    /// Some other parse error.
+    Parse(String),
+}
+
+/// XML stream reader specialized for working with OPC-UA XML.
+pub struct XmlStreamReader<T> {
+    reader: quick_xml::Reader<BufReader<T>>,
+    buffer: Vec<u8>,
+}
+
+impl<T: Read> XmlStreamReader<T> {
+    /// Create a new stream reader with an internal buffer.
+    pub fn new(reader: T) -> Self {
+        Self {
+            reader: quick_xml::Reader::from_reader(BufReader::new(reader)),
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Get the next event from the stream.
+    pub fn next_event(&mut self) -> Result<quick_xml::events::Event, XmlReadError> {
+        self.buffer.clear();
+        Ok(self.reader.read_event_into(&mut self.buffer)?)
+    }
+
+    /// Skip the current value. This should be called after encountering a
+    /// `Start` event, and will skip until the corresponding `End` event is consumed.
+    ///
+    /// Note that this does not check that the document is coherent, just that
+    /// an equal number of start and end events are consumed.
+    pub fn skip_value(&mut self) -> Result<(), XmlReadError> {
+        let mut depth = 1u32;
+        loop {
+            match self.next_event()? {
+                Event::Start(_) => depth += 1,
+                Event::End(_) => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(());
+                    }
+                }
+                Event::Eof => return Err(XmlReadError::UnexpectedEof),
+                _ => {}
+            }
+        }
+    }
+
+    /// Consume the current event, skipping any child elements and returning the combined text
+    /// content with leading and trailing whitespace removed.
+    /// Note that if there are multiple text elements they will be concatenated, but
+    /// whitespace between these will not be removed.
+    pub fn consume_as_text(&mut self) -> Result<String, XmlReadError> {
+        let mut text: Option<String> = None;
+        let mut depth = 1u32;
+        loop {
+            match self.next_event()? {
+                Event::Start(_) => depth += 1,
+                Event::End(_) => {
+                    depth -= 1;
+                    if depth == 0 {
+                        if let Some(mut text) = text {
+                            let trimmed = text.trim_ascii_end();
+                            text.truncate(trimmed.len());
+                            return Ok(text);
+                        } else {
+                            return Ok(String::new());
+                        }
+                    }
+                }
+                Event::Text(mut e) => {
+                    if depth != 1 {
+                        continue;
+                    }
+                    if let Some(text) = text.as_mut() {
+                        text.push_str(&e.unescape()?);
+                    } else if e.inplace_trim_start() {
+                        continue;
+                    } else {
+                        text = Some(e.unescape()?.into_owned());
+                    }
+                }
+
+                Event::Eof => return Err(XmlReadError::UnexpectedEof),
+                _ => continue,
+            }
+        }
+    }
+
+    /// Consume the current node as a text value and parse it as the given type.
+    pub fn consume_content<R: FromStr>(&mut self) -> Result<R, XmlReadError>
+    where
+        XmlReadError: From<<R as FromStr>::Err>,
+    {
+        let text = self.consume_as_text()?;
+        Ok(text.parse()?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+
+    use quick_xml::events::Event;
+
+    #[test]
+    fn test_xml_text_comments() {
+        let xml = r#"
+        <Foo>
+            Ho
+            <Bar>
+            Hello
+            </Bar>
+            Hello <!-- Comment --> there
+        </Foo>
+        "#;
+        let mut cursor = Cursor::new(xml.as_bytes());
+        let mut reader = super::XmlStreamReader::new(&mut cursor);
+        // You canend up with text everywhere. Any loading needs to account for this.
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Start(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Start(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::End(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Comment(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::End(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Text(_)));
+        assert!(matches!(reader.next_event().unwrap(), Event::Eof));
+        assert!(matches!(reader.next_event().unwrap(), Event::Eof));
+    }
+
+    #[test]
+    fn test_consume_as_text() {
+        let xml = r#"<Foo>
+            <Bar>
+            Hello
+            </Bar>
+            Hello <!-- Comment -->there
+        </Foo>"#;
+
+        let mut cursor = Cursor::new(xml.as_bytes());
+        let mut reader = super::XmlStreamReader::new(&mut cursor);
+
+        assert!(matches!(reader.next_event().unwrap(), Event::Start(_)));
+        assert_eq!(reader.consume_as_text().unwrap(), "Hello there");
+    }
+
+    #[test]
+    fn test_consume_content() {
+        let xml = r#"<Foo>
+            12345
+        </Foo>"#;
+        let mut cursor = Cursor::new(xml.as_bytes());
+        let mut reader = super::XmlStreamReader::new(&mut cursor);
+
+        assert!(matches!(reader.next_event().unwrap(), Event::Start(_)));
+        assert_eq!(reader.consume_content::<u32>().unwrap(), 12345);
+    }
+}

--- a/async-opcua-xml/src/encoding/writer.rs
+++ b/async-opcua-xml/src/encoding/writer.rs
@@ -1,0 +1,62 @@
+use std::io::Write;
+
+use quick_xml::{
+    events::{BytesEnd, BytesStart, BytesText, Event},
+    ElementWriter,
+};
+use thiserror::Error;
+
+/// XML stream writer specialized for working with OPC-UA XML.
+pub struct XmlStreamWriter<T> {
+    writer: quick_xml::Writer<T>,
+}
+
+#[derive(Debug, Error)]
+/// Error returned when writing XML.
+pub enum XmlWriteError {
+    #[error("{0}")]
+    /// Invalid XML input.
+    Xml(#[from] quick_xml::Error),
+    #[error("Failed to write to stream: {0}")]
+    /// Failed to write XML to stream.
+    Io(#[from] std::io::Error),
+}
+
+impl<T: Write> XmlStreamWriter<T> {
+    /// Create a new writer with the given inner Write implementation.
+    pub fn new(writer: T) -> Self {
+        Self {
+            writer: quick_xml::Writer::new(writer),
+        }
+    }
+
+    /// Write an event to the stream.
+    pub fn write_event(&mut self, element: Event<'_>) -> Result<(), XmlWriteError> {
+        self.writer.write_event(element)?;
+        Ok(())
+    }
+
+    /// Write a start tag to the stream.
+    pub fn write_start(&mut self, tag: &str) -> Result<(), XmlWriteError> {
+        self.writer
+            .write_event(Event::Start(BytesStart::new(tag)))?;
+        Ok(())
+    }
+
+    /// Write an end tag to the stream.
+    pub fn write_end(&mut self, tag: &str) -> Result<(), XmlWriteError> {
+        self.writer.write_event(Event::End(BytesEnd::new(tag)))?;
+        Ok(())
+    }
+
+    /// Write node contents to the stream.
+    pub fn write_text(&mut self, text: &str) -> Result<(), XmlWriteError> {
+        self.writer.write_event(Event::Text(BytesText::new(text)))?;
+        Ok(())
+    }
+
+    /// Get a flexible event builder from quick-xml.
+    pub fn create_element<'a>(&'a mut self, name: &'a str) -> ElementWriter<'a, T> {
+        self.writer.create_element(name)
+    }
+}

--- a/async-opcua-xml/src/error.rs
+++ b/async-opcua-xml/src/error.rs
@@ -53,6 +53,15 @@ pub struct XmlError {
     pub error: XmlErrorInner,
 }
 
+impl From<roxmltree::Error> for XmlError {
+    fn from(value: roxmltree::Error) -> Self {
+        Self {
+            span: 0..0,
+            error: XmlErrorInner::Xml(value),
+        }
+    }
+}
+
 impl XmlError {
     /// Create an error for a node with a missing field with name `name`.
     pub fn missing_field(node: &Node<'_, '_>, name: &str) -> Self {

--- a/async-opcua-xml/src/lib.rs
+++ b/async-opcua-xml/src/lib.rs
@@ -14,9 +14,12 @@
 use ext::NodeExt;
 use roxmltree::Node;
 
+mod encoding;
 mod error;
 mod ext;
 pub mod schema;
+
+pub use encoding::{XmlReadError, XmlStreamReader, XmlStreamWriter, XmlWriteError};
 
 pub use error::{XmlError, XmlErrorInner};
 pub use schema::opc_binary_schema::load_bsd_file;

--- a/async-opcua-xml/src/lib.rs
+++ b/async-opcua-xml/src/lib.rs
@@ -20,6 +20,7 @@ mod ext;
 pub mod schema;
 
 pub use encoding::{XmlReadError, XmlStreamReader, XmlStreamWriter, XmlWriteError};
+pub use quick_xml::events;
 
 pub use error::{XmlError, XmlErrorInner};
 pub use schema::opc_binary_schema::load_bsd_file;

--- a/code_gen_config.yml
+++ b/code_gen_config.yml
@@ -23,6 +23,7 @@ targets:
       mod opcua { pub use crate as types; }
     default_excluded:
       - AnonymousIdentityToken
+      - HistoryUpdateType
   - type: nodes
     file_path: schemas/1.05/Opc.Ua.NodeSet2.xml
     output_dir: async-opcua-core-namespace/src/generated

--- a/samples/custom-codegen/src/generated/types/enums.rs
+++ b/samples/custom-codegen/src/generated/types/enums.rs
@@ -21,7 +21,14 @@
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum IMTagSelectorEnumeration {
     #[opcua(default)]
@@ -43,7 +50,14 @@ pub enum IMTagSelectorEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnARStateEnumeration {
     #[opcua(default)]
@@ -67,7 +81,14 @@ pub enum PnARStateEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnARTypeEnumeration {
     #[opcua(default)]
@@ -90,7 +111,14 @@ pub enum PnARTypeEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnAssetChangeEnumeration {
     #[opcua(default)]
@@ -112,7 +140,14 @@ pub enum PnAssetChangeEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnAssetTypeEnumeration {
     #[opcua(default)]
@@ -135,7 +170,14 @@ pub enum PnAssetTypeEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnChannelAccumulativeEnumeration {
     #[opcua(default)]
@@ -156,7 +198,14 @@ pub enum PnChannelAccumulativeEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnChannelDirectionEnumeration {
     #[opcua(default)]
@@ -179,7 +228,14 @@ pub enum PnChannelDirectionEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnChannelMaintenanceEnumeration {
     #[opcua(default)]
@@ -202,7 +258,14 @@ pub enum PnChannelMaintenanceEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnChannelSpecifierEnumeration {
     #[opcua(default)]
@@ -225,7 +288,14 @@ pub enum PnChannelSpecifierEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnChannelTypeEnumeration {
     #[opcua(default)]
@@ -252,7 +322,14 @@ pub enum PnChannelTypeEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnDeviceStateEnumeration {
     #[opcua(default)]
@@ -275,7 +352,14 @@ pub enum PnDeviceStateEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnLinkStateEnumeration {
     UP = 1i32,
@@ -300,7 +384,14 @@ pub enum PnLinkStateEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnModuleStateEnumeration {
     #[opcua(default)]
@@ -324,7 +415,14 @@ pub enum PnModuleStateEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnPortStateEnumeration {
     #[opcua(default)]
@@ -350,7 +448,14 @@ pub enum PnPortStateEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnSubmoduleAddInfoEnumeration {
     #[opcua(default)]
@@ -371,7 +476,14 @@ pub enum PnSubmoduleAddInfoEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnSubmoduleARInfoEnumeration {
     #[opcua(default)]
@@ -395,7 +507,14 @@ pub enum PnSubmoduleARInfoEnumeration {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[repr(i32)]
 pub enum PnSubmoduleIdentInfoEnumeration {
     #[opcua(default)]

--- a/samples/custom-codegen/src/generated/types/mod.rs
+++ b/samples/custom-codegen/src/generated/types/mod.rs
@@ -95,7 +95,7 @@ impl opcua::types::TypeLoader for GeneratedTypeLoader {
     fn load_from_xml(
         &self,
         node_id: &opcua::types::NodeId,
-        stream: &opcua::types::xml::XmlElement,
+        stream: &mut opcua::types::xml::XmlStreamReader<&mut dyn std::io::Read>,
         ctx: &opcua::types::Context<'_>,
     ) -> Option<opcua::types::EncodingResult<Box<dyn opcua::types::DynEncodable>>> {
         let idx = ctx
@@ -105,9 +105,9 @@ impl opcua::types::TypeLoader for GeneratedTypeLoader {
             return None;
         }
         let Some(num_id) = node_id.as_u32() else {
-            return Some(Err(opcua::types::Error::decoding(format!(
-                "Unsupported encoding ID {node_id}, we only support numeric IDs"
-            ))));
+            return Some(Err(opcua::types::Error::decoding(
+                "Unsupported encoding ID. Only numeric encoding IDs are currently supported",
+            )));
         };
         TYPES.decode_xml(num_id, stream, ctx)
     }

--- a/samples/custom-codegen/src/generated/types/structs.rs
+++ b/samples/custom-codegen/src/generated/types/structs.rs
@@ -12,7 +12,14 @@
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PnDeviceDiagnosisDataType {
     pub api: u32,
@@ -60,7 +67,14 @@ impl opcua::types::ExpandedMessageInfo for PnDeviceDiagnosisDataType {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PnDeviceRoleOptionSet {
     pub value: opcua::types::byte_string::ByteString,
@@ -93,7 +107,14 @@ impl opcua::types::ExpandedMessageInfo for PnDeviceRoleOptionSet {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct PnIM5DataType {
     pub annotation: opcua::types::string::UAString,

--- a/samples/demo-server/src/customs.rs
+++ b/samples/demo-server/src/customs.rs
@@ -133,7 +133,14 @@ fn add_custom_data_type(nm: &SimpleNodeManager, ns: u16, e_state_id: &NodeId) ->
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 #[repr(i32)]
 pub enum AxisState {
@@ -150,7 +157,14 @@ pub enum AxisState {
     feature = "json",
     derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
 )]
-#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
+#[cfg_attr(
+    feature = "xml",
+    derive(
+        opcua::types::XmlEncodable,
+        opcua::types::XmlDecodable,
+        opcua::types::XmlType
+    )
+)]
 #[derive(Default)]
 pub struct ErrorData {
     message: opcua::types::UAString,


### PR DESCRIPTION
This is a major rewrite of XML parsing, adding support for XML serialization, and bringing it up to the same level as JSON and binary. I also fixed a few bugs I hit on in a few places. There are still some things remaining:

 - Unions
 - XML in binary/json encoded extension objects.
 - Proper support for the XmlElement variant (currently it doesn't work properly for XML). Note that this variant type is deprecated.

This PR is already way too big. There was no real way to make it smaller, since once you start replacing FromXml there's no way to stop while still having the library compile.

The PR is split into a few smaller commits, that incrementally add features, at least as much as was possible while still having each commit compile. The line count may be a little misleading, since a fair bit of it is generated, but this is a _big_ PR, just because there are so many changes.

I want to, in the future, use `quick-xml`s serde feature to replace `roxmltree` entirely, but this is currently not possible, as there is no way to capture raw XML, which we need to in order to defer loading of values for later, once `Context` is available.

We may also want to create an attribute-macro to automatically derive all the different encoding macros depending on input type, since just the derives are getting a bit verbose.