### PR TITLE
Unified nullable trait for encoding

### DIFF
--- a/async-opcua-codegen/src/types/gen.rs
+++ b/async-opcua-codegen/src/types/gen.rs
@@ -326,6 +326,14 @@ impl CodeGenerator {
         let write_method = Ident::new(&format!("write_{}", item.typ), Span::call_site());
 
         impls.push(parse_quote! {
+            impl opcua::types::UaNullable for #enum_ident {
+                fn is_ua_null(&self) -> bool {
+                    self.is_empty()
+                }
+            }
+        });
+
+        impls.push(parse_quote! {
             impl opcua::types::BinaryEncodable for #enum_ident {
                 fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
                     #size

--- a/async-opcua-macros/src/encoding/json.rs
+++ b/async-opcua-macros/src/encoding/json.rs
@@ -27,7 +27,7 @@ pub fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStre
             }
             let ident = &field.ident;
             body.extend(quote! {
-                if self.#ident.as_ref().is_some_and(|f| !f.is_null_json()) {
+                if self.#ident.as_ref().is_some_and(|f| !opcua::types::UaNullable::is_ua_null(f)) {
                     encoding_mask |= 1 << #optional_index;
                 }
             });
@@ -53,7 +53,7 @@ pub fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStre
         if field.attr.optional {
             body.extend(quote! {
                 if let Some(item) = &self.#ident {
-                    if !item.is_null_json() {
+                    if !opcua::types::UaNullable::is_ua_null(item){
                         stream.name(#name)?;
                         opcua::types::json::JsonEncodable::encode(item, stream, ctx)?;
                     }
@@ -61,7 +61,7 @@ pub fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStre
             });
         } else {
             body.extend(quote! {
-                if !self.#ident.is_null_json() {
+                if !opcua::types::UaNullable::is_ua_null(&self.#ident) {
                     stream.name(#name)?;
                     opcua::types::json::JsonEncodable::encode(&self.#ident, stream, ctx)?;
                 }

--- a/async-opcua-macros/src/encoding/xml.rs
+++ b/async-opcua-macros/src/encoding/xml.rs
@@ -102,14 +102,14 @@ pub fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStrea
         if field.attr.optional {
             body.extend(quote! {
                 if let Some(item) = &self.#ident {
-                    if !item.is_null_xml() {
+                    if !opcua::types::UaNullable::is_ua_null(item) {
                         stream.encode_child(#name, item, ctx)?;
                     }
                 }
             });
         } else {
             body.extend(quote! {
-                if !self.#ident.is_null_xml() {
+                if !opcua::types::UaNullable::is_ua_null(&self.#ident) {
                     stream.encode_child(#name, &self.#ident, ctx)?;
                 }
             });

--- a/async-opcua-macros/src/lib.rs
+++ b/async-opcua-macros/src/lib.rs
@@ -6,7 +6,9 @@ mod encoding;
 mod events;
 mod utils;
 
-use encoding::{derive_all_inner, generate_encoding_impl, EncodingToImpl};
+use encoding::{
+    derive_all_inner, derive_ua_nullable_inner, generate_encoding_impl, EncodingToImpl,
+};
 use events::{derive_event_field_inner, derive_event_inner};
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
@@ -181,6 +183,16 @@ pub fn derive_xml_decodable(item: TokenStream) -> TokenStream {
 /// the type name, which can be overridden with an item-level `opcua(rename = ...)` attribute.
 pub fn derive_xml_type(item: TokenStream) -> TokenStream {
     match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::XmlType) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(UaNullable, attributes(opcua))]
+/// Derive the `UaNullable` trait on this struct or enum. This indicates whether the
+/// value is null/default in OPC-UA encoding.
+pub fn derive_ua_nullable(item: TokenStream) -> TokenStream {
+    match derive_ua_nullable_inner(parse_macro_input!(item)) {
         Ok(r) => r.into(),
         Err(e) => e.to_compile_error().into(),
     }

--- a/async-opcua-types/src/argument.rs
+++ b/async-opcua-types/src/argument.rs
@@ -31,7 +31,7 @@ mod opcua {
     pub use crate as types;
 }
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default, crate::UaNullable)]
 #[cfg_attr(feature = "json", derive(crate::JsonEncodable, crate::JsonDecodable))]
 #[cfg_attr(
     feature = "xml",

--- a/async-opcua-types/src/byte_string.rs
+++ b/async-opcua-types/src/byte_string.rs
@@ -14,7 +14,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use crate::{
     encoding::{process_decode_io_result, process_encode_io_result, write_i32, EncodingResult},
     read_i32, DecodingOptions, Error, Guid, OutOfRange, SimpleBinaryDecodable,
-    SimpleBinaryEncodable,
+    SimpleBinaryEncodable, UaNullable,
 };
 
 /// A sequence of octets.
@@ -31,6 +31,12 @@ impl AsRef<[u8]> for ByteString {
         } else {
             self.value.as_ref().unwrap()
         }
+    }
+}
+
+impl UaNullable for ByteString {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
     }
 }
 

--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -4,7 +4,7 @@ use crate::{
     write_i32, write_u32, Array, BinaryDecodable, BinaryEncodable, ByteString, Context, DataValue,
     DateTime, DiagnosticInfo, EncodingResult, Error, ExpandedMessageInfo, ExpandedNodeId,
     ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, StructureType,
-    TypeLoader, UAString, Variant, XmlElement,
+    TypeLoader, UAString, UaNullable, Variant, XmlElement,
 };
 
 use super::type_tree::{DataTypeTree, ParsedStructureField, StructTypeInfo};
@@ -220,6 +220,16 @@ impl DynamicStructure {
             }
             Variant::Empty => Err(Error::encoding("Empty variant value in structure")),
             r => r.encode_value(stream, ctx),
+        }
+    }
+}
+
+impl UaNullable for DynamicStructure {
+    fn is_ua_null(&self) -> bool {
+        if self.type_def.structure_type == StructureType::Union {
+            self.discriminant == 0
+        } else {
+            false
         }
     }
 }

--- a/async-opcua-types/src/data_value.rs
+++ b/async-opcua-types/src/data_value.rs
@@ -38,7 +38,7 @@ mod opcua {
 
 /// A data value is a value of a variable in the OPC UA server and contains information about its
 /// value, status and change timestamps.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, crate::UaNullable)]
 #[cfg_attr(
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)

--- a/async-opcua-types/src/date_time.rs
+++ b/async-opcua-types/src/date_time.rs
@@ -34,6 +34,12 @@ pub struct DateTime {
     date_time: DateTimeUtc,
 }
 
+impl crate::UaNullable for DateTime {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
+    }
+}
+
 #[cfg(feature = "json")]
 mod json {
     use crate::{json::*, Error};

--- a/async-opcua-types/src/diagnostic_info.rs
+++ b/async-opcua-types/src/diagnostic_info.rs
@@ -62,6 +62,12 @@ bitflags! {
     }
 }
 
+impl crate::UaNullable for DiagnosticBits {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
+
 #[cfg(feature = "json")]
 mod json {
     use crate::json::*;
@@ -127,7 +133,7 @@ mod opcua {
 }
 
 /// Diagnostic information.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, crate::UaNullable)]
 #[cfg_attr(
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)

--- a/async-opcua-types/src/expanded_node_id.rs
+++ b/async-opcua-types/src/expanded_node_id.rs
@@ -21,7 +21,7 @@ use crate::{
     read_u16, read_u32, read_u8,
     status_code::StatusCode,
     string::*,
-    write_u16, write_u32, write_u8, Context, Error, NamespaceMap,
+    write_u16, write_u32, write_u8, Context, Error, NamespaceMap, UaNullable,
 };
 
 /// A NodeId that allows the namespace URI to be specified instead of an index.
@@ -33,6 +33,12 @@ pub struct ExpandedNodeId {
     pub namespace_uri: UAString,
     /// The server index. 0 means current server.
     pub server_index: u32,
+}
+
+impl UaNullable for ExpandedNodeId {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
+    }
 }
 
 #[cfg(feature = "json")]
@@ -117,10 +123,6 @@ mod json {
             }
             stream.end_object()?;
             Ok(())
-        }
-
-        fn is_null_json(&self) -> bool {
-            self.is_null()
         }
     }
 
