### PR TITLE
Improve handling of unions in CustomStruct

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,6 @@ This is a list of things that are known to be missing, or ideas that could be im
  - Write a sophisticated server example with a persistent store. This would be a great way to verify the flexibility of the server.
  - Write some "bad ideas" servers, it would be nice to showcase how flexible this is.
  - Finish up XML implementation.
-   - Support for XML bodies in binary and JSON extension objects.
-   - Support for unions in derive macros.
    - Support for XmlElement in Variant.
  - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
  - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.

--- a/async-opcua-macros/src/encoding/mod.rs
+++ b/async-opcua-macros/src/encoding/mod.rs
@@ -45,10 +45,7 @@ impl EncodingInput {
                 input.ident,
             )?)),
             syn::Data::Enum(data_enum) => {
-                let is_union = data_enum
-                    .variants
-                    .first()
-                    .is_some_and(|v| !v.fields.is_empty());
+                let is_union = data_enum.variants.iter().any(|v| !v.fields.is_empty());
                 if is_union {
                     return Ok(Self::AdvancedEnum(AdvancedEnum::from_input(
                         data_enum,

--- a/async-opcua-types/src/custom/type_tree.rs
+++ b/async-opcua-types/src/custom/type_tree.rs
@@ -114,6 +114,17 @@ impl StructTypeInfo {
             .get(idx)
             .and_then(|i| self.fields.get(*i))
     }
+
+    /// Return whether this struct is supported by the current version of the library.
+    /// Types that are not supported will panic on encoding, and be skipped when decoding.
+    ///
+    /// Currently this is only structures and unions with subtyped values.
+    pub fn is_supported(&self) -> bool {
+        !matches!(
+            self.structure_type,
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues
+        )
+    }
 }
 
 #[derive(Debug, Default)]

--- a/async-opcua-types/src/expanded_node_id.rs
+++ b/async-opcua-types/src/expanded_node_id.rs
@@ -538,6 +538,15 @@ impl ExpandedNodeId {
         value.into()
     }
 
+    /// Creates an expanded node id from a namespace URI and an identifier.
+    pub fn new_with_namespace(namespace: &str, value: impl Into<Identifier> + 'static) -> Self {
+        Self {
+            namespace_uri: namespace.into(),
+            node_id: NodeId::new(0, value),
+            server_index: 0,
+        }
+    }
+
     /// Return a null ExpandedNodeId.
     pub fn null() -> ExpandedNodeId {
         Self::new(NodeId::null())


### PR DESCRIPTION
We didn't properly handle null unions, we do so now.

Also add a bunch of tests for all the different encodings, including union round-trips now that we have native union support for all the different encodings.

I also added a type to make it more convenient to implement `TypeLoader`, since the support code for the test got a little annoying.