### PR TITLE
Create a unified macro to derive all the encodable traits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Mark generated files as generated, for github
+Cargo.lock linguist-generated=true
+async-opcua-types/src/generated/** linguist-generated=true
+async-opcua-core-namespace/src/generated/** linguist-generated=true
+async-opcua-core-namespace/src/events/generated.rs linguist-generated=true

--- a/async-opcua-codegen/src/nodeset/value.rs
+++ b/async-opcua-codegen/src/nodeset/value.rs
@@ -270,13 +270,7 @@ impl<'a> ValueBuilder<'a> {
             });
         };
 
-        let element = XmlElement::parse(data)?;
-        let Some(element) = element else {
-            return Ok(quote::quote! {
-                opcua::types::ExtensionObject::null()
-            });
-        };
-        let content = self.render_extension_object_inner(&element)?;
+        let content = self.render_extension_object_inner(data)?;
 
         Ok(quote! {
             opcua::types::ExtensionObject::from_message(#content)

--- a/async-opcua-codegen/src/types/gen.rs
+++ b/async-opcua-codegen/src/types/gen.rs
@@ -445,27 +445,16 @@ impl CodeGenerator {
         let mut attrs = Vec::new();
         let mut variants = Punctuated::new();
 
+        attrs.push(parse_quote! {
+            #[opcua::types::ua_encodable]
+        });
         if let Some(doc) = item.documentation {
             attrs.push(parse_quote! {
                 #[doc = #doc]
             });
         }
         attrs.push(parse_quote! {
-            #[derive(Debug, Copy, Clone, PartialEq, Eq,
-            opcua::types::UaEnum, opcua::types::BinaryEncodable,
-            opcua::types::BinaryDecodable)]
-        });
-        attrs.push(parse_quote! {
-            #[cfg_attr(
-                feature = "json",
-                derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-            )]
-        });
-        attrs.push(parse_quote! {
-            #[cfg_attr(
-                feature = "xml",
-                derive(opcua::types::XmlEncodable, opcua::types::XmlDecodable, opcua::types::XmlType)
-            )]
+            #[derive(Debug, Copy, Clone, PartialEq, Eq)]
         });
         let ty: Type = syn::parse_str(&item.typ.to_string())?;
         attrs.push(parse_quote! {
@@ -581,22 +570,16 @@ impl CodeGenerator {
         let mut attrs = Vec::new();
         let mut fields = Punctuated::new();
 
+        attrs.push(parse_quote! {
+            #[opcua::types::ua_encodable]
+        });
         if let Some(doc) = &item.documentation {
             attrs.push(parse_quote! {
                 #[doc = #doc]
             });
         }
         attrs.push(parse_quote! {
-            #[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-        });
-        attrs.push(parse_quote! {
-            #[cfg_attr(feature = "json", derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable))]
-        });
-        attrs.push(parse_quote! {
-            #[cfg_attr(
-                feature = "xml",
-                derive(opcua::types::XmlEncodable, opcua::types::XmlDecodable, opcua::types::XmlType)
-            )]
+            #[derive(Debug, Clone, PartialEq)]
         });
 
         if self.has_default(&item.name) && !self.default_excluded.contains(&item.name) {

--- a/async-opcua-macros/src/lib.rs
+++ b/async-opcua-macros/src/lib.rs
@@ -6,7 +6,7 @@ mod encoding;
 mod events;
 mod utils;
 
-use encoding::{generate_encoding_impl, EncodingToImpl};
+use encoding::{derive_all_inner, generate_encoding_impl, EncodingToImpl};
 use events::{derive_event_field_inner, derive_event_inner};
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
@@ -181,6 +181,20 @@ pub fn derive_xml_decodable(item: TokenStream) -> TokenStream {
 /// the type name, which can be overridden with an item-level `opcua(rename = ...)` attribute.
 pub fn derive_xml_type(item: TokenStream) -> TokenStream {
     match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::XmlType) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+/// Derive all the standard encoding traits on this struct or enum.
+/// This will derive `BinaryEncodable`, `BinaryDecodable`, `JsonEncodable`, `JsonDecodable`,
+/// `XmlEncodable`, `XmlDecodable`, `XmlType`, and `UaEnum` if the type is a simple enum.
+///
+/// Normal attributes for those still apply. Note that the XML and JSON traits will
+/// be behind `"xml"` and `"json"` feature gates respectively.
+pub fn ua_encodable(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    match derive_all_inner(parse_macro_input!(item)) {
         Ok(r) => r.into(),
         Err(e) => e.to_compile_error().into(),
     }

--- a/async-opcua-types/src/generated/types/activate_session_request.rs
+++ b/async-opcua-types/src/generated/types/activate_session_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ActivateSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub client_signature: super::signature_data::SignatureData,

--- a/async-opcua-types/src/generated/types/activate_session_response.rs
+++ b/async-opcua-types/src/generated/types/activate_session_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ActivateSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub server_nonce: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/add_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_item.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddNodesItem {
     pub parent_node_id: opcua::types::expanded_node_id::ExpandedNodeId,
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/add_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub nodes_to_add: Option<Vec<super::add_nodes_item::AddNodesItem>>,

--- a/async-opcua-types/src/generated/types/add_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::add_nodes_result::AddNodesResult>>,

--- a/async-opcua-types/src/generated/types/add_nodes_result.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddNodesResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub added_node_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/add_references_item.rs
+++ b/async-opcua-types/src/generated/types/add_references_item.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddReferencesItem {
     pub source_node_id: opcua::types::node_id::NodeId,
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/add_references_request.rs
+++ b/async-opcua-types/src/generated/types/add_references_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddReferencesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub references_to_add: Option<Vec<super::add_references_item::AddReferencesItem>>,

--- a/async-opcua-types/src/generated/types/add_references_response.rs
+++ b/async-opcua-types/src/generated/types/add_references_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AddReferencesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/additional_parameters_type.rs
+++ b/async-opcua-types/src/generated/types/additional_parameters_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AdditionalParametersType {
     pub parameters: Option<Vec<super::key_value_pair::KeyValuePair>>,
 }

--- a/async-opcua-types/src/generated/types/aggregate_configuration.rs
+++ b/async-opcua-types/src/generated/types/aggregate_configuration.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AggregateConfiguration {
     pub use_server_capabilities_defaults: bool,
     pub treat_uncertain_as_bad: bool,

--- a/async-opcua-types/src/generated/types/aggregate_filter.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AggregateFilter {
     pub start_time: opcua::types::date_time::DateTime,
     pub aggregate_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/aggregate_filter_result.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AggregateFilterResult {
     pub revised_start_time: opcua::types::date_time::DateTime,
     pub revised_processing_interval: f64,

--- a/async-opcua-types/src/generated/types/alias_name_data_type.rs
+++ b/async-opcua-types/src/generated/types/alias_name_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AliasNameDataType {
     pub alias_name: opcua::types::qualified_name::QualifiedName,
     pub referenced_nodes: Option<Vec<opcua::types::expanded_node_id::ExpandedNodeId>>,

--- a/async-opcua-types/src/generated/types/annotation.rs
+++ b/async-opcua-types/src/generated/types/annotation.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Annotation {
     pub message: opcua::types::string::UAString,
     pub user_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/annotation_data_type.rs
+++ b/async-opcua-types/src/generated/types/annotation_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AnnotationDataType {
     pub annotation: opcua::types::string::UAString,
     pub discipline: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/anonymous_identity_token.rs
+++ b/async-opcua-types/src/generated/types/anonymous_identity_token.rs
@@ -9,19 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AnonymousIdentityToken {
     pub policy_id: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/application_description.rs
+++ b/async-opcua-types/src/generated/types/application_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ApplicationDescription {
     pub application_uri: opcua::types::string::UAString,
     pub product_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/attribute_operand.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AttributeOperand {
     pub node_id: opcua::types::node_id::NodeId,
     pub alias: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/axis_information.rs
+++ b/async-opcua-types/src/generated/types/axis_information.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AxisInformation {
     pub engineering_units: super::eu_information::EUInformation,
     pub eu_range: super::range::Range,

--- a/async-opcua-types/src/generated/types/bit_field_definition.rs
+++ b/async-opcua-types/src/generated/types/bit_field_definition.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BitFieldDefinition {
     pub name: opcua::types::string::UAString,
     pub description: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrokerConnectionTransportDataType {
     pub resource_uri: opcua::types::string::UAString,
     pub authentication_profile_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrokerDataSetReaderTransportDataType {
     pub queue_name: opcua::types::string::UAString,
     pub resource_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrokerDataSetWriterTransportDataType {
     pub queue_name: opcua::types::string::UAString,
     pub resource_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrokerWriterGroupTransportDataType {
     pub queue_name: opcua::types::string::UAString,
     pub resource_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/browse_description.rs
+++ b/async-opcua-types/src/generated/types/browse_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseDescription {
     pub node_id: opcua::types::node_id::NodeId,
     pub browse_direction: super::enums::BrowseDirection,

--- a/async-opcua-types/src/generated/types/browse_next_request.rs
+++ b/async-opcua-types/src/generated/types/browse_next_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseNextRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub release_continuation_points: bool,

--- a/async-opcua-types/src/generated/types/browse_next_response.rs
+++ b/async-opcua-types/src/generated/types/browse_next_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseNextResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::browse_result::BrowseResult>>,

--- a/async-opcua-types/src/generated/types/browse_path.rs
+++ b/async-opcua-types/src/generated/types/browse_path.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowsePath {
     pub starting_node: opcua::types::node_id::NodeId,
     pub relative_path: super::relative_path::RelativePath,

--- a/async-opcua-types/src/generated/types/browse_path_result.rs
+++ b/async-opcua-types/src/generated/types/browse_path_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowsePathResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub targets: Option<Vec<super::browse_path_target::BrowsePathTarget>>,

--- a/async-opcua-types/src/generated/types/browse_path_target.rs
+++ b/async-opcua-types/src/generated/types/browse_path_target.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowsePathTarget {
     pub target_id: opcua::types::expanded_node_id::ExpandedNodeId,
     pub remaining_path_index: u32,

--- a/async-opcua-types/src/generated/types/browse_request.rs
+++ b/async-opcua-types/src/generated/types/browse_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub view: super::view_description::ViewDescription,

--- a/async-opcua-types/src/generated/types/browse_response.rs
+++ b/async-opcua-types/src/generated/types/browse_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::browse_result::BrowseResult>>,

--- a/async-opcua-types/src/generated/types/browse_result.rs
+++ b/async-opcua-types/src/generated/types/browse_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BrowseResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub continuation_point: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/build_info.rs
+++ b/async-opcua-types/src/generated/types/build_info.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BuildInfo {
     pub product_uri: opcua::types::string::UAString,
     pub manufacturer_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/call_method_request.rs
+++ b/async-opcua-types/src/generated/types/call_method_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CallMethodRequest {
     pub object_id: opcua::types::node_id::NodeId,
     pub method_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/call_method_result.rs
+++ b/async-opcua-types/src/generated/types/call_method_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CallMethodResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub input_argument_results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/call_request.rs
+++ b/async-opcua-types/src/generated/types/call_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CallRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub methods_to_call: Option<Vec<super::call_method_request::CallMethodRequest>>,

--- a/async-opcua-types/src/generated/types/call_response.rs
+++ b/async-opcua-types/src/generated/types/call_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CallResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::call_method_result::CallMethodResult>>,

--- a/async-opcua-types/src/generated/types/cancel_request.rs
+++ b/async-opcua-types/src/generated/types/cancel_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CancelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub request_handle: u32,

--- a/async-opcua-types/src/generated/types/cancel_response.rs
+++ b/async-opcua-types/src/generated/types/cancel_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CancelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub cancel_count: u32,

--- a/async-opcua-types/src/generated/types/cartesian_coordinates.rs
+++ b/async-opcua-types/src/generated/types/cartesian_coordinates.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CartesianCoordinates {}
 impl opcua::types::MessageInfo for CartesianCoordinates {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/channel_security_token.rs
+++ b/async-opcua-types/src/generated/types/channel_security_token.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ChannelSecurityToken {
     pub channel_id: u32,
     pub token_id: u32,

--- a/async-opcua-types/src/generated/types/close_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CloseSecureChannelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
 }

--- a/async-opcua-types/src/generated/types/close_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CloseSecureChannelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
 }

--- a/async-opcua-types/src/generated/types/close_session_request.rs
+++ b/async-opcua-types/src/generated/types/close_session_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CloseSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub delete_subscriptions: bool,

--- a/async-opcua-types/src/generated/types/close_session_response.rs
+++ b/async-opcua-types/src/generated/types/close_session_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CloseSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
 }

--- a/async-opcua-types/src/generated/types/complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/complex_number_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ComplexNumberType {
     pub real: f32,
     pub imaginary: f32,

--- a/async-opcua-types/src/generated/types/configuration_version_data_type.rs
+++ b/async-opcua-types/src/generated/types/configuration_version_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ConfigurationVersionDataType {
     pub major_version: u32,
     pub minor_version: u32,

--- a/async-opcua-types/src/generated/types/connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/connection_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ConnectionTransportDataType {}
 impl opcua::types::MessageInfo for ConnectionTransportDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/content_filter.rs
+++ b/async-opcua-types/src/generated/types/content_filter.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ContentFilter {
     pub elements: Option<Vec<super::content_filter_element::ContentFilterElement>>,
 }

--- a/async-opcua-types/src/generated/types/content_filter_element.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ContentFilterElement {
     pub filter_operator: super::enums::FilterOperator,
     pub filter_operands: Option<Vec<opcua::types::extension_object::ExtensionObject>>,

--- a/async-opcua-types/src/generated/types/content_filter_element_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ContentFilterElementResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub operand_status_codes: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/content_filter_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ContentFilterResult {
     pub element_results:
         Option<Vec<super::content_filter_element_result::ContentFilterElementResult>>,

--- a/async-opcua-types/src/generated/types/create_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/create_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::monitored_item_create_result::MonitoredItemCreateResult>>,

--- a/async-opcua-types/src/generated/types/create_session_request.rs
+++ b/async-opcua-types/src/generated/types/create_session_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub client_description: super::application_description::ApplicationDescription,

--- a/async-opcua-types/src/generated/types/create_session_response.rs
+++ b/async-opcua-types/src/generated/types/create_session_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateSessionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub session_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/create_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateSubscriptionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub requested_publishing_interval: f64,

--- a/async-opcua-types/src/generated/types/create_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CreateSubscriptionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/currency_unit_type.rs
+++ b/async-opcua-types/src/generated/types/currency_unit_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CurrencyUnitType {
     pub numeric_code: i16,
     pub exponent: i8,

--- a/async-opcua-types/src/generated/types/data_change_filter.rs
+++ b/async-opcua-types/src/generated/types/data_change_filter.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataChangeFilter {
     pub trigger: super::enums::DataChangeTrigger,
     pub deadband_type: u32,

--- a/async-opcua-types/src/generated/types/data_change_notification.rs
+++ b/async-opcua-types/src/generated/types/data_change_notification.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataChangeNotification {
     pub monitored_items: Option<Vec<super::monitored_item_notification::MonitoredItemNotification>>,
     pub diagnostic_infos: Option<Vec<opcua::types::diagnostic_info::DiagnosticInfo>>,

--- a/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetMetaDataType {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,
     pub structure_data_types: Option<Vec<super::structure_description::StructureDescription>>,

--- a/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetReaderDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetReaderMessageDataType {}
 impl opcua::types::MessageInfo for DataSetReaderMessageDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetReaderTransportDataType {}
 impl opcua::types::MessageInfo for DataSetReaderTransportDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetWriterDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetWriterMessageDataType {}
 impl opcua::types::MessageInfo for DataSetWriterMessageDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/data_set_writer_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataSetWriterTransportDataType {}
 impl opcua::types::MessageInfo for DataSetWriterTransportDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/data_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/data_type_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataTypeAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/data_type_description.rs
+++ b/async-opcua-types/src/generated/types/data_type_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataTypeDescription {
     pub data_type_id: opcua::types::node_id::NodeId,
     pub name: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/data_type_schema_header.rs
+++ b/async-opcua-types/src/generated/types/data_type_schema_header.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DataTypeSchemaHeader {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,
     pub structure_data_types: Option<Vec<super::structure_description::StructureDescription>>,

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DatagramConnectionTransport2DataType {
     pub discovery_address: opcua::types::extension_object::ExtensionObject,
     pub discovery_announce_rate: u32,

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DatagramConnectionTransportDataType {
     pub discovery_address: opcua::types::extension_object::ExtensionObject,
 }

--- a/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DatagramDataSetReaderTransportDataType {
     pub address: opcua::types::extension_object::ExtensionObject,
     pub qos_category: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DatagramWriterGroupTransport2DataType {
     pub message_repeat_count: u8,
     pub message_repeat_delay: f64,

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DatagramWriterGroupTransportDataType {
     pub message_repeat_count: u8,
     pub message_repeat_delay: f64,

--- a/async-opcua-types/src/generated/types/delete_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/delete_at_time_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteAtTimeDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,

--- a/async-opcua-types/src/generated/types/delete_event_details.rs
+++ b/async-opcua-types/src/generated/types/delete_event_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteEventDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub event_ids: Option<Vec<opcua::types::byte_string::ByteString>>,

--- a/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/delete_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_item.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteNodesItem {
     pub node_id: opcua::types::node_id::NodeId,
     pub delete_target_references: bool,

--- a/async-opcua-types/src/generated/types/delete_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub nodes_to_delete: Option<Vec<super::delete_nodes_item::DeleteNodesItem>>,

--- a/async-opcua-types/src/generated/types/delete_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteRawModifiedDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub is_delete_modified: bool,

--- a/async-opcua-types/src/generated/types/delete_references_item.rs
+++ b/async-opcua-types/src/generated/types/delete_references_item.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteReferencesItem {
     pub source_node_id: opcua::types::node_id::NodeId,
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/delete_references_request.rs
+++ b/async-opcua-types/src/generated/types/delete_references_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteReferencesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub references_to_delete: Option<Vec<super::delete_references_item::DeleteReferencesItem>>,

--- a/async-opcua-types/src/generated/types/delete_references_response.rs
+++ b/async-opcua-types/src/generated/types/delete_references_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteReferencesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteSubscriptionsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_ids: Option<Vec<u32>>,

--- a/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DeleteSubscriptionsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/discovery_configuration.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DiscoveryConfiguration {}
 impl opcua::types::MessageInfo for DiscoveryConfiguration {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/double_complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/double_complex_number_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct DoubleComplexNumberType {
     pub real: f64,
     pub imaginary: f64,

--- a/async-opcua-types/src/generated/types/element_operand.rs
+++ b/async-opcua-types/src/generated/types/element_operand.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ElementOperand {
     pub index: u32,
 }

--- a/async-opcua-types/src/generated/types/endpoint_configuration.rs
+++ b/async-opcua-types/src/generated/types/endpoint_configuration.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EndpointConfiguration {
     pub operation_timeout: i32,
     pub use_binary_encoding: bool,

--- a/async-opcua-types/src/generated/types/endpoint_description.rs
+++ b/async-opcua-types/src/generated/types/endpoint_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EndpointDescription {
     pub endpoint_url: opcua::types::string::UAString,
     pub server: super::application_description::ApplicationDescription,

--- a/async-opcua-types/src/generated/types/endpoint_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EndpointType {
     pub endpoint_url: opcua::types::string::UAString,
     pub security_mode: super::enums::MessageSecurityMode,

--- a/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EndpointUrlListDataType {
     pub endpoint_url_list: Option<Vec<opcua::types::string::UAString>>,
 }

--- a/async-opcua-types/src/generated/types/enum_definition.rs
+++ b/async-opcua-types/src/generated/types/enum_definition.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EnumDefinition {
     pub fields: Option<Vec<super::enum_field::EnumField>>,
 }

--- a/async-opcua-types/src/generated/types/enum_description.rs
+++ b/async-opcua-types/src/generated/types/enum_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EnumDescription {
     pub data_type_id: opcua::types::node_id::NodeId,
     pub name: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/enum_field.rs
+++ b/async-opcua-types/src/generated/types/enum_field.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EnumField {
     pub value: i64,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/enum_value_type.rs
+++ b/async-opcua-types/src/generated/types/enum_value_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EnumValueType {
     pub value: i64,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/enums.rs
+++ b/async-opcua-types/src/generated/types/enums.rs
@@ -332,28 +332,8 @@ impl opcua::types::json::JsonEncodable for AlarmMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ApplicationType {
     #[opcua(default)]
@@ -450,28 +430,8 @@ impl opcua::types::json::JsonEncodable for AttributeWriteMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum AxisScaleEnumeration {
     #[opcua(default)]
@@ -479,28 +439,8 @@ pub enum AxisScaleEnumeration {
     Log = 1i32,
     Ln = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum BrokerTransportQualityOfService {
     #[opcua(default)]
@@ -510,28 +450,8 @@ pub enum BrokerTransportQualityOfService {
     AtMostOnce = 3i32,
     ExactlyOnce = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum BrowseDirection {
     #[opcua(default)]
@@ -540,28 +460,8 @@ pub enum BrowseDirection {
     Both = 2i32,
     Invalid = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum BrowseResultMask {
     #[opcua(default)]
@@ -576,28 +476,8 @@ pub enum BrowseResultMask {
     ReferenceTypeInfo = 3i32,
     TargetInfo = 60i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ConversionLimitEnum {
     #[opcua(default)]
@@ -605,28 +485,8 @@ pub enum ConversionLimitEnum {
     Limited = 1i32,
     Unlimited = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DataChangeTrigger {
     #[opcua(default)]
@@ -794,28 +654,8 @@ impl opcua::types::json::JsonEncodable for DataSetFieldFlags {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DataSetOrderingType {
     #[opcua(default)]
@@ -823,28 +663,8 @@ pub enum DataSetOrderingType {
     AscendingWriterId = 1i32,
     AscendingWriterIdSingle = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DeadbandType {
     #[opcua(default)]
@@ -852,28 +672,8 @@ pub enum DeadbandType {
     Absolute = 1i32,
     Percent = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DiagnosticsLevel {
     #[opcua(default)]
@@ -883,28 +683,8 @@ pub enum DiagnosticsLevel {
     Log = 3i32,
     Debug = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum Duplex {
     #[opcua(default)]
@@ -992,28 +772,8 @@ impl opcua::types::json::JsonEncodable for EventNotifierType {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ExceptionDeviationFormat {
     #[opcua(default)]
@@ -1023,28 +783,8 @@ pub enum ExceptionDeviationFormat {
     PercentOfEURange = 3i32,
     Unknown = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum FilterOperator {
     #[opcua(default)]
@@ -1067,28 +807,8 @@ pub enum FilterOperator {
     BitwiseAnd = 16i32,
     BitwiseOr = 17i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum HistoryUpdateType {
     Insert = 1i32,
@@ -1096,28 +816,8 @@ pub enum HistoryUpdateType {
     Update = 3i32,
     Delete = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum IdentityCriteriaType {
     UserName = 1i32,
@@ -1129,28 +829,8 @@ pub enum IdentityCriteriaType {
     Application = 7i32,
     X509Subject = 8i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum IdType {
     #[opcua(default)]
@@ -1159,28 +839,8 @@ pub enum IdType {
     Guid = 2i32,
     Opaque = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum InterfaceAdminStatus {
     #[opcua(default)]
@@ -1188,28 +848,8 @@ pub enum InterfaceAdminStatus {
     Down = 1i32,
     Testing = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum InterfaceOperStatus {
     #[opcua(default)]
@@ -1386,28 +1026,8 @@ impl opcua::types::json::JsonEncodable for JsonNetworkMessageContentMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum MessageSecurityMode {
     #[opcua(default)]
@@ -1416,28 +1036,8 @@ pub enum MessageSecurityMode {
     Sign = 2i32,
     SignAndEncrypt = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ModelChangeStructureVerbMask {
     NodeAdded = 1i32,
@@ -1446,28 +1046,8 @@ pub enum ModelChangeStructureVerbMask {
     ReferenceDeleted = 8i32,
     DataTypeChanged = 16i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum MonitoringMode {
     #[opcua(default)]
@@ -1475,56 +1055,16 @@ pub enum MonitoringMode {
     Sampling = 1i32,
     Reporting = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum NamingRuleType {
     Mandatory = 1i32,
     Optional = 2i32,
     Constraint = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum NegotiationStatus {
     #[opcua(default)]
@@ -1534,28 +1074,8 @@ pub enum NegotiationStatus {
     Unknown = 3i32,
     NoNegotiation = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum NodeAttributesMask {
     #[opcua(default)]
@@ -1595,28 +1115,8 @@ pub enum NodeAttributesMask {
     ReferenceType = 26537060i32,
     View = 26501356i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum NodeClass {
     #[opcua(default)]
@@ -1630,29 +1130,9 @@ pub enum NodeClass {
     DataType = 64i32,
     View = 128i32,
 }
+#[opcua::types::ua_encodable]
 ///The possible encodings for a NodeId value.
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum NodeIdType {
     #[opcua(default)]
@@ -1663,28 +1143,8 @@ pub enum NodeIdType {
     Guid = 4u8,
     ByteString = 5u8,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum OpenFileMode {
     Read = 1i32,
@@ -1692,28 +1152,8 @@ pub enum OpenFileMode {
     EraseExisting = 4i32,
     Append = 8i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum OverrideValueHandling {
     #[opcua(default)]
@@ -1804,28 +1244,8 @@ impl opcua::types::json::JsonEncodable for PasswordOptionsMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PerformUpdateType {
     Insert = 1i32,
@@ -2001,56 +1421,16 @@ impl opcua::types::json::JsonEncodable for PubSubConfigurationRefMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PubSubDiagnosticsCounterClassification {
     #[opcua(default)]
     Information = 0i32,
     Error = 1i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PubSubState {
     #[opcua(default)]
@@ -2060,28 +1440,8 @@ pub enum PubSubState {
     Error = 3i32,
     PreOperational = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum RedundancySupport {
     #[opcua(default)]
@@ -2092,28 +1452,8 @@ pub enum RedundancySupport {
     Transparent = 4i32,
     HotAndMirrored = 5i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum RedundantServerMode {
     #[opcua(default)]
@@ -2122,56 +1462,16 @@ pub enum RedundantServerMode {
     BackupReady = 2i32,
     BackupNotReady = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum SecurityTokenRequestType {
     #[opcua(default)]
     Issue = 0i32,
     Renew = 1i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ServerState {
     #[opcua(default)]
@@ -2184,28 +1484,8 @@ pub enum ServerState {
     CommunicationFault = 6i32,
     Unknown = 7i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum StructureType {
     #[opcua(default)]
@@ -2215,28 +1495,8 @@ pub enum StructureType {
     StructureWithSubtypedValues = 3i32,
     UnionWithSubtypedValues = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TimestampsToReturn {
     #[opcua(default)]
@@ -2246,28 +1506,8 @@ pub enum TimestampsToReturn {
     Neither = 3i32,
     Invalid = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TrustListMasks {
     #[opcua(default)]
@@ -2361,28 +1601,8 @@ impl opcua::types::json::JsonEncodable for TrustListValidationOptions {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TsnFailureCode {
     #[opcua(default)]
@@ -2413,28 +1633,8 @@ pub enum TsnFailureCode {
     StreamIdTypeNotSupported = 24i32,
     FeatureNotSupported = 25i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TsnListenerStatus {
     #[opcua(default)]
@@ -2443,28 +1643,8 @@ pub enum TsnListenerStatus {
     PartialFailed = 2i32,
     Failed = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TsnStreamState {
     #[opcua(default)]
@@ -2474,28 +1654,8 @@ pub enum TsnStreamState {
     Operational = 3i32,
     Error = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TsnTalkerStatus {
     #[opcua(default)]
@@ -2747,28 +1907,8 @@ impl opcua::types::json::JsonEncodable for UserConfigurationMask {
         Ok(())
     }
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum UserTokenType {
     #[opcua(default)]

--- a/async-opcua-types/src/generated/types/ephemeral_key_type.rs
+++ b/async-opcua-types/src/generated/types/ephemeral_key_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EphemeralKeyType {
     pub public_key: opcua::types::byte_string::ByteString,
     pub signature: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/eu_information.rs
+++ b/async-opcua-types/src/generated/types/eu_information.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EUInformation {
     pub namespace_uri: opcua::types::string::UAString,
     pub unit_id: i32,

--- a/async-opcua-types/src/generated/types/event_field_list.rs
+++ b/async-opcua-types/src/generated/types/event_field_list.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EventFieldList {
     pub client_handle: u32,
     pub event_fields: Option<Vec<opcua::types::variant::Variant>>,

--- a/async-opcua-types/src/generated/types/event_filter.rs
+++ b/async-opcua-types/src/generated/types/event_filter.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EventFilter {
     pub select_clauses: Option<Vec<super::simple_attribute_operand::SimpleAttributeOperand>>,
     pub where_clause: super::content_filter::ContentFilter,

--- a/async-opcua-types/src/generated/types/event_filter_result.rs
+++ b/async-opcua-types/src/generated/types/event_filter_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EventFilterResult {
     pub select_clause_results: Option<Vec<opcua::types::status_code::StatusCode>>,
     pub select_clause_diagnostic_infos: Option<Vec<opcua::types::diagnostic_info::DiagnosticInfo>>,

--- a/async-opcua-types/src/generated/types/event_notification_list.rs
+++ b/async-opcua-types/src/generated/types/event_notification_list.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EventNotificationList {
     pub events: Option<Vec<super::event_field_list::EventFieldList>>,
 }

--- a/async-opcua-types/src/generated/types/field_meta_data.rs
+++ b/async-opcua-types/src/generated/types/field_meta_data.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FieldMetaData {
     pub name: opcua::types::string::UAString,
     pub description: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/field_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/field_target_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FieldTargetDataType {
     pub data_set_field_id: opcua::types::guid::Guid,
     pub receiver_index_range: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/filter_operand.rs
+++ b/async-opcua-types/src/generated/types/filter_operand.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FilterOperand {}
 impl opcua::types::MessageInfo for FilterOperand {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FindServersOnNetworkRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub starting_record_id: u32,

--- a/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FindServersOnNetworkResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub last_counter_reset_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/find_servers_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FindServersRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub endpoint_url: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/find_servers_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct FindServersResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub servers: Option<Vec<super::application_description::ApplicationDescription>>,

--- a/async-opcua-types/src/generated/types/frame.rs
+++ b/async-opcua-types/src/generated/types/frame.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Frame {}
 impl opcua::types::MessageInfo for Frame {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/generic_attribute_value.rs
+++ b/async-opcua-types/src/generated/types/generic_attribute_value.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct GenericAttributeValue {
     pub attribute_id: u32,
     pub value: opcua::types::variant::Variant,

--- a/async-opcua-types/src/generated/types/generic_attributes.rs
+++ b/async-opcua-types/src/generated/types/generic_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct GenericAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/get_endpoints_request.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct GetEndpointsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub endpoint_url: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/get_endpoints_response.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct GetEndpointsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub endpoints: Option<Vec<super::endpoint_description::EndpointDescription>>,

--- a/async-opcua-types/src/generated/types/history_data.rs
+++ b/async-opcua-types/src/generated/types/history_data.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryData {
     pub data_values: Option<Vec<opcua::types::data_value::DataValue>>,
 }

--- a/async-opcua-types/src/generated/types/history_event.rs
+++ b/async-opcua-types/src/generated/types/history_event.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryEvent {
     pub events: Option<Vec<super::history_event_field_list::HistoryEventFieldList>>,
 }

--- a/async-opcua-types/src/generated/types/history_event_field_list.rs
+++ b/async-opcua-types/src/generated/types/history_event_field_list.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryEventFieldList {
     pub event_fields: Option<Vec<opcua::types::variant::Variant>>,
 }

--- a/async-opcua-types/src/generated/types/history_modified_data.rs
+++ b/async-opcua-types/src/generated/types/history_modified_data.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryModifiedData {
     pub data_values: Option<Vec<opcua::types::data_value::DataValue>>,
     pub modification_infos: Option<Vec<super::modification_info::ModificationInfo>>,

--- a/async-opcua-types/src/generated/types/history_modified_event.rs
+++ b/async-opcua-types/src/generated/types/history_modified_event.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryModifiedEvent {
     pub events: Option<Vec<super::history_event_field_list::HistoryEventFieldList>>,
     pub modification_infos: Option<Vec<super::modification_info::ModificationInfo>>,

--- a/async-opcua-types/src/generated/types/history_read_details.rs
+++ b/async-opcua-types/src/generated/types/history_read_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryReadDetails {}
 impl opcua::types::MessageInfo for HistoryReadDetails {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/history_read_request.rs
+++ b/async-opcua-types/src/generated/types/history_read_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryReadRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub history_read_details: opcua::types::extension_object::ExtensionObject,

--- a/async-opcua-types/src/generated/types/history_read_response.rs
+++ b/async-opcua-types/src/generated/types/history_read_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryReadResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::history_read_result::HistoryReadResult>>,

--- a/async-opcua-types/src/generated/types/history_read_result.rs
+++ b/async-opcua-types/src/generated/types/history_read_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryReadResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub continuation_point: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/history_read_value_id.rs
+++ b/async-opcua-types/src/generated/types/history_read_value_id.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryReadValueId {
     pub node_id: opcua::types::node_id::NodeId,
     pub index_range: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/history_update_details.rs
+++ b/async-opcua-types/src/generated/types/history_update_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryUpdateDetails {}
 impl opcua::types::MessageInfo for HistoryUpdateDetails {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/history_update_request.rs
+++ b/async-opcua-types/src/generated/types/history_update_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryUpdateRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub history_update_details: Option<Vec<opcua::types::extension_object::ExtensionObject>>,

--- a/async-opcua-types/src/generated/types/history_update_response.rs
+++ b/async-opcua-types/src/generated/types/history_update_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryUpdateResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::history_update_result::HistoryUpdateResult>>,

--- a/async-opcua-types/src/generated/types/history_update_result.rs
+++ b/async-opcua-types/src/generated/types/history_update_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct HistoryUpdateResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub operation_results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
+++ b/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
@@ -9,19 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IdentityMappingRuleType {
     pub criteria_type: super::enums::IdentityCriteriaType,
     pub criteria: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/issued_identity_token.rs
+++ b/async-opcua-types/src/generated/types/issued_identity_token.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct IssuedIdentityToken {
     pub policy_id: opcua::types::string::UAString,
     pub token_data: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct JsonDataSetReaderMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,
     pub data_set_message_content_mask: super::enums::JsonDataSetMessageContentMask,

--- a/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct JsonDataSetWriterMessageDataType {
     pub data_set_message_content_mask: super::enums::JsonDataSetMessageContentMask,
 }

--- a/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct JsonWriterGroupMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,
 }

--- a/async-opcua-types/src/generated/types/key_value_pair.rs
+++ b/async-opcua-types/src/generated/types/key_value_pair.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct KeyValuePair {
     pub key: opcua::types::qualified_name::QualifiedName,
     pub value: opcua::types::variant::Variant,

--- a/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
+++ b/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct LinearConversionDataType {
     pub initial_addend: f32,
     pub multiplicand: f32,

--- a/async-opcua-types/src/generated/types/literal_operand.rs
+++ b/async-opcua-types/src/generated/types/literal_operand.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct LiteralOperand {
     pub value: opcua::types::variant::Variant,
 }

--- a/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MdnsDiscoveryConfiguration {
     pub mdns_server_name: opcua::types::string::UAString,
     pub server_capabilities: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/method_attributes.rs
+++ b/async-opcua-types/src/generated/types/method_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MethodAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModelChangeStructureDataType {
     pub affected: opcua::types::node_id::NodeId,
     pub affected_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/modification_info.rs
+++ b/async-opcua-types/src/generated/types/modification_info.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModificationInfo {
     pub modification_time: opcua::types::date_time::DateTime,
     pub update_type: super::enums::HistoryUpdateType,

--- a/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModifyMonitoredItemsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModifyMonitoredItemsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::monitored_item_modify_result::MonitoredItemModifyResult>>,

--- a/async-opcua-types/src/generated/types/modify_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModifySubscriptionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/modify_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModifySubscriptionResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub revised_publishing_interval: f64,

--- a/async-opcua-types/src/generated/types/monitored_item_create_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoredItemCreateRequest {
     pub item_to_monitor: super::read_value_id::ReadValueId,
     pub monitoring_mode: super::enums::MonitoringMode,

--- a/async-opcua-types/src/generated/types/monitored_item_create_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoredItemCreateResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub monitored_item_id: u32,

--- a/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoredItemModifyRequest {
     pub monitored_item_id: u32,
     pub requested_parameters: super::monitoring_parameters::MonitoringParameters,

--- a/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoredItemModifyResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub revised_sampling_interval: f64,

--- a/async-opcua-types/src/generated/types/monitored_item_notification.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_notification.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoredItemNotification {
     pub client_handle: u32,
     pub value: opcua::types::data_value::DataValue,

--- a/async-opcua-types/src/generated/types/monitoring_filter.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoringFilter {}
 impl opcua::types::MessageInfo for MonitoringFilter {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/monitoring_filter_result.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoringFilterResult {}
 impl opcua::types::MessageInfo for MonitoringFilterResult {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/monitoring_parameters.rs
+++ b/async-opcua-types/src/generated/types/monitoring_parameters.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct MonitoringParameters {
     pub client_handle: u32,
     pub sampling_interval: f64,

--- a/async-opcua-types/src/generated/types/network_address_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_address_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NetworkAddressDataType {
     pub network_interface: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/network_address_url_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_address_url_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NetworkAddressUrlDataType {
     pub network_interface: opcua::types::string::UAString,
     pub url: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/network_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_group_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NetworkGroupDataType {
     pub server_uri: opcua::types::string::UAString,
     pub network_paths: Option<Vec<super::endpoint_url_list_data_type::EndpointUrlListDataType>>,

--- a/async-opcua-types/src/generated/types/node_attributes.rs
+++ b/async-opcua-types/src/generated/types/node_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NodeAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/node_reference.rs
+++ b/async-opcua-types/src/generated/types/node_reference.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NodeReference {
     pub node_id: opcua::types::node_id::NodeId,
     pub reference_type_id: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/node_type_description.rs
+++ b/async-opcua-types/src/generated/types/node_type_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NodeTypeDescription {
     pub type_definition_node: opcua::types::expanded_node_id::ExpandedNodeId,
     pub include_sub_types: bool,

--- a/async-opcua-types/src/generated/types/notification_data.rs
+++ b/async-opcua-types/src/generated/types/notification_data.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NotificationData {}
 impl opcua::types::MessageInfo for NotificationData {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/notification_message.rs
+++ b/async-opcua-types/src/generated/types/notification_message.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NotificationMessage {
     pub sequence_number: u32,
     pub publish_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/object_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ObjectAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/object_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_type_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ObjectTypeAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/open_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct OpenSecureChannelRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub client_protocol_version: u32,

--- a/async-opcua-types/src/generated/types/open_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct OpenSecureChannelResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub server_protocol_version: u32,

--- a/async-opcua-types/src/generated/types/option_set.rs
+++ b/async-opcua-types/src/generated/types/option_set.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct OptionSet {
     pub value: opcua::types::byte_string::ByteString,
     pub valid_bits: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/orientation.rs
+++ b/async-opcua-types/src/generated/types/orientation.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Orientation {}
 impl opcua::types::MessageInfo for Orientation {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/parsing_result.rs
+++ b/async-opcua-types/src/generated/types/parsing_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ParsingResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub data_status_codes: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/portable_node_id.rs
+++ b/async-opcua-types/src/generated/types/portable_node_id.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PortableNodeId {
     pub namespace_uri: opcua::types::string::UAString,
     pub identifier: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/portable_qualified_name.rs
+++ b/async-opcua-types/src/generated/types/portable_qualified_name.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PortableQualifiedName {
     pub namespace_uri: opcua::types::string::UAString,
     pub name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
+++ b/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PriorityMappingEntryType {
     pub mapping_uri: opcua::types::string::UAString,
     pub priority_label: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ProgramDiagnostic2DataType {
     pub create_session_id: opcua::types::node_id::NodeId,
     pub create_client_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ProgramDiagnosticDataType {
     pub create_session_id: opcua::types::node_id::NodeId,
     pub create_client_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubConfiguration2DataType {
     pub published_data_sets:
         Option<Vec<super::published_data_set_data_type::PublishedDataSetDataType>>,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubConfigurationDataType {
     pub published_data_sets:
         Option<Vec<super::published_data_set_data_type::PublishedDataSetDataType>>,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubConfigurationRefDataType {
     pub configuration_mask: super::enums::PubSubConfigurationRefMask,
     pub element_index: u16,

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubConfigurationValueDataType {
     pub configuration_element:
         super::pub_sub_configuration_ref_data_type::PubSubConfigurationRefDataType,

--- a/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubConnectionDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/pub_sub_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_group_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubGroupDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PubSubKeyPushTargetDataType {
     pub application_uri: opcua::types::string::UAString,
     pub push_target_folder: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/publish_request.rs
+++ b/async-opcua-types/src/generated/types/publish_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_acknowledgements:

--- a/async-opcua-types/src/generated/types/publish_response.rs
+++ b/async-opcua-types/src/generated/types/publish_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/published_data_items_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_items_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedDataItemsDataType {
     pub published_data: Option<Vec<super::published_variable_data_type::PublishedVariableDataType>>,
 }

--- a/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedDataSetCustomSourceDataType {
     pub cyclic_data_set: bool,
 }

--- a/async-opcua-types/src/generated/types/published_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedDataSetDataType {
     pub name: opcua::types::string::UAString,
     pub data_set_folder: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/published_data_set_source_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_source_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedDataSetSourceDataType {}
 impl opcua::types::MessageInfo for PublishedDataSetSourceDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/published_events_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_events_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedEventsDataType {
     pub event_notifier: opcua::types::node_id::NodeId,
     pub selected_fields: Option<Vec<super::simple_attribute_operand::SimpleAttributeOperand>>,

--- a/async-opcua-types/src/generated/types/published_variable_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_variable_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PublishedVariableDataType {
     pub published_variable: opcua::types::node_id::NodeId,
     pub attribute_id: u32,

--- a/async-opcua-types/src/generated/types/qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/qos_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QosDataType {}
 impl opcua::types::MessageInfo for QosDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/quantity_dimension.rs
+++ b/async-opcua-types/src/generated/types/quantity_dimension.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QuantityDimension {
     pub mass_exponent: i8,
     pub length_exponent: i8,

--- a/async-opcua-types/src/generated/types/query_data_description.rs
+++ b/async-opcua-types/src/generated/types/query_data_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryDataDescription {
     pub relative_path: super::relative_path::RelativePath,
     pub attribute_id: u32,

--- a/async-opcua-types/src/generated/types/query_data_set.rs
+++ b/async-opcua-types/src/generated/types/query_data_set.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryDataSet {
     pub node_id: opcua::types::expanded_node_id::ExpandedNodeId,
     pub type_definition_node: opcua::types::expanded_node_id::ExpandedNodeId,

--- a/async-opcua-types/src/generated/types/query_first_request.rs
+++ b/async-opcua-types/src/generated/types/query_first_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryFirstRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub view: super::view_description::ViewDescription,

--- a/async-opcua-types/src/generated/types/query_first_response.rs
+++ b/async-opcua-types/src/generated/types/query_first_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryFirstResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub query_data_sets: Option<Vec<super::query_data_set::QueryDataSet>>,

--- a/async-opcua-types/src/generated/types/query_next_request.rs
+++ b/async-opcua-types/src/generated/types/query_next_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryNextRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub release_continuation_point: bool,

--- a/async-opcua-types/src/generated/types/query_next_response.rs
+++ b/async-opcua-types/src/generated/types/query_next_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct QueryNextResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub query_data_sets: Option<Vec<super::query_data_set::QueryDataSet>>,

--- a/async-opcua-types/src/generated/types/range.rs
+++ b/async-opcua-types/src/generated/types/range.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Range {
     pub low: f64,
     pub high: f64,

--- a/async-opcua-types/src/generated/types/rational_number.rs
+++ b/async-opcua-types/src/generated/types/rational_number.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RationalNumber {
     pub numerator: i32,
     pub denominator: u32,

--- a/async-opcua-types/src/generated/types/read_annotation_data_details.rs
+++ b/async-opcua-types/src/generated/types/read_annotation_data_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadAnnotationDataDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,
 }

--- a/async-opcua-types/src/generated/types/read_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/read_at_time_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadAtTimeDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,
     pub use_simple_bounds: bool,

--- a/async-opcua-types/src/generated/types/read_event_details.rs
+++ b/async-opcua-types/src/generated/types/read_event_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadEventDetails {
     pub num_values_per_node: u32,
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/read_event_details_2.rs
+++ b/async-opcua-types/src/generated/types/read_event_details_2.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadEventDetails2 {
     pub num_values_per_node: u32,
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/read_processed_details.rs
+++ b/async-opcua-types/src/generated/types/read_processed_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadProcessedDetails {
     pub start_time: opcua::types::date_time::DateTime,
     pub end_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/read_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/read_raw_modified_details.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadRawModifiedDetails {
     pub is_read_modified: bool,
     pub start_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/read_request.rs
+++ b/async-opcua-types/src/generated/types/read_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub max_age: f64,

--- a/async-opcua-types/src/generated/types/read_response.rs
+++ b/async-opcua-types/src/generated/types/read_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::data_value::DataValue>>,

--- a/async-opcua-types/src/generated/types/read_value_id.rs
+++ b/async-opcua-types/src/generated/types/read_value_id.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReadValueId {
     pub node_id: opcua::types::node_id::NodeId,
     pub attribute_id: u32,

--- a/async-opcua-types/src/generated/types/reader_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReaderGroupDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/reader_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReaderGroupMessageDataType {}
 impl opcua::types::MessageInfo for ReaderGroupMessageDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/reader_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReaderGroupTransportDataType {}
 impl opcua::types::MessageInfo for ReaderGroupTransportDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/receive_qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/receive_qos_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReceiveQosDataType {}
 impl opcua::types::MessageInfo for ReceiveQosDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReceiveQosPriorityDataType {
     pub priority_label: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/redundant_server_data_type.rs
+++ b/async-opcua-types/src/generated/types/redundant_server_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RedundantServerDataType {
     pub server_id: opcua::types::string::UAString,
     pub service_level: u8,

--- a/async-opcua-types/src/generated/types/reference_description.rs
+++ b/async-opcua-types/src/generated/types/reference_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReferenceDescription {
     pub reference_type_id: opcua::types::node_id::NodeId,
     pub is_forward: bool,

--- a/async-opcua-types/src/generated/types/reference_description_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_description_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReferenceDescriptionDataType {
     pub source_node: opcua::types::node_id::NodeId,
     pub reference_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReferenceListEntryDataType {
     pub reference_type: opcua::types::node_id::NodeId,
     pub is_forward: bool,

--- a/async-opcua-types/src/generated/types/reference_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/reference_type_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReferenceTypeAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/register_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub nodes_to_register: Option<Vec<opcua::types::node_id::NodeId>>,

--- a/async-opcua-types/src/generated/types/register_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub registered_node_ids: Option<Vec<opcua::types::node_id::NodeId>>,

--- a/async-opcua-types/src/generated/types/register_server_2_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterServer2Request {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub server: super::registered_server::RegisteredServer,

--- a/async-opcua-types/src/generated/types/register_server_2_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterServer2Response {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub configuration_results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/register_server_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterServerRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub server: super::registered_server::RegisteredServer,

--- a/async-opcua-types/src/generated/types/register_server_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisterServerResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
 }

--- a/async-opcua-types/src/generated/types/registered_server.rs
+++ b/async-opcua-types/src/generated/types/registered_server.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RegisteredServer {
     pub server_uri: opcua::types::string::UAString,
     pub product_uri: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/relative_path.rs
+++ b/async-opcua-types/src/generated/types/relative_path.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RelativePath {
     pub elements: Option<Vec<super::relative_path_element::RelativePathElement>>,
 }

--- a/async-opcua-types/src/generated/types/relative_path_element.rs
+++ b/async-opcua-types/src/generated/types/relative_path_element.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RelativePathElement {
     pub reference_type_id: opcua::types::node_id::NodeId,
     pub is_inverse: bool,

--- a/async-opcua-types/src/generated/types/republish_request.rs
+++ b/async-opcua-types/src/generated/types/republish_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RepublishRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/republish_response.rs
+++ b/async-opcua-types/src/generated/types/republish_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RepublishResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub notification_message: super::notification_message::NotificationMessage,

--- a/async-opcua-types/src/generated/types/role_permission_type.rs
+++ b/async-opcua-types/src/generated/types/role_permission_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RolePermissionType {
     pub role_id: opcua::types::node_id::NodeId,
     pub permissions: super::enums::PermissionType,

--- a/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SamplingIntervalDiagnosticsDataType {
     pub sampling_interval: f64,
     pub monitored_item_count: u32,

--- a/async-opcua-types/src/generated/types/security_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/security_group_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SecurityGroupDataType {
     pub name: opcua::types::string::UAString,
     pub security_group_folder: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SemanticChangeStructureDataType {
     pub affected: opcua::types::node_id::NodeId,
     pub affected_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ServerDiagnosticsSummaryDataType {
     pub server_view_count: u32,
     pub current_session_count: u32,

--- a/async-opcua-types/src/generated/types/server_on_network.rs
+++ b/async-opcua-types/src/generated/types/server_on_network.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ServerOnNetwork {
     pub record_id: u32,
     pub server_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/server_status_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_status_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ServerStatusDataType {
     pub start_time: opcua::types::date_time::DateTime,
     pub current_time: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/service_counter_data_type.rs
+++ b/async-opcua-types/src/generated/types/service_counter_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ServiceCounterDataType {
     pub total_count: u32,
     pub error_count: u32,

--- a/async-opcua-types/src/generated/types/service_fault.rs
+++ b/async-opcua-types/src/generated/types/service_fault.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ServiceFault {
     pub response_header: opcua::types::response_header::ResponseHeader,
 }

--- a/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SessionDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,
     pub session_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SessionSecurityDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,
     pub client_user_id_of_session: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SessionlessInvokeRequestType {
     pub uris_version: u32,
     pub namespace_uris: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SessionlessInvokeResponseType {
     pub namespace_uris: Option<Vec<opcua::types::string::UAString>>,
     pub server_uris: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetMonitoringModeRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetMonitoringModeResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetPublishingModeRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub publishing_enabled: bool,

--- a/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetPublishingModeResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/set_triggering_request.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetTriggeringRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/set_triggering_response.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SetTriggeringResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub add_results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/signature_data.rs
+++ b/async-opcua-types/src/generated/types/signature_data.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SignatureData {
     pub algorithm: opcua::types::string::UAString,
     pub signature: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/signed_software_certificate.rs
+++ b/async-opcua-types/src/generated/types/signed_software_certificate.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SignedSoftwareCertificate {
     pub certificate_data: opcua::types::byte_string::ByteString,
     pub signature: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/simple_attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/simple_attribute_operand.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SimpleAttributeOperand {
     pub type_definition_id: opcua::types::node_id::NodeId,
     pub browse_path: Option<Vec<opcua::types::qualified_name::QualifiedName>>,

--- a/async-opcua-types/src/generated/types/simple_type_description.rs
+++ b/async-opcua-types/src/generated/types/simple_type_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SimpleTypeDescription {
     pub data_type_id: opcua::types::node_id::NodeId,
     pub name: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StandaloneSubscribedDataSetDataType {
     pub name: opcua::types::string::UAString,
     pub data_set_folder: Option<Vec<opcua::types::string::UAString>>,

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StandaloneSubscribedDataSetRefDataType {
     pub data_set_name: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/status_change_notification.rs
+++ b/async-opcua-types/src/generated/types/status_change_notification.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StatusChangeNotification {
     pub status: opcua::types::status_code::StatusCode,
     pub diagnostic_info: opcua::types::diagnostic_info::DiagnosticInfo,

--- a/async-opcua-types/src/generated/types/status_result.rs
+++ b/async-opcua-types/src/generated/types/status_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StatusResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub diagnostic_info: opcua::types::diagnostic_info::DiagnosticInfo,

--- a/async-opcua-types/src/generated/types/structure_definition.rs
+++ b/async-opcua-types/src/generated/types/structure_definition.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructureDefinition {
     pub default_encoding_id: opcua::types::node_id::NodeId,
     pub base_data_type: opcua::types::node_id::NodeId,

--- a/async-opcua-types/src/generated/types/structure_description.rs
+++ b/async-opcua-types/src/generated/types/structure_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructureDescription {
     pub data_type_id: opcua::types::node_id::NodeId,
     pub name: opcua::types::qualified_name::QualifiedName,

--- a/async-opcua-types/src/generated/types/structure_field.rs
+++ b/async-opcua-types/src/generated/types/structure_field.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructureField {
     pub name: opcua::types::string::UAString,
     pub description: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/subscribed_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscribed_data_set_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SubscribedDataSetDataType {}
 impl opcua::types::MessageInfo for SubscribedDataSetDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SubscribedDataSetMirrorDataType {
     pub parent_node_name: opcua::types::string::UAString,
     pub role_permissions: Option<Vec<super::role_permission_type::RolePermissionType>>,

--- a/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
+++ b/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SubscriptionAcknowledgement {
     pub subscription_id: u32,
     pub sequence_number: u32,

--- a/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SubscriptionDiagnosticsDataType {
     pub session_id: opcua::types::node_id::NodeId,
     pub subscription_id: u32,

--- a/async-opcua-types/src/generated/types/target_variables_data_type.rs
+++ b/async-opcua-types/src/generated/types/target_variables_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TargetVariablesDataType {
     pub target_variables: Option<Vec<super::field_target_data_type::FieldTargetDataType>>,
 }

--- a/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
+++ b/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ThreeDCartesianCoordinates {
     pub x: f64,
     pub y: f64,

--- a/async-opcua-types/src/generated/types/three_d_frame.rs
+++ b/async-opcua-types/src/generated/types/three_d_frame.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ThreeDFrame {
     pub cartesian_coordinates: super::three_d_cartesian_coordinates::ThreeDCartesianCoordinates,
     pub orientation: super::three_d_orientation::ThreeDOrientation,

--- a/async-opcua-types/src/generated/types/three_d_orientation.rs
+++ b/async-opcua-types/src/generated/types/three_d_orientation.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ThreeDOrientation {
     pub a: f64,
     pub b: f64,

--- a/async-opcua-types/src/generated/types/three_d_vector.rs
+++ b/async-opcua-types/src/generated/types/three_d_vector.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ThreeDVector {
     pub x: f64,
     pub y: f64,

--- a/async-opcua-types/src/generated/types/time_zone_data_type.rs
+++ b/async-opcua-types/src/generated/types/time_zone_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TimeZoneDataType {
     pub offset: i16,
     pub daylight_saving_in_offset: bool,

--- a/async-opcua-types/src/generated/types/transaction_error_type.rs
+++ b/async-opcua-types/src/generated/types/transaction_error_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransactionErrorType {
     pub target_id: opcua::types::node_id::NodeId,
     pub error: opcua::types::status_code::StatusCode,

--- a/async-opcua-types/src/generated/types/transfer_result.rs
+++ b/async-opcua-types/src/generated/types/transfer_result.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransferResult {
     pub status_code: opcua::types::status_code::StatusCode,
     pub available_sequence_numbers: Option<Vec<u32>>,

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransferSubscriptionsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub subscription_ids: Option<Vec<u32>>,

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransferSubscriptionsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::transfer_result::TransferResult>>,

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TranslateBrowsePathsToNodeIdsRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub browse_paths: Option<Vec<super::browse_path::BrowsePath>>,

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TranslateBrowsePathsToNodeIdsResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<super::browse_path_result::BrowsePathResult>>,

--- a/async-opcua-types/src/generated/types/transmit_qos_data_type.rs
+++ b/async-opcua-types/src/generated/types/transmit_qos_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransmitQosDataType {}
 impl opcua::types::MessageInfo for TransmitQosDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TransmitQosPriorityDataType {
     pub priority_label: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/trust_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/trust_list_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TrustListDataType {
     pub specified_lists: u32,
     pub trusted_certificates: Option<Vec<opcua::types::byte_string::ByteString>>,

--- a/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
+++ b/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UABinaryFileDataType {
     pub namespaces: Option<Vec<opcua::types::string::UAString>>,
     pub structure_data_types: Option<Vec<super::structure_description::StructureDescription>>,

--- a/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UadpDataSetReaderMessageDataType {
     pub group_version: u32,
     pub network_message_number: u16,

--- a/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UadpDataSetWriterMessageDataType {
     pub data_set_message_content_mask: super::enums::UadpDataSetMessageContentMask,
     pub configured_size: u16,

--- a/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UadpWriterGroupMessageDataType {
     pub group_version: u32,
     pub data_set_ordering: super::enums::DataSetOrderingType,

--- a/async-opcua-types/src/generated/types/unregister_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnregisterNodesRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub nodes_to_unregister: Option<Vec<opcua::types::node_id::NodeId>>,

--- a/async-opcua-types/src/generated/types/unregister_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnregisterNodesResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
 }

--- a/async-opcua-types/src/generated/types/unsigned_rational_number.rs
+++ b/async-opcua-types/src/generated/types/unsigned_rational_number.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnsignedRationalNumber {
     pub numerator: u32,
     pub denominator: u32,

--- a/async-opcua-types/src/generated/types/update_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_data_details.rs
@@ -9,19 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateDataDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/update_event_details.rs
+++ b/async-opcua-types/src/generated/types/update_event_details.rs
@@ -9,19 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateEventDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/update_structure_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_structure_data_details.rs
@@ -9,19 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateStructureDataDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub perform_insert_replace: super::enums::PerformUpdateType,

--- a/async-opcua-types/src/generated/types/user_identity_token.rs
+++ b/async-opcua-types/src/generated/types/user_identity_token.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UserIdentityToken {
     pub policy_id: opcua::types::string::UAString,
 }

--- a/async-opcua-types/src/generated/types/user_management_data_type.rs
+++ b/async-opcua-types/src/generated/types/user_management_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UserManagementDataType {
     pub user_name: opcua::types::string::UAString,
     pub user_configuration: super::enums::UserConfigurationMask,

--- a/async-opcua-types/src/generated/types/user_name_identity_token.rs
+++ b/async-opcua-types/src/generated/types/user_name_identity_token.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UserNameIdentityToken {
     pub policy_id: opcua::types::string::UAString,
     pub user_name: opcua::types::string::UAString,

--- a/async-opcua-types/src/generated/types/user_token_policy.rs
+++ b/async-opcua-types/src/generated/types/user_token_policy.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct UserTokenPolicy {
     pub policy_id: opcua::types::string::UAString,
     pub token_type: super::enums::UserTokenType,

--- a/async-opcua-types/src/generated/types/variable_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct VariableAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/variable_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_type_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct VariableTypeAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/vector.rs
+++ b/async-opcua-types/src/generated/types/vector.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Vector {}
 impl opcua::types::MessageInfo for Vector {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/view_attributes.rs
+++ b/async-opcua-types/src/generated/types/view_attributes.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ViewAttributes {
     pub specified_attributes: u32,
     pub display_name: opcua::types::localized_text::LocalizedText,

--- a/async-opcua-types/src/generated/types/view_description.rs
+++ b/async-opcua-types/src/generated/types/view_description.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ViewDescription {
     pub view_id: opcua::types::node_id::NodeId,
     pub timestamp: opcua::types::date_time::DateTime,

--- a/async-opcua-types/src/generated/types/write_request.rs
+++ b/async-opcua-types/src/generated/types/write_request.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriteRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub nodes_to_write: Option<Vec<super::write_value::WriteValue>>,

--- a/async-opcua-types/src/generated/types/write_response.rs
+++ b/async-opcua-types/src/generated/types/write_response.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriteResponse {
     pub response_header: opcua::types::response_header::ResponseHeader,
     pub results: Option<Vec<opcua::types::status_code::StatusCode>>,

--- a/async-opcua-types/src/generated/types/write_value.rs
+++ b/async-opcua-types/src/generated/types/write_value.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriteValue {
     pub node_id: opcua::types::node_id::NodeId,
     pub attribute_id: u32,

--- a/async-opcua-types/src/generated/types/writer_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriterGroupDataType {
     pub name: opcua::types::string::UAString,
     pub enabled: bool,

--- a/async-opcua-types/src/generated/types/writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_message_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriterGroupMessageDataType {}
 impl opcua::types::MessageInfo for WriterGroupMessageDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_transport_data_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct WriterGroupTransportDataType {}
 impl opcua::types::MessageInfo for WriterGroupTransportDataType {
     fn type_id(&self) -> opcua::types::ObjectId {

--- a/async-opcua-types/src/generated/types/x_509_identity_token.rs
+++ b/async-opcua-types/src/generated/types/x_509_identity_token.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct X509IdentityToken {
     pub policy_id: opcua::types::string::UAString,
     pub certificate_data: opcua::types::byte_string::ByteString,

--- a/async-opcua-types/src/generated/types/xv_type.rs
+++ b/async-opcua-types/src/generated/types/xv_type.rs
@@ -9,20 +9,8 @@
 mod opcua {
     pub use crate as types;
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct XVType {
     pub x: f64,
     pub value: f32,

--- a/async-opcua-types/src/lib.rs
+++ b/async-opcua-types/src/lib.rs
@@ -284,6 +284,7 @@ pub use opcua_macros::{JsonDecodable, JsonEncodable};
 #[cfg(feature = "xml")]
 pub use opcua_macros::{XmlDecodable, XmlEncodable, XmlType};
 
+pub use opcua_macros::ua_encodable;
 pub use opcua_macros::BinaryDecodable;
 pub use opcua_macros::BinaryEncodable;
 pub use opcua_macros::UaEnum;

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -64,7 +64,7 @@ fn mk_extension_object(
     let Some(body) = &val.body else {
         return Ok(ExtensionObject::null());
     };
-    let Some(data) = &body.data else {
+    let Some(data) = &body.raw else {
         return Ok(ExtensionObject::null());
     };
     let Some(type_id) = &val.type_id else {

--- a/samples/custom-codegen/src/generated/types/enums.rs
+++ b/samples/custom-codegen/src/generated/types/enums.rs
@@ -7,28 +7,8 @@
 // Copyright (C) 2017-2024 Einar Omang
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum IMTagSelectorEnumeration {
     #[opcua(default)]
@@ -36,28 +16,8 @@ pub enum IMTagSelectorEnumeration {
     LOCATION = 1i32,
     BOTH = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnARStateEnumeration {
     #[opcua(default)]
@@ -67,28 +27,8 @@ pub enum PnARStateEnumeration {
     UNCONNECTED_ERR_DUPLICATE_IP = 3i32,
     UNCONNECTED_ERR_DUPLICATE_NOS = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnARTypeEnumeration {
     #[opcua(default)]
@@ -97,28 +37,8 @@ pub enum PnARTypeEnumeration {
     IOCARSingleUsingRT_CLASS_3 = 16i32,
     IOCARSR = 32i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnAssetChangeEnumeration {
     #[opcua(default)]
@@ -126,28 +46,8 @@ pub enum PnAssetChangeEnumeration {
     REMOVED = 1i32,
     CHANGED = 2i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnAssetTypeEnumeration {
     #[opcua(default)]
@@ -156,56 +56,16 @@ pub enum PnAssetTypeEnumeration {
     SUBMODULE = 2i32,
     ASSET = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnChannelAccumulativeEnumeration {
     #[opcua(default)]
     SINGLE = 0i32,
     ACCUMULATIVE = 256i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnChannelDirectionEnumeration {
     #[opcua(default)]
@@ -214,28 +74,8 @@ pub enum PnChannelDirectionEnumeration {
     OUTPUT_CHANNEL = 16384i32,
     BIDIRECTIONAL_CHANNEL = 24576i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnChannelMaintenanceEnumeration {
     #[opcua(default)]
@@ -244,28 +84,8 @@ pub enum PnChannelMaintenanceEnumeration {
     MAINTENANCE_DEMANDED = 1024i32,
     USE_QUALIFIED_CHANNEL_QUALIFIER = 1536i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnChannelSpecifierEnumeration {
     #[opcua(default)]
@@ -274,28 +94,8 @@ pub enum PnChannelSpecifierEnumeration {
     DISAPPEARS = 4096i32,
     DISAPPEARS_OTHER_REMAIN = 6144i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnChannelTypeEnumeration {
     #[opcua(default)]
@@ -308,28 +108,8 @@ pub enum PnChannelTypeEnumeration {
     __32BIT = 6i32,
     __64BIT = 7i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnDeviceStateEnumeration {
     #[opcua(default)]
@@ -338,28 +118,8 @@ pub enum PnDeviceStateEnumeration {
     ONLINE = 2i32,
     ONLINE_DOCKING = 3i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnLinkStateEnumeration {
     UP = 1i32,
@@ -370,28 +130,8 @@ pub enum PnLinkStateEnumeration {
     NOT_PRESENT = 6i32,
     LOWER_LAYER_DOWN = 7i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnModuleStateEnumeration {
     #[opcua(default)]
@@ -401,28 +141,8 @@ pub enum PnModuleStateEnumeration {
     SUBSTITUTE = 3i32,
     OK = 4i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnPortStateEnumeration {
     #[opcua(default)]
@@ -434,56 +154,16 @@ pub enum PnPortStateEnumeration {
     FORWARDING = 5i32,
     BROKEN = 6i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnSubmoduleAddInfoEnumeration {
     #[opcua(default)]
     NO_ADD_INFO = 0i32,
     TAKEOVER_NOT_ALLOWED = 1i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnSubmoduleARInfoEnumeration {
     #[opcua(default)]
@@ -493,28 +173,8 @@ pub enum PnSubmoduleARInfoEnumeration {
     LOCKED_BY_IO_CONTROLLER = 384i32,
     LOCKED_BY_IO_SUPERVISOR = 512i32,
 }
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PnSubmoduleIdentInfoEnumeration {
     #[opcua(default)]

--- a/samples/custom-codegen/src/generated/types/structs.rs
+++ b/samples/custom-codegen/src/generated/types/structs.rs
@@ -7,20 +7,8 @@
 // Copyright (C) 2017-2024 Einar Omang
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PnDeviceDiagnosisDataType {
     pub api: u32,
     pub slot: u16,
@@ -62,20 +50,8 @@ impl opcua::types::ExpandedMessageInfo for PnDeviceDiagnosisDataType {
         opcua::types::ExpandedNodeId::from((id, "http://opcfoundation.org/UA/PROFINET/"))
     }
 }
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[opcua::types::ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PnDeviceRoleOptionSet {
     pub value: opcua::types::byte_string::ByteString,
     pub valid_bits: opcua::types::byte_string::ByteString,
@@ -101,21 +77,9 @@ impl opcua::types::ExpandedMessageInfo for PnDeviceRoleOptionSet {
         opcua::types::ExpandedNodeId::from((id, "http://opcfoundation.org/UA/PROFINET/"))
     }
 }
+#[opcua::types::ua_encodable]
 ///Contains the fields of the APDU element I&M5 | I&M5Data
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PnIM5DataType {
     pub annotation: opcua::types::string::UAString,
     pub order_id: opcua::types::string::UAString,

--- a/samples/demo-server/src/customs.rs
+++ b/samples/demo-server/src/customs.rs
@@ -4,9 +4,9 @@ use opcua::{
     nodes::{DataTypeBuilder, ObjectBuilder, ReferenceDirection, VariableBuilder},
     server::node_manager::memory::SimpleNodeManager,
     types::{
-        DataTypeDefinition, DataTypeId, EnumDefinition, EnumField, ExpandedNodeId, ExtensionObject,
-        NodeId, ObjectId, ObjectTypeId, ReferenceTypeId, StructureDefinition, StructureField,
-        StructureType,
+        ua_encodable, DataTypeDefinition, DataTypeId, EnumDefinition, EnumField, ExpandedNodeId,
+        ExtensionObject, NodeId, ObjectId, ObjectTypeId, ReferenceTypeId, StructureDefinition,
+        StructureField, StructureType,
     },
 };
 
@@ -119,29 +119,8 @@ fn add_custom_data_type(nm: &SimpleNodeManager, ns: u16, e_state_id: &NodeId) ->
     struct_id
 }
 
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    opcua::types::UaEnum,
-    opcua::types::BinaryEncodable,
-    opcua::types::BinaryDecodable,
-)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[ua_encodable]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum AxisState {
     #[default]
@@ -152,20 +131,8 @@ pub enum AxisState {
     Error = 5i32,
 }
 
-#[derive(Debug, Clone, PartialEq, opcua::types::BinaryEncodable, opcua::types::BinaryDecodable)]
-#[cfg_attr(
-    feature = "json",
-    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
-)]
-#[cfg_attr(
-    feature = "xml",
-    derive(
-        opcua::types::XmlEncodable,
-        opcua::types::XmlDecodable,
-        opcua::types::XmlType
-    )
-)]
-#[derive(Default)]
+#[ua_encodable]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ErrorData {
     message: opcua::types::UAString,
     error_id: u32,


### PR DESCRIPTION
The derives are getting very verbose, which is especially bad for users that want to create their own custom structs. This adds an attribute macro that simply derives these traits as appropriate.

I also found an issue with the XML parsing and custom codegen that required an unpleasant workaround.