@@ -262,10 +264,6 @@ mod xml {
                 ));
             };
             node_id.encode(writer, context)
-        }
-
-        fn is_null_xml(&self) -> bool {
-            self.is_null()
         }
     }
 

--- a/async-opcua-types/src/extension_object.rs
+++ b/async-opcua-types/src/extension_object.rs
@@ -10,7 +10,7 @@ use std::{
     io::{Read, Write},
 };
 
-use crate::{write_i32, write_u8, Error, ExpandedMessageInfo, ExpandedNodeId};
+use crate::{write_i32, write_u8, Error, ExpandedMessageInfo, ExpandedNodeId, UaNullable};
 
 use super::{
     encoding::{BinaryDecodable, BinaryEncodable, EncodingResult},
@@ -223,6 +223,8 @@ impl PartialEq for dyn DynEncodable {
 }
 
 impl std::error::Error for ExtensionObjectError {}
+
+impl UaNullable for ExtensionObject {}
 
 #[cfg(feature = "json")]
 mod json {

--- a/async-opcua-types/src/generated/types/enums.rs
+++ b/async-opcua-types/src/generated/types/enums.rs
@@ -17,6 +17,11 @@ bitflags::bitflags! {
     NonatomicWrite = 512i32; const WriteFullArrayOnly = 1024i32; const NoSubDataTypes =
     2048i32; const NonVolatile = 4096i32; const Constant = 8192i32; }
 }
+impl opcua::types::UaNullable for AccessLevelExType {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for AccessLevelExType {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -98,6 +103,11 @@ bitflags::bitflags! {
     const HistoryWrite = 8u8; const SemanticChange = 16u8; const StatusWrite = 32u8;
     const TimestampWrite = 64u8; }
 }
+impl opcua::types::UaNullable for AccessLevelType {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for AccessLevelType {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         1usize
@@ -178,6 +188,11 @@ bitflags::bitflags! {
     const None = 0i16; const SigningRequired = 1i16; const EncryptionRequired = 2i16;
     const SessionRequired = 4i16; const ApplyRestrictionsToBrowse = 8i16; }
 }
+impl opcua::types::UaNullable for AccessRestrictionType {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for AccessRestrictionType {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         2usize
@@ -256,6 +271,11 @@ impl opcua::types::json::JsonEncodable for AccessRestrictionType {
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct AlarmMask : i16 { const None =
     0i16; const Active = 1i16; const Unacknowledged = 2i16; const Unconfirmed = 4i16; }
+}
+impl opcua::types::UaNullable for AlarmMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for AlarmMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -354,6 +374,11 @@ bitflags::bitflags! {
     524288i32; const WriteMask = 1048576i32; const ValueForVariableType = 2097152i32;
     const DataTypeDefinition = 4194304i32; const RolePermissions = 8388608i32; const
     AccessRestrictions = 16777216i32; const AccessLevelEx = 33554432i32; }
+}
+impl opcua::types::UaNullable for AttributeWriteMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for AttributeWriteMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -500,6 +525,11 @@ bitflags::bitflags! {
     ServerTimestamp = 4i32; const SourcePicoSeconds = 8i32; const ServerPicoSeconds =
     16i32; const RawData = 32i32; }
 }
+impl opcua::types::UaNullable for DataSetFieldContentMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for DataSetFieldContentMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -578,6 +608,11 @@ impl opcua::types::json::JsonEncodable for DataSetFieldContentMask {
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct DataSetFieldFlags : i16 { const
     None = 0i16; const PromotedField = 1i16; }
+}
+impl opcua::types::UaNullable for DataSetFieldFlags {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for DataSetFieldFlags {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -696,6 +731,11 @@ bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct EventNotifierType : u8 { const
     None = 0u8; const SubscribeToEvents = 1u8; const HistoryRead = 4u8; const
     HistoryWrite = 8u8; }
+}
+impl opcua::types::UaNullable for EventNotifierType {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for EventNotifierType {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -869,6 +909,11 @@ bitflags::bitflags! {
     128i32; const PublisherId = 256i32; const WriterGroupName = 512i32; const
     MinorVersion = 1024i32; }
 }
+impl opcua::types::UaNullable for JsonDataSetMessageContentMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for JsonDataSetMessageContentMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -950,6 +995,11 @@ bitflags::bitflags! {
     DataSetMessageHeader = 2i32; const SingleDataSetMessage = 4i32; const PublisherId =
     8i32; const DataSetClassId = 16i32; const ReplyTo = 32i32; const WriterGroupName =
     64i32; }
+}
+impl opcua::types::UaNullable for JsonNetworkMessageContentMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for JsonNetworkMessageContentMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -1169,6 +1219,11 @@ bitflags::bitflags! {
     const RequiresLowerCaseCharacters = 64i32; const RequiresDigitCharacters = 128i32;
     const RequiresSpecialCharacters = 256i32; }
 }
+impl opcua::types::UaNullable for PasswordOptionsMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for PasswordOptionsMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -1262,6 +1317,11 @@ bitflags::bitflags! {
     2048i32; const Call = 4096i32; const AddReference = 8192i32; const RemoveReference =
     16384i32; const DeleteNode = 32768i32; const AddNode = 65536i32; }
 }
+impl opcua::types::UaNullable for PermissionType {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for PermissionType {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -1345,6 +1405,11 @@ bitflags::bitflags! {
     ReferenceReaderGroup = 128i32; const ReferenceConnection = 256i32; const
     ReferencePubDataset = 512i32; const ReferenceSubDataset = 1024i32; const
     ReferenceSecurityGroup = 2048i32; const ReferencePushTarget = 4096i32; }
+}
+impl opcua::types::UaNullable for PubSubConfigurationRefMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for PubSubConfigurationRefMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
@@ -1526,6 +1591,11 @@ bitflags::bitflags! {
     = 16i32; const CheckRevocationStatusOnline = 32i32; const
     CheckRevocationStatusOffline = 64i32; }
 }
+impl opcua::types::UaNullable for TrustListValidationOptions {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for TrustListValidationOptions {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -1669,6 +1739,11 @@ bitflags::bitflags! {
     Status = 4i32; const MajorVersion = 8i32; const MinorVersion = 16i32; const
     SequenceNumber = 32i32; }
 }
+impl opcua::types::UaNullable for UadpDataSetMessageContentMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for UadpDataSetMessageContentMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -1752,6 +1827,11 @@ bitflags::bitflags! {
     const PicoSeconds = 256i32; const DataSetClassId = 512i32; const PromotedFields =
     1024i32; }
 }
+impl opcua::types::UaNullable for UadpNetworkMessageContentMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
+}
 impl opcua::types::BinaryEncodable for UadpNetworkMessageContentMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
         4usize
@@ -1831,6 +1911,11 @@ bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct UserConfigurationMask : i32 {
     const None = 0i32; const NoDelete = 1i32; const Disabled = 2i32; const NoChangeByUser
     = 4i32; const MustChangePassword = 8i32; }
+}
+impl opcua::types::UaNullable for UserConfigurationMask {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
+    }
 }
 impl opcua::types::BinaryEncodable for UserConfigurationMask {
     fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {

--- a/async-opcua-types/src/guid.rs
+++ b/async-opcua-types/src/guid.rs
@@ -26,6 +26,12 @@ impl From<Guid> for Uuid {
     }
 }
 
+impl UaNullable for Guid {
+    fn is_ua_null(&self) -> bool {
+        self.uuid.is_nil()
+    }
+}
+
 #[cfg(feature = "json")]
 mod json {
     use std::io::{Read, Write};

--- a/async-opcua-types/src/json.rs
+++ b/async-opcua-types/src/json.rs
@@ -15,10 +15,10 @@ pub use struson::{
     writer::{JsonStreamWriter, JsonWriter},
 };
 
-use crate::{EncodingResult, Error};
+use crate::{EncodingResult, Error, UaNullable};
 
 /// Trait for OPC-UA json encoding.
-pub trait JsonEncodable {
+pub trait JsonEncodable: UaNullable {
     #[allow(unused)]
     /// Write the type to the provided JSON writer.
     fn encode(
@@ -26,12 +26,6 @@ pub trait JsonEncodable {
         stream: &mut JsonStreamWriter<&mut dyn Write>,
         ctx: &crate::Context<'_>,
     ) -> EncodingResult<()>;
-
-    /// This method should return `true` if the value is default
-    /// and should not be serialized.
-    fn is_null_json(&self) -> bool {
-        false
-    }
 }
 
 impl From<struson::reader::ReaderError> for Error {
@@ -87,10 +81,6 @@ where
             Some(s) => s.encode(stream, ctx),
             None => Ok(stream.null_value()?),
         }
-    }
-
-    fn is_null_json(&self) -> bool {
-        self.is_none()
     }
 }
 
@@ -165,10 +155,6 @@ where
     ) -> EncodingResult<()> {
         T::encode(self, stream, ctx)
     }
-
-    fn is_null_json(&self) -> bool {
-        T::is_null_json(self)
-    }
 }
 
 impl<T> JsonDecodable for Box<T>
