### PR TITLE
Support for XmlElement in XML bodies.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,6 @@ This is a list of things that are known to be missing, or ideas that could be im
  - Implement a better framework for security checks on the server.
  - Write a sophisticated server example with a persistent store. This would be a great way to verify the flexibility of the server.
  - Write some "bad ideas" servers, it would be nice to showcase how flexible this is.
- - Finish up XML implementation.
-   - Support for XmlElement in Variant.
  - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
  - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.
  - Look into running certain services concurrently. Currently they are sequential because that makes everything much simpler, but the services that don't have any cross node-manager interaction could run on all node managers concurrently.

--- a/async-opcua-types/src/string.rs
+++ b/async-opcua-types/src/string.rs
@@ -344,6 +344,3 @@ fn string_substring() {
 
     assert!(UAString::null().substring(0, 0).is_err());
 }
-
-/// An XML element.
-pub type XmlElement = UAString;

--- a/async-opcua-types/src/tests/xml.rs
+++ b/async-opcua-types/src/tests/xml.rs
@@ -8,7 +8,7 @@ use crate::xml::{XmlDecodable, XmlEncodable};
 use crate::{
     Argument, Array, ByteString, DataTypeId, DataValue, DateTime, EUInformation, ExpandedNodeId,
     ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, UAString, UaNullable,
-    Variant,
+    Variant, XmlElement,
 };
 use crate::{Context, ContextOwned, DecodingOptions, EncodingResult};
 
@@ -275,6 +275,15 @@ fn from_xml_data_value() {
 }
 
 #[test]
