### PR TITLE
Cross decoding

### DIFF
--- a/async-opcua-types/src/byte_string.rs
+++ b/async-opcua-types/src/byte_string.rs
@@ -241,7 +241,7 @@ impl ByteString {
         self.is_null() || self.is_empty()
     }
 
-    /// Creates a byte string from a Base64 encoded string
+    /// Creates a byte string from a base64 encoded string
     pub fn from_base64(data: &str) -> Option<ByteString> {
         if let Ok(bytes) = STANDARD.decode(data) {
             Some(Self::from(bytes))
@@ -250,9 +250,9 @@ impl ByteString {
         }
     }
 
-    /// Creates a byte string from a Base64 encoded string, ignoring whitespace.
+    /// Creates a byte string from a base64 encoded string, ignoring whitespace.
     pub fn from_base64_ignore_whitespace(mut data: String) -> Option<ByteString> {
-        data.retain(|c| !['\n', ' ', '\t', '\r'].contains(&c));
+        data.retain(|c| !c.is_whitespace());
         if let Ok(bytes) = STANDARD.decode(&data) {
             Some(Self::from(bytes))
         } else {
@@ -260,7 +260,7 @@ impl ByteString {
         }
     }
 
-    /// Encodes the bytestring as a Base64 encoded string
+    /// Encodes the bytestring as a base64 encoded string
     pub fn as_base64(&self) -> String {
         // Base64 encodes the byte string so it can be represented as a string
         if let Some(ref value) = self.value {

--- a/async-opcua-types/src/encoding.rs
+++ b/async-opcua-types/src/encoding.rs
@@ -666,6 +666,12 @@ pub fn read_f64<R: Read + ?Sized>(stream: &mut R) -> EncodingResult<f64> {
     Ok(LittleEndian::read_f64(&buf))
 }
 
+/// Skip `bytes` bytes in the stream.
+pub fn skip_bytes<R: Read + ?Sized>(stream: &mut R, bytes: u64) -> EncodingResult<()> {
+    std::io::copy(&mut stream.take(bytes), &mut std::io::sink())?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -44,6 +44,19 @@ use opcua_xml::{
     schema::opc_ua_types::{self, Variant as XmlVariant},
 };
 
+/// Enter the first tag in the stream, returning `true` if a start tag was found.
+pub(crate) fn enter_first_tag(stream: &mut XmlStreamReader<&mut dyn Read>) -> EncodingResult<bool> {
+    loop {
+        match stream.next_event()? {
+            Event::Start(_) => return Ok(true),
+            Event::End(_) | Event::Eof | Event::Empty(_) => {
+                return Ok(false);
+            }
+            _ => (),
+        }
+    }
+}
+
 fn mk_extension_object(
     val: &opc_ua_types::ExtensionObject,
     ctx: &Context<'_>,
@@ -61,15 +74,7 @@ fn mk_extension_object(
     let mut cursor = Cursor::new(data.as_bytes());
     let mut stream = XmlStreamReader::new(&mut cursor as &mut dyn Read);
     // Read the entry tag, as this is how extension objects are parsed
-    loop {
-        match stream.next_event()? {
-            Event::Start(_) => break,
-            Event::End(_) | Event::Eof | Event::Empty(_) => {
-                return Ok(ExtensionObject::null());
-            }
-            _ => (),
-        }
-    }
+    enter_first_tag(&mut stream)?;
     ctx.load_from_xml(&node_id, &mut stream)
 }
 


### PR DESCRIPTION
Support for XML in JSON, and XML in binary.

This isn't strictly speaking in the spec, but I skip whitespace when parsing the base64 string. The reason for this is that it is super common in XML (at least) to assume that whitespace is ignored, even the base nodeset does this, though the XML standard _does_ include whitespace in text bodies, so it's technically wrong, but we are better off ignoring it, even at a small performance penalty.

Apart from that this also changes JSON extension objects to use `UaTypeId` and `UaBody`, as this is how it is in the spec (part 6 5.4.2.16).

I believe we are slightly too conservative in skipping errors in extension objects, which we may be supposed to do, technically. In order to do so better we should create "fallback" types that allow storing raw data in an extension object. This would also make it possible to encode extension objects as other types manually, if you want that for some reason.

I'll be honest and say I don't see a ton of use for these, but completeness is valuable when it comes to encoding/decoding.