@@ -209,10 +195,6 @@ macro_rules! json_enc_float {
 
                 Ok(())
             }
-
-            fn is_null_json(&self) -> bool {
-                *self == 0.0
-            }
         }
 
         impl JsonDecodable for $t {
@@ -248,10 +230,6 @@ macro_rules! json_enc_number {
             ) -> EncodingResult<()> {
                 stream.number_value(*self)?;
                 Ok(())
-            }
-
-            fn is_null_json(&self) -> bool {
-                *self == 0
             }
         }
 
@@ -305,10 +283,6 @@ impl JsonEncodable for bool {
     ) -> EncodingResult<()> {
         stream.bool_value(*self)?;
         Ok(())
-    }
-
-    fn is_null_json(&self) -> bool {
-        !self
     }
 }
 

--- a/async-opcua-types/src/lib.rs
+++ b/async-opcua-types/src/lib.rs
@@ -288,6 +288,7 @@ pub use opcua_macros::ua_encodable;
 pub use opcua_macros::BinaryDecodable;
 pub use opcua_macros::BinaryEncodable;
 pub use opcua_macros::UaEnum;
+pub use opcua_macros::UaNullable;
 mod ua_enum;
 
 pub use self::{

--- a/async-opcua-types/src/localized_text.rs
+++ b/async-opcua-types/src/localized_text.rs
@@ -18,7 +18,7 @@ mod opcua {
     pub use crate as types;
 }
 /// A human readable text with an optional locale identifier.
-#[derive(PartialEq, Default, Debug, Clone)]
+#[derive(PartialEq, Default, Debug, Clone, crate::UaNullable)]
 #[cfg_attr(
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)