+fn from_xml_xml_element() {
+    let data = r#"<Thing>Hello there</Thing>
+<Thing>Other thing</Thing>
+"#;
+    // XML elements are simply captured one-to-one.
+    xml_round_trip(&XmlElement::from(data), data);
+}
+
+#[test]
 fn from_xml_variant() {
     xml_round_trip(&Variant::from(1u8), "<Byte>1</Byte>");
     xml_round_trip(
@@ -356,6 +365,17 @@ fn from_xml_variant() {
     xml_round_trip(
         &Variant::from(vec![StatusCode::Bad, StatusCode::Good]),
         "<ListOfStatusCode><StatusCode><Code>2147483648</Code></StatusCode><StatusCode><Code>0</Code></StatusCode></ListOfStatusCode>",
+    );
+    let data = r#"<Thing>Hello there</Thing>
+<Thing>Other thing</Thing>
+"#;
+    xml_round_trip(
+        &Variant::from(XmlElement::from(data)),
+        &format!("<XmlElement>{data}</XmlElement>"),
+    );
+    xml_round_trip(
+        &Variant::from(vec![XmlElement::from(data), XmlElement::from(data)]),
+        &format!("<ListOfXmlElement><XmlElement>{data}</XmlElement><XmlElement>{data}</XmlElement></ListOfXmlElement>"),
     );
     xml_round_trip(
         &Variant::from(EUInformation {

--- a/async-opcua-types/src/variant/from.rs
+++ b/async-opcua-types/src/variant/from.rs
@@ -6,7 +6,7 @@ use crate::{
     UAString, VariantScalarTypeId,
 };
 
-use super::Variant;
+use super::{Variant, XmlElement};
 
 /// Trait for types that can be cast from a variant.
 ///
@@ -65,6 +65,7 @@ impl_from_variant_primitive!(u64, UInt64);
 impl_from_variant_primitive!(f32, Float);
 impl_from_variant_primitive!(f64, Double);
 impl_from_variant_primitive!(UAString, String);
+impl_from_variant_primitive!(XmlElement, XmlElement);
 impl_from_variant_primitive_unbox!(DateTime, DateTime);
 impl_from_variant_primitive_unbox!(Guid, Guid);
 impl_from_variant_primitive!(StatusCode, StatusCode);

--- a/async-opcua-types/src/variant/into.rs
+++ b/async-opcua-types/src/variant/into.rs
@@ -5,7 +5,7 @@ use crate::{
     ExtensionObject, Guid, LocalizedText, NodeId, QualifiedName, StatusCode, UAString,
 };
 
-use super::{Array, Variant, VariantScalarTypeId, VariantType};
+use super::{Array, Variant, VariantScalarTypeId, VariantType, XmlElement};
 
 /// Trait implemented by types that can be converted to a variant.
 /// This is a workaround for specialization in `EventField`.
@@ -63,6 +63,7 @@ impl_into_variant!(u64, UInt64);
 impl_into_variant!(f32, Float);
 impl_into_variant!(f64, Double);
 impl_into_variant!(UAString, String);
+impl_into_variant!(XmlElement, XmlElement);
 impl_into_variant_boxed!(DateTime, DateTime);
 impl_into_variant_boxed!(Guid, Guid);
 impl_into_variant!(StatusCode, StatusCode);

--- a/async-opcua-types/src/variant/mod.rs
+++ b/async-opcua-types/src/variant/mod.rs
@@ -13,6 +13,10 @@ mod type_id;
 #[cfg(feature = "xml")]
 mod xml;
 
+mod xml_element;
+
+pub use xml_element::XmlElement;
+
 pub use from::TryFromVariant;
 pub use into::IntoVariant;
 pub use type_id::*;
@@ -40,7 +44,7 @@ use crate::{
     numeric_range::NumericRange,
     qualified_name::QualifiedName,
     status_code::StatusCode,
-    string::{UAString, XmlElement},
+    string::UAString,
     write_i32, write_u8, DataTypeId, DataValue, DiagnosticInfo, DynEncodable, Error, UaNullable,
 };
 /// A `Variant` holds built-in OPC UA data types, including single and multi dimensional arrays,
@@ -156,6 +160,7 @@ impl_variant_type_for!(DateTime, VariantScalarTypeId::DateTime);
 impl_variant_type_for!(Guid, VariantScalarTypeId::Guid);
 impl_variant_type_for!(StatusCode, VariantScalarTypeId::StatusCode);
 impl_variant_type_for!(ByteString, VariantScalarTypeId::ByteString);
+impl_variant_type_for!(XmlElement, VariantScalarTypeId::XmlElement);
 impl_variant_type_for!(QualifiedName, VariantScalarTypeId::QualifiedName);
 impl_variant_type_for!(LocalizedText, VariantScalarTypeId::LocalizedText);
 impl_variant_type_for!(NodeId, VariantScalarTypeId::NodeId);

--- a/async-opcua-types/src/variant/xml.rs
+++ b/async-opcua-types/src/variant/xml.rs
@@ -239,7 +239,7 @@ impl XmlEncodable for Variant {
             Variant::Guid(v) => stream.encode_child(Guid::TAG, v, ctx)?,
             Variant::StatusCode(v) => stream.encode_child(StatusCode::TAG, v, ctx)?,
             Variant::ByteString(v) => stream.encode_child(ByteString::TAG, v, ctx)?,
-            Variant::XmlElement(v) => stream.encode_child("XmlElement", v, ctx)?,
+            Variant::XmlElement(v) => stream.encode_child(crate::XmlElement::TAG, v, ctx)?,
             Variant::QualifiedName(v) => stream.encode_child(QualifiedName::TAG, v, ctx)?,
             Variant::LocalizedText(v) => stream.encode_child(LocalizedText::TAG, v, ctx)?,
             Variant::NodeId(v) => stream.encode_child(NodeId::TAG, v, ctx)?,

--- a/async-opcua-types/src/variant/xml_element.rs
+++ b/async-opcua-types/src/variant/xml_element.rs
@@ -1,0 +1,129 @@
+// OPCUA for Rust
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2017-2025 Einar Omang
+
+use crate::{BinaryDecodable, BinaryEncodable, UAString, UaNullable};
+
+/// XML element, represented as a string.
+///
+/// Note that this is deprecated, according to the OPC-UA standard,
+/// it is kept in the library for backwards compatibility.
+///
+/// Constructors are not checked, so the contents are not guaranteed to
+/// be valid XML, or really XML at all.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct XmlElement(UAString);
+
+impl XmlElement {
+    /// Create a new null XmlElement.
+    pub fn null() -> Self {
+        Self(UAString::null())
+    }
+}
+
+impl From<String> for XmlElement {
+    fn from(value: String) -> Self {
+        Self(UAString::from(value))
+    }
+}
+
+impl From<&str> for XmlElement {
+    fn from(value: &str) -> Self {
+        Self(UAString::from(value))
+    }
+}
+
+impl From<UAString> for XmlElement {
+    fn from(value: UAString) -> Self {
+        Self(value)
+    }
+}
+
+impl BinaryEncodable for XmlElement {
+    fn byte_len(&self, ctx: &crate::Context<'_>) -> usize {
+        self.0.byte_len(ctx)
+    }
+
+    fn encode<S: std::io::Write + ?Sized>(
+        &self,
+        stream: &mut S,
+        ctx: &crate::Context<'_>,
+    ) -> crate::EncodingResult<()> {
+        self.0.encode(stream, ctx)
+    }
+}
+
+impl BinaryDecodable for XmlElement {
+    fn decode<S: std::io::Read + ?Sized>(
+        stream: &mut S,
+        ctx: &crate::Context<'_>,
+    ) -> crate::EncodingResult<Self> {
+        Ok(XmlElement(UAString::decode(stream, ctx)?))
+    }
+}
+
+impl UaNullable for XmlElement {
+    fn is_ua_null(&self) -> bool {
+        self.0.is_null()
+    }
+}
+
+#[cfg(feature = "json")]
+mod json {
+    use crate::{json::*, UAString};
+
+    // XMLElement is stored as a string in JSON.
+
+    impl JsonEncodable for super::XmlElement {
+        fn encode(
+            &self,
+            stream: &mut JsonStreamWriter<&mut dyn std::io::Write>,
+            ctx: &crate::Context<'_>,
+        ) -> crate::EncodingResult<()> {
+            self.0.encode(stream, ctx)
+        }
+    }
+
+    impl JsonDecodable for super::XmlElement {
+        fn decode(
+            stream: &mut JsonStreamReader<&mut dyn std::io::Read>,
+            ctx: &Context<'_>,
+        ) -> crate::EncodingResult<Self> {
+            Ok(super::XmlElement(UAString::decode(stream, ctx)?))
+        }
+    }
+}
+
+#[cfg(feature = "xml")]
+mod xml {
+    use crate::xml::*;
+
+    impl XmlType for super::XmlElement {
+        const TAG: &'static str = "XmlElement";
+    }
+
+    impl XmlEncodable for super::XmlElement {
+        fn encode(
+            &self,
+            writer: &mut XmlStreamWriter<&mut dyn std::io::Write>,
+            _context: &Context<'_>,
+        ) -> EncodingResult<()> {
+            writer.write_raw(self.0.as_ref().as_bytes())?;
+            Ok(())
+        }
+    }
+
+    impl XmlDecodable for super::XmlElement {
+        fn decode(
+            read: &mut XmlStreamReader<&mut dyn std::io::Read>,
+            _context: &Context<'_>,
+        ) -> Result<Self, Error>
+        where
+            Self: Sized,
+        {
+            let raw = read.consume_raw()?;
+            let string = String::from_utf8(raw).map_err(Error::decoding)?;
+            Ok(Self(string.into()))
+        }
+    }
+}

--- a/async-opcua-xml/src/encoding/writer.rs
+++ b/async-opcua-xml/src/encoding/writer.rs
@@ -67,3 +67,12 @@ impl<T: Write> XmlStreamWriter<T> {
         self.writer.create_element(name)
     }
 }
+
+impl XmlStreamWriter<&mut dyn Write> {
+    /// Write the given bytes raw to the stream.
+    /// This may produce invalid XML, if the data is not valid and properly escaped.
+    pub fn write_raw(&mut self, data: &[u8]) -> Result<(), XmlWriteError> {
+        self.writer.get_mut().write_all(data)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is technically deprecated in the OPC-UA standard, but it's still good to have support for it.

The old solution just used a type-alias for UAString, which is fine for both JSON and binary, but won't work properly for XML. The lack of a concrete, unique type also caused issues with variant.

This adds a newtype for it instead, just a wrapper around UAString.

Reading the contents of an element as raw XML was quite hairy, but the solution I ended up with seems to work fine.