### PR TITLE
Handle null values in XML as well

### DIFF
--- a/async-opcua-macros/src/encoding/xml.rs
+++ b/async-opcua-macros/src/encoding/xml.rs
@@ -102,12 +102,16 @@ pub fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStrea
         if field.attr.optional {
             body.extend(quote! {
                 if let Some(item) = &self.#ident {
-                    stream.encode_child(#name, item, ctx)?;
+                    if !item.is_null_xml() {
+                        stream.encode_child(#name, item, ctx)?;
+                    }
                 }
             });
         } else {
             body.extend(quote! {
-                stream.encode_child(#name, &self.#ident, ctx)?;
+                if !self.#ident.is_null_xml() {
+                    stream.encode_child(#name, &self.#ident, ctx)?;
+                }
             });
         }
     }

--- a/async-opcua-types/src/expanded_node_id.rs
+++ b/async-opcua-types/src/expanded_node_id.rs
@@ -263,6 +263,10 @@ mod xml {
             };
             node_id.encode(writer, context)
         }
+
+        fn is_null_xml(&self) -> bool {
+            self.is_null()
+        }
     }
 
     impl XmlDecodable for ExpandedNodeId {

--- a/async-opcua-types/src/node_id.rs
+++ b/async-opcua-types/src/node_id.rs
@@ -357,6 +357,10 @@ mod xml {
             let val = ctx.resolve_alias_inverse(&self_str);
             writer.encode_child("Identifier", val, ctx)
         }
+
+        fn is_null_xml(&self) -> bool {
+            self.is_null()
+        }
     }
 
     impl XmlDecodable for NodeId {

--- a/async-opcua-types/src/qualified_name.rs
+++ b/async-opcua-types/src/qualified_name.rs
@@ -67,6 +67,10 @@ mod xml {
             writer.encode_child("Name", &self.name, context)?;
             Ok(())
         }
+
+        fn is_null_xml(&self) -> bool {
+            self.is_null()
+        }
     }
 
     impl XmlDecodable for QualifiedName {

--- a/async-opcua-types/src/string.rs
+++ b/async-opcua-types/src/string.rs
@@ -159,6 +159,10 @@ mod xml {
 
             Ok(())
         }
+
+        fn is_null_xml(&self) -> bool {
+            self.is_null()
+        }
     }
 
     impl XmlDecodable for UAString {

--- a/async-opcua-types/src/tests/xml.rs
+++ b/async-opcua-types/src/tests/xml.rs
@@ -359,7 +359,7 @@ fn from_xml_variant() {
         &Variant::from(EUInformation {
             namespace_uri: "https://my.namespace.uri".into(),
             unit_id: 1,
-            display_name: LocalizedText::new("en", "MyUnit"),
+            display_name: LocalizedText::from("MyUnit"),
             description: LocalizedText::new("en", "MyDesc"),
         }),
         r#"
@@ -369,7 +369,7 @@ fn from_xml_variant() {
                 <EUInformation>
                     <NamespaceUri>https://my.namespace.uri</NamespaceUri>
                     <UnitId>1</UnitId>
-                    <DisplayName><Locale>en</Locale><Text>MyUnit</Text></DisplayName>
+                    <DisplayName><Text>MyUnit</Text></DisplayName>
                     <Description><Locale>en</Locale><Text>MyDesc</Text></Description>
                 </EUInformation>
             </Body>

--- a/async-opcua-types/src/xml/encoding.rs
+++ b/async-opcua-types/src/xml/encoding.rs
@@ -55,6 +55,12 @@ pub trait XmlEncodable: XmlType {
         writer: &mut XmlStreamWriter<&mut dyn Write>,
         context: &Context<'_>,
     ) -> EncodingResult<()>;
+
+    /// This method should return `true` if the value is default
+    /// and should not be serialized.
+    fn is_null_xml(&self) -> bool {
+        false
+    }
 }
 
 /// Extensions for XmlStreamWriter.

--- a/async-opcua-xml/src/encoding/writer.rs
+++ b/async-opcua-xml/src/encoding/writer.rs
@@ -49,6 +49,13 @@ impl<T: Write> XmlStreamWriter<T> {
         Ok(())
     }
 
+    /// Write an empty tag to the stream.
+    pub fn write_empty(&mut self, tag: &str) -> Result<(), XmlWriteError> {
+        self.writer
+            .write_event(Event::Empty(BytesStart::new(tag)))?;
+        Ok(())
+    }
+
     /// Write node contents to the stream.
     pub fn write_text(&mut self, text: &str) -> Result<(), XmlWriteError> {
         self.writer.write_event(Event::Text(BytesText::new(text)))?;


### PR DESCRIPTION
This is the same as what we do for JSON, we make it possible to leave out values that are null, which is important for certain special values like UAString, where an empty value is different from a null value.

I considered making this a separate trait, but it would be annoying to have to derive a trait that does nothing most of the time, and without specialization there's no better way. We also can't put it on BinaryEncodable since that trait isn't implemented for `Option`, and can't really be at the moment. It's now effectively duplicated between JsonEncodable and XmlEncodable, which is fine.