--- a/async-opcua-types/src/node_id.rs
+++ b/async-opcua-types/src/node_id.rs
@@ -24,7 +24,7 @@ use crate::{
     status_code::StatusCode,
     string::*,
     write_u16, write_u32, write_u8, DataTypeId, Error, MethodId, ObjectId, ObjectTypeId,
-    ReferenceTypeId, VariableId, VariableTypeId,
+    ReferenceTypeId, UaNullable, VariableId, VariableTypeId,
 };
 
 /// The kind of identifier, numeric, string, guid or byte
@@ -150,6 +150,12 @@ impl fmt::Display for NodeId {
     }
 }
 
+impl UaNullable for NodeId {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
+    }
+}
+
 // JSON serialization schema as per spec:
 //
 // "Type"
@@ -222,10 +228,6 @@ mod json {
             }
             stream.end_object()?;
             Ok(())
-        }
-
-        fn is_null_json(&self) -> bool {
-            self.is_null()
         }
     }
 
@@ -356,10 +358,6 @@ mod xml {
             };
             let val = ctx.resolve_alias_inverse(&self_str);
             writer.encode_child("Identifier", val, ctx)
-        }
-
-        fn is_null_xml(&self) -> bool {
-            self.is_null()
         }
     }
 

--- a/async-opcua-types/src/qualified_name.rs
+++ b/async-opcua-types/src/qualified_name.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 use crate::{
     encoding::{BinaryDecodable, BinaryEncodable, EncodingResult},
     string::*,
-    NamespaceMap,
+    NamespaceMap, UaNullable,
 };
 
 #[allow(unused)]
@@ -46,6 +46,12 @@ pub struct QualifiedName {
     pub name: UAString,
 }
 
+impl UaNullable for QualifiedName {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
+    }
+}
+
 #[cfg(feature = "xml")]
 mod xml {
     use crate::{xml::*, UAString};
@@ -66,10 +72,6 @@ mod xml {
             writer.encode_child("NamespaceIndex", &namespace_index, context)?;
             writer.encode_child("Name", &self.name, context)?;
             Ok(())
-        }
-
-        fn is_null_xml(&self) -> bool {
-            self.is_null()
         }
     }
 
@@ -132,10 +134,6 @@ mod json {
             }
             stream.string_value(&self.to_string())?;
             Ok(())
-        }
-
-        fn is_null_json(&self) -> bool {
-            self.name.is_null_json()
         }
     }
 

--- a/async-opcua-types/src/request_header.rs
+++ b/async-opcua-types/src/request_header.rs
@@ -26,7 +26,7 @@ mod opcua {
 }
 
 /// The `RequestHeader` contains information common to every request from a client to the server.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, crate::UaNullable)]
 #[cfg_attr(
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)

--- a/async-opcua-types/src/response_header.rs
+++ b/async-opcua-types/src/response_header.rs
@@ -27,7 +27,7 @@ mod opcua {
 }
 
 /// The `ResponseHeader` contains information common to every response from server to client.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, crate::UaNullable)]
 #[cfg_attr(
     feature = "json",
     derive(opcua_macros::JsonEncodable, opcua_macros::JsonDecodable)

--- a/async-opcua-types/src/status_code.rs
+++ b/async-opcua-types/src/status_code.rs
@@ -8,7 +8,7 @@ use std::{
     io::{Read, Write},
 };
 
-use crate::{DecodingOptions, SimpleBinaryDecodable};
+use crate::{DecodingOptions, SimpleBinaryDecodable, UaNullable};
 
 use super::encoding::{read_u32, write_u32, EncodingResult, SimpleBinaryEncodable};
 
@@ -16,6 +16,12 @@ use super::encoding::{read_u32, write_u32, EncodingResult, SimpleBinaryEncodable
 /// Wrapper around an OPC-UA status code, with utilities for displaying,
 /// parsing, and reading.
 pub struct StatusCode(u32);
+
+impl UaNullable for StatusCode {
+    fn is_ua_null(&self) -> bool {
+        self.0 == 0
+    }
+}
 
 #[cfg(feature = "json")]
 mod json {

--- a/async-opcua-types/src/string.rs
+++ b/async-opcua-types/src/string.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::{
     encoding::{process_decode_io_result, process_encode_io_result, write_i32, EncodingResult},
     read_i32, DecodingOptions, Error, OutOfRange, SimpleBinaryDecodable, SimpleBinaryEncodable,
+    UaNullable,
 };
 
 /// To avoid naming conflict hell, the OPC UA String type is typed `UAString` so it does not collide
@@ -32,6 +33,12 @@ impl fmt::Display for UAString {
         } else {
             write!(f, "[null]")
         }
+    }
+}
+
+impl UaNullable for UAString {
+    fn is_ua_null(&self) -> bool {
+        self.is_null()
     }
 }
 
@@ -60,10 +67,6 @@ mod json {
             }
 
             Ok(())
-        }
-
-        fn is_null_json(&self) -> bool {
-            self.is_null()
         }
     }
 
@@ -158,10 +161,6 @@ mod xml {
             }
 
             Ok(())
-        }
-
-        fn is_null_xml(&self) -> bool {
-            self.is_null()
         }
     }
 

--- a/async-opcua-types/src/tests/json.rs
+++ b/async-opcua-types/src/tests/json.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use base64::Engine;
-use opcua_macros::{JsonDecodable, JsonEncodable};
+use opcua_macros::{JsonDecodable, JsonEncodable, UaNullable};
 use serde_json::{json, Value};
 use struson::{
     reader::JsonStreamReader,
@@ -767,7 +767,7 @@ fn test_custom_struct_with_optional() {
         pub use crate as types;
     }
 
-    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable)]
+    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
     pub struct MyStructWithOptionalFields {
         foo: i32,
         #[opcua(optional)]
@@ -838,7 +838,7 @@ fn test_custom_union() {
         pub use crate as types;
     }
 
-    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable)]
+    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
     pub enum MyUnion {
         Var1(i32),
         #[opcua(rename = "EUInfo")]
@@ -903,7 +903,7 @@ fn test_custom_union_nullable() {
         pub use crate as types;
     }
 
-    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable)]
+    #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
     pub enum MyUnion {
         Var1(i32),
         Null,

--- a/async-opcua-types/src/variant/json.rs
+++ b/async-opcua-types/src/variant/json.rs
@@ -100,10 +100,6 @@ impl JsonEncodable for Variant {
 
         Ok(())
     }
-
-    fn is_null_json(&self) -> bool {
-        matches!(self, Variant::Empty)
-    }
 }
 
 enum VariantOrArray {

--- a/async-opcua-types/src/variant/mod.rs
+++ b/async-opcua-types/src/variant/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     qualified_name::QualifiedName,
     status_code::StatusCode,
     string::{UAString, XmlElement},
-    write_i32, write_u8, DataTypeId, DataValue, DiagnosticInfo, DynEncodable, Error,
+    write_i32, write_u8, DataTypeId, DataValue, DiagnosticInfo, DynEncodable, Error, UaNullable,
 };
 /// A `Variant` holds built-in OPC UA data types, including single and multi dimensional arrays,
 /// data values and extension objects.
@@ -311,6 +311,12 @@ impl Variant {
                 Ok(())
             }
         }
+    }
+}
+
+impl UaNullable for Variant {
+    fn is_ua_null(&self) -> bool {
+        self.is_empty()
     }
 }
 

--- a/async-opcua-types/src/xml/builtins.rs
+++ b/async-opcua-types/src/xml/builtins.rs
@@ -21,10 +21,6 @@ macro_rules! xml_enc_number {
                 writer.write_text(&self.to_string())?;
                 Ok(())
             }
-
-            fn is_null_xml(&self) -> bool {
-                *self == 0
-            }
         }
 
         impl XmlDecodable for $t {
@@ -66,10 +62,6 @@ macro_rules! xml_enc_float {
                     writer.write_text(&self.to_string())?;
                 }
                 Ok(())
-            }
-
-            fn is_null_xml(&self) -> bool {
-                *self == 0.0
             }
         }
 
@@ -173,10 +165,6 @@ impl XmlEncodable for bool {
         writer.write_text(if *self { "true" } else { "false" })?;
         Ok(())
     }
-
-    fn is_null_xml(&self) -> bool {
-        !self
-    }
 }
 
 impl<T> XmlType for Box<T>
@@ -211,10 +199,6 @@ where
         context: &Context<'_>,
     ) -> Result<(), Error> {
         self.as_ref().encode(writer, context)
-    }
-
-    fn is_null_xml(&self) -> bool {
-        self.as_ref().is_null_xml()
     }
 }
 
@@ -264,7 +248,7 @@ where
         context: &Context<'_>,
     ) -> super::EncodingResult<()> {
         for item in self {
-            if item.is_null_xml() {
+            if item.is_ua_null() {
                 writer.write_empty(item.tag())?;
             } else {
                 writer.encode_child(item.tag(), item, context)?;
@@ -311,9 +295,5 @@ where
             value.encode(writer, context)?;
         }
         Ok(())
-    }
-
-    fn is_null_xml(&self) -> bool {
-        self.is_none()
     }
 }

--- a/async-opcua-types/src/xml/encoding.rs
+++ b/async-opcua-types/src/xml/encoding.rs
@@ -5,7 +5,7 @@ use std::{
 
 use opcua_xml::{XmlReadError, XmlStreamReader, XmlStreamWriter, XmlWriteError};
 
-use crate::{Context, EncodingResult, Error};
+use crate::{Context, EncodingResult, Error, UaNullable};
 
 impl From<XmlReadError> for Error {
     fn from(value: XmlReadError) -> Self {
@@ -48,19 +48,13 @@ pub trait XmlDecodable: XmlType {
 }
 
 /// Trait for types that can be encoded to XML.
-pub trait XmlEncodable: XmlType {
+pub trait XmlEncodable: XmlType + UaNullable {
     /// Encode a value to an XML stream.
     fn encode(
         &self,
         writer: &mut XmlStreamWriter<&mut dyn Write>,
         context: &Context<'_>,
     ) -> EncodingResult<()>;
-
-    /// This method should return `true` if the value is default
-    /// and should not be serialized.
-    fn is_null_xml(&self) -> bool {
-        false
-    }
 }
 
 /// Extensions for XmlStreamWriter.


### PR DESCRIPTION
There's currently duplicated logic between XML and JSON. This unifies them into a single trait, and adds a derive macro for that.

It also expands the logic around enums/unions a bit, so that we cover more cases that are null according to the standard.