### PR TITLE
Add a schema cache for code generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "chrono",
  "convert_case",
  "log",
+ "pathdiff",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1493,6 +1494,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"

--- a/async-opcua-codegen/Cargo.toml
+++ b/async-opcua-codegen/Cargo.toml
@@ -19,6 +19,7 @@ base64 = "0.22.1"
 chrono = "0.4.38"
 convert_case = "0.6.0"
 log = { workspace = true }
+pathdiff = "0.2.3"
 prettyplease = "0.2.20"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"

--- a/async-opcua-codegen/src/config.rs
+++ b/async-opcua-codegen/src/config.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{input::SchemaCache, CodeGenError};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum ExplicitCodeGenSource {
+    #[serde(rename = "xml-schema")]
+    Xml { path: String },
+    #[serde(rename = "binary-schema")]
+    Binary { path: String },
+    #[serde(rename = "node-set")]
+    NodeSet {
+        path: String,
+        documentation: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum CodeGenSource {
+    Implicit(String),
+    Explicit(ExplicitCodeGenSource),
+}
+
+pub fn load_schemas(
+    root_path: &str,
+    sources: &[CodeGenSource],
+) -> Result<SchemaCache, CodeGenError> {
+    let mut cache = SchemaCache::new(root_path);
+    for source in sources {
+        match source {
+            CodeGenSource::Implicit(path) => {
+                cache.auto_load_schemas(path)?;
+            }
+            CodeGenSource::Explicit(explicit) => match explicit {
+                ExplicitCodeGenSource::Xml { path } => {
+                    cache.load_xml_schema(path)?;
+                }
+                ExplicitCodeGenSource::Binary { path } => {
+                    cache.load_binary_schema(path)?;
+                }
+                ExplicitCodeGenSource::NodeSet {
+                    path,
+                    documentation,
+                } => {
+                    cache.load_nodeset(path, documentation.as_deref())?;
+                }
+            },
+        }
+    }
+    cache.validate()?;
+
+    Ok(cache)
+}

--- a/async-opcua-codegen/src/input/binary_schema.rs
+++ b/async-opcua-codegen/src/input/binary_schema.rs
@@ -1,0 +1,26 @@
+use opcua_xml::{load_bsd_file, schema::opc_binary_schema::TypeDictionary};
+
+use crate::CodeGenError;
+
+pub struct BinarySchemaInput {
+    pub xml: TypeDictionary,
+    pub namespace: String,
+    pub path: String,
+}
+
+impl BinarySchemaInput {
+    pub fn parse(data: &str, path: &str) -> Result<Self, CodeGenError> {
+        let xml = load_bsd_file(data)?;
+        Ok(Self {
+            namespace: xml.target_namespace.clone(),
+            xml,
+            path: path.to_owned(),
+        })
+    }
+
+    pub fn load(root_path: &str, file_path: &str) -> Result<Self, CodeGenError> {
+        let data = std::fs::read_to_string(format!("{}/{}", root_path, file_path))
+            .map_err(|e| CodeGenError::io(&format!("Failed to read file {}", file_path), e))?;
+        Self::parse(&data, file_path)
+    }
+}

--- a/async-opcua-codegen/src/input/mod.rs
+++ b/async-opcua-codegen/src/input/mod.rs
@@ -1,0 +1,186 @@
+use std::{collections::HashMap, path::Path};
+
+use log::warn;
+use pathdiff::diff_paths;
+
+use crate::CodeGenError;
+
+mod binary_schema;
+mod nodeset;
+mod xml_schema;
+
+pub use binary_schema::BinarySchemaInput;
+pub use nodeset::NodeSetInput;
+pub use xml_schema::XmlSchemaInput;
+
+struct SchemaCacheInst<T> {
+    aliases: HashMap<String, usize>,
+    items: Vec<T>,
+}
+
+impl<T> SchemaCacheInst<T> {
+    pub fn new() -> Self {
+        Self {
+            aliases: HashMap::new(),
+            items: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: String, value: T) -> usize {
+        let idx = self.items.len();
+        self.items.push(value);
+        self.aliases.insert(key, idx);
+        idx
+    }
+
+    pub fn get(&self, key: &str) -> Option<&T> {
+        let idx = self.aliases.get(key)?;
+        self.items.get(*idx)
+    }
+
+    pub fn add_file_aliases(&mut self, file_path: &str, index: usize) {
+        self.aliases.insert(file_path.to_owned(), index);
+        let path = Path::new(file_path);
+        if let Some(file_name) = path.file_name() {
+            self.aliases
+                .insert(file_name.to_string_lossy().to_string(), index);
+        }
+        if let Some(file_name) = path.with_extension("").file_name() {
+            self.aliases
+                .insert(file_name.to_string_lossy().to_string(), index);
+        }
+    }
+}
+
+pub struct SchemaCache {
+    root_path: String,
+    nodesets: SchemaCacheInst<NodeSetInput>,
+    binary_schemas: SchemaCacheInst<BinarySchemaInput>,
+    xml_schemas: SchemaCacheInst<XmlSchemaInput>,
+}
+
+impl SchemaCache {
+    pub fn new(root_path: &str) -> Self {
+        Self {
+            root_path: root_path.to_owned(),
+            nodesets: SchemaCacheInst::new(),
+            binary_schemas: SchemaCacheInst::new(),
+            xml_schemas: SchemaCacheInst::new(),
+        }
+    }
+
+    fn auto_load_file(&mut self, path: &Path) -> Result<(), CodeGenError> {
+        if let Some(ext) = path.extension() {
+            // The rest of the schema cache expects a relative path, but here we're operating
+            // on the full, absolute path.
+            // Using relative paths makes it so that you get the same result from codegen, no matter
+            // where you run it from, so long as the config file is in the same place.
+            let relative_path = diff_paths(path, &self.root_path).ok_or_else(|| {
+                CodeGenError::other(format!(
+                    "Failed to get relative path for {}",
+                    path.to_string_lossy()
+                ))
+            })?;
+            let path_str = relative_path.to_string_lossy();
+            match ext.to_string_lossy().as_ref() {
+                "xsd" => self.load_xml_schema(&path_str)?,
+                "bsd" => self.load_binary_schema(&path_str)?,
+                "xml" => {
+                    // Check if there is a file on the form <filename>.documentation.csv
+                    let docs_path = if path.with_extension("documentation.csv").exists() {
+                        Some(
+                            relative_path
+                                .with_extension("documentation.csv")
+                                .to_string_lossy()
+                                .into_owned(),
+                        )
+                    } else {
+                        None
+                    };
+                    self.load_nodeset(&path_str, docs_path.as_deref())?
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<(), CodeGenError> {
+        for nodeset in &self.nodesets.items {
+            nodeset.validate(self)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn auto_load_schemas(&mut self, path: &str) -> Result<(), CodeGenError> {
+        let path_buf = Path::new(&self.root_path).join(path);
+        let path: &Path = path_buf.as_ref();
+        if path.is_dir() {
+            for entry in std::fs::read_dir(path).map_err(|e| {
+                CodeGenError::other(format!(
+                    "Failed to list files in path {}, {e}",
+                    path.to_string_lossy()
+                ))
+            })? {
+                let Ok(entry) = entry else {
+                    warn!("Failed to read entry: {:?}", entry);
+                    continue;
+                };
+                let path = entry.path();
+                self.auto_load_file(&path)?;
+            }
+        } else if path.is_file() {
+            self.auto_load_file(path)?;
+        } else {
+            return Err(CodeGenError::other(format!(
+                "Path {} not found",
+                path.to_string_lossy()
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn load_nodeset(
+        &mut self,
+        file_path: &str,
+        docs_path: Option<&str>,
+    ) -> Result<(), CodeGenError> {
+        let nodeset = NodeSetInput::load(&self.root_path, file_path, docs_path)?;
+        let idx = self.nodesets.insert(nodeset.uri.clone(), nodeset);
+        self.nodesets.add_file_aliases(file_path, idx);
+        Ok(())
+    }
+
+    pub fn load_binary_schema(&mut self, file_path: &str) -> Result<(), CodeGenError> {
+        let schema = BinarySchemaInput::load(&self.root_path, file_path)?;
+        let idx = self.binary_schemas.insert(schema.namespace.clone(), schema);
+        self.binary_schemas.add_file_aliases(file_path, idx);
+        Ok(())
+    }
+
+    pub fn load_xml_schema(&mut self, file_path: &str) -> Result<(), CodeGenError> {
+        let schema = XmlSchemaInput::load(&self.root_path, file_path)?;
+        let idx = self.xml_schemas.insert(schema.namespace.clone(), schema);
+        self.xml_schemas.add_file_aliases(file_path, idx);
+        Ok(())
+    }
+
+    pub fn get_nodeset(&self, key: &str) -> Result<&NodeSetInput, CodeGenError> {
+        self.nodesets.get(key).ok_or_else(|| {
+            CodeGenError::other(format!("Missing required nodeset with key {}", key))
+        })
+    }
+
+    pub fn get_binary_schema(&self, key: &str) -> Result<&BinarySchemaInput, CodeGenError> {
+        self.binary_schemas.get(key).ok_or_else(|| {
+            CodeGenError::other(format!("Missing required binary schema with key {}", key))
+        })
+    }
+
+    pub fn get_xml_schema(&self, key: &str) -> Result<&XmlSchemaInput, CodeGenError> {
+        self.xml_schemas.get(key).ok_or_else(|| {
+            CodeGenError::other(format!("Missing required xml schema with key {}", key))
+        })
+    }
+}

--- a/async-opcua-codegen/src/input/nodeset.rs
+++ b/async-opcua-codegen/src/input/nodeset.rs
@@ -1,0 +1,171 @@
+use std::collections::{HashMap, HashSet};
+
+use opcua_xml::{
+    load_nodeset2_file,
+    schema::{opc_ua_types::Variant, ua_node_set::UANodeSet},
+    XmlElement,
+};
+
+use crate::CodeGenError;
+
+use super::SchemaCache;
+
+pub struct NodeSetInput {
+    pub xml: UANodeSet,
+    pub aliases: HashMap<String, String>,
+    pub uri: String,
+    pub required_model_uris: Vec<String>,
+    /// Map from numeric ID to documentation link.
+    pub documentation: Option<HashMap<i64, String>>,
+    pub referenced_xsd_schemas: HashSet<String>,
+    pub path: String,
+}
+
+impl NodeSetInput {
+    fn find_referenced_xsd_schemas_rec(obj: &XmlElement, map: &mut HashSet<String>) {
+        if let Some(attr) = obj.attributes.get("xmlns") {
+            map.insert(attr.clone());
+        }
+        if let Some(attr) = obj.attributes.get("xmlns:uax") {
+            map.insert(attr.clone());
+        }
+        for child in obj.children.values() {
+            for child in child {
+                Self::find_referenced_xsd_schemas_rec(child, map);
+            }
+        }
+    }
+
+    fn find_referenced_xsd_schemas_variant(variant: &Variant, map: &mut HashSet<String>) {
+        match variant {
+            opcua_xml::schema::opc_ua_types::Variant::ExtensionObject(obj) => {
+                if let Some(body) = obj.body.as_ref().and_then(|b| b.data.as_ref()) {
+                    Self::find_referenced_xsd_schemas_rec(body, map);
+                }
+            }
+            opcua_xml::schema::opc_ua_types::Variant::ListOfExtensionObject(objs) => {
+                for obj in objs {
+                    if let Some(body) = obj.body.as_ref().and_then(|b| b.data.as_ref()) {
+                        Self::find_referenced_xsd_schemas_rec(body, map);
+                    }
+                }
+            }
+            opcua_xml::schema::opc_ua_types::Variant::Variant(variant) => {
+                Self::find_referenced_xsd_schemas_variant(variant, map);
+            }
+            _ => (),
+        }
+    }
+
+    fn find_referenced_xsd_schemas(node_set: &UANodeSet) -> HashSet<String> {
+        // Recursively look through all values to find which XSD schemas are referenced,
+        // since this isn't reported anywhere centrally.
+        let mut res = HashSet::new();
+        for node in &node_set.nodes {
+            let value = match node {
+                opcua_xml::schema::ua_node_set::UANode::Variable(v) => v.value.as_ref(),
+                opcua_xml::schema::ua_node_set::UANode::VariableType(v) => v.value.as_ref(),
+                _ => continue,
+            };
+            let Some(value) = value else {
+                continue;
+            };
+            Self::find_referenced_xsd_schemas_variant(&value.0, &mut res);
+        }
+        res
+    }
+
+    pub fn parse(data: &str, path: &str, docs: Option<&str>) -> Result<Self, CodeGenError> {
+        let nodeset = load_nodeset2_file(data)?;
+
+        let Some(nodeset) = nodeset.node_set else {
+            return Err(CodeGenError::missing_required_value("NodeSet"));
+        };
+        let aliases = nodeset.aliases.as_ref().map(|a| {
+            a.aliases
+                .iter()
+                .map(|a| (a.alias.clone(), a.id.0.clone()))
+                .collect::<HashMap<_, _>>()
+        });
+        let Some(models) = nodeset.models.as_ref() else {
+            return Err(CodeGenError::missing_required_value("Models"));
+        };
+
+        if models.models.len() > 1 {
+            println!("Warning, multiple models found in nodeset file, this is not supported, and only the first will be used.");
+        }
+
+        let Some(model) = models.models.first() else {
+            return Err(CodeGenError::other("No model in model table"));
+        };
+
+        let required_model_uris = model
+            .required_model
+            .iter()
+            .map(|v| v.model_uri.clone())
+            .collect();
+
+        println!(
+            "Loaded nodeset {} with {} nodes",
+            model.model_uri,
+            nodeset.nodes.len(),
+        );
+
+        let documentation = if let Some(docs) = docs {
+            let mut res = HashMap::new();
+            for line in docs.lines() {
+                let vals: Vec<_> = line.split(',').collect();
+                if vals.len() >= 3 {
+                    res.insert(vals[0].parse()?, vals[2].to_owned());
+                } else {
+                    return Err(CodeGenError::other(format!(
+                        "CSV file is on incorrect format. Expected at least three columns, got {}",
+                        vals.len()
+                    )));
+                }
+            }
+            Some(res)
+        } else {
+            None
+        };
+
+        let xsd_uris = Self::find_referenced_xsd_schemas(&nodeset);
+
+        Ok(Self {
+            uri: model.model_uri.clone(),
+            xml: nodeset,
+            aliases: aliases.unwrap_or_default(),
+            required_model_uris,
+            documentation,
+            referenced_xsd_schemas: xsd_uris,
+            path: path.to_owned(),
+        })
+    }
+
+    pub fn load(
+        root_path: &str,
+        file_path: &str,
+        docs_path: Option<&str>,
+    ) -> Result<Self, CodeGenError> {
+        let data = std::fs::read_to_string(format!("{}/{}", root_path, file_path))
+            .map_err(|e| CodeGenError::io(&format!("Failed to read file {}", file_path), e))?;
+        let docs = docs_path
+            .map(|p| {
+                std::fs::read_to_string(format!("{}/{}", root_path, p))
+                    .map_err(|e| CodeGenError::io(&format!("Failed to read file {}", p), e))
+            })
+            .transpose()?;
+        Self::parse(&data, file_path, docs.as_deref()).map_err(|e| e.in_file(file_path))
+    }
+
+    pub fn validate(&self, cache: &SchemaCache) -> Result<(), CodeGenError> {
+        for uri in &self.required_model_uris {
+            cache.get_nodeset(uri)?;
+        }
+        for uri in &self.referenced_xsd_schemas {
+            cache.get_xml_schema(uri)?;
+        }
+
+        Ok(())
+    }
+}

--- a/async-opcua-codegen/src/input/xml_schema.rs
+++ b/async-opcua-codegen/src/input/xml_schema.rs
@@ -1,0 +1,29 @@
+use opcua_xml::{load_xsd_schema, schema::xml_schema::XmlSchema};
+
+use crate::CodeGenError;
+
+pub struct XmlSchemaInput {
+    pub xml: XmlSchema,
+    pub namespace: String,
+    pub path: String,
+}
+
+impl XmlSchemaInput {
+    pub fn parse(data: &str, path: &str) -> Result<Self, CodeGenError> {
+        let xml = load_xsd_schema(data)?;
+        Ok(Self {
+            namespace: xml
+                .target_namespace
+                .clone()
+                .ok_or_else(|| CodeGenError::missing_required_value("targetNamespace"))?,
+            xml,
+            path: path.to_owned(),
+        })
+    }
+
+    pub fn load(root_path: &str, file_path: &str) -> Result<Self, CodeGenError> {
+        let data = std::fs::read_to_string(format!("{}/{}", root_path, file_path))
+            .map_err(|e| CodeGenError::io(&format!("Failed to read file {}", file_path), e))?;
+        Self::parse(&data, file_path)
+    }
+}

--- a/async-opcua-xml/src/schema/ua_node_set.rs
+++ b/async-opcua-xml/src/schema/ua_node_set.rs
@@ -374,7 +374,7 @@ macro_rules! value_wrapper {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Description of a model contained in a nodeset file.
 pub struct ModelTableEntry {
     /// Role permissions that apply to this entry.
@@ -405,7 +405,7 @@ impl<'input> XmlLoad<'input> for ModelTableEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Table containing models defined in a nodeset file.
 pub struct ModelTable {
     /// List of models.
@@ -551,7 +551,7 @@ impl<'input> XmlLoad<'input> for ListOfReferences {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Role permission for a node.
 pub struct RolePermission {
     /// Role ID.
@@ -569,7 +569,7 @@ impl<'input> XmlLoad<'input> for RolePermission {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// List of role permissions.
 pub struct ListOfRolePermissions {
     /// Role permissions.

--- a/async-opcua-xml/src/schema/xml_schema.rs
+++ b/async-opcua-xml/src/schema/xml_schema.rs
@@ -21,7 +21,7 @@ pub fn load_xsd_schema(document: &str) -> Result<XmlSchema, XmlError> {
     first_child_with_name(&root, "schema")
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Value of a Facet node.
 pub struct FacetValue {
     /// Facet value.
@@ -39,7 +39,7 @@ impl<'input> XmlLoad<'input> for FacetValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A restriction facet.
 pub enum Facet {
     /// Exclusive minimum of the type value.
@@ -88,7 +88,7 @@ impl<'input> XmlLoad<'input> for Option<Facet> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A restriction is a property of a type that limits valid values.
 pub struct Restriction {
     /// Inherit from some other type.
@@ -115,7 +115,7 @@ impl<'input> XmlLoad<'input> for Restriction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// List of values.
 pub struct List {
     /// Inner type.
@@ -133,7 +133,7 @@ impl<'input> XmlLoad<'input> for List {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Discriminated union of different variants.
 pub struct Union {
     /// Possible variants.
@@ -151,7 +151,7 @@ impl<'input> XmlLoad<'input> for Union {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Simple derivation.
 pub enum SimpleDerivation {
     /// Restriction type.
@@ -173,7 +173,7 @@ impl<'input> XmlLoad<'input> for Option<SimpleDerivation> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A simple type.
 pub struct SimpleType {
     /// Type name.
@@ -191,7 +191,7 @@ impl<'input> XmlLoad<'input> for SimpleType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// The Any type.
 pub struct Any {
     /// Minimum number of times this field occurs.
@@ -210,6 +210,7 @@ impl<'input> XmlLoad<'input> for Any {
 }
 
 /// Particle, some element of the schema.
+#[derive(Debug, Clone)]
 pub enum Particle {
     /// General element.
     Element(Element),
@@ -236,7 +237,7 @@ impl<'input> XmlLoad<'input> for Option<Particle> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A variant of particle that can occur inside another object.
 pub enum NestedParticle {
     /// Element type
@@ -261,7 +262,7 @@ impl<'input> XmlLoad<'input> for Option<NestedParticle> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A group of multiple particles.
 pub struct Group {
     /// Particles in the group.
@@ -282,7 +283,7 @@ impl<'input> XmlLoad<'input> for Group {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Type definition particle.
 pub enum TypeDefParticle {
     /// All elements of the group must hold.
@@ -304,7 +305,7 @@ impl<'input> XmlLoad<'input> for Option<TypeDefParticle> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A type that extends another type.
 pub struct Extension {
     /// Extension content.
@@ -325,7 +326,7 @@ impl<'input> XmlLoad<'input> for Extension {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Content of a simple type.
 pub enum SimpleContent {
     /// Restriction of some other type.
@@ -344,7 +345,7 @@ impl<'input> XmlLoad<'input> for Option<SimpleContent> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Complex restriction variant.
 pub struct ComplexRestriction {
     /// Inner base restriction.
@@ -362,7 +363,7 @@ impl<'input> XmlLoad<'input> for ComplexRestriction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Content of a complex type.
 pub enum ComplexContent {
     /// Complex restriction of some other type.
@@ -381,7 +382,7 @@ impl<'input> XmlLoad<'input> for Option<ComplexContent> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Possible contents of a complex type.
 pub enum ComplexTypeContents {
     /// Simple content.
@@ -408,7 +409,7 @@ impl<'input> XmlLoad<'input> for Option<ComplexTypeContents> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A complex structure.
 pub struct ComplexType {
     /// Complex type contents.
@@ -432,7 +433,7 @@ impl<'input> XmlLoad<'input> for ComplexType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Contents of an element.
 pub enum ElementContents {
     /// A simple type.
@@ -451,7 +452,7 @@ impl<'input> XmlLoad<'input> for Option<ElementContents> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Maximum number of occurences of something.
 pub enum MaxOccurs {
     /// A specific number.
@@ -470,7 +471,7 @@ impl FromValue for MaxOccurs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Legal uses of an attribute.
 pub enum AttributeUse {
     /// Attribute cannot be used.
@@ -495,7 +496,7 @@ impl FromValue for AttributeUse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Definition of an attribute on a type.
 pub struct Attribute {
     /// Attribute content.
@@ -525,7 +526,7 @@ impl<'input> XmlLoad<'input> for Attribute {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Attribute declaration wrapper.
 pub struct AttrDecls {
     /// Attributes in declaration.
@@ -540,7 +541,7 @@ impl<'input> XmlLoad<'input> for AttrDecls {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Element, representing some part of a type.
 pub struct Element {
     /// Element type.

--- a/code_gen_config.yml
+++ b/code_gen_config.yml
@@ -4,7 +4,7 @@ extra_header: |
   // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 targets:
   - type: types
-    file_path: schemas/1.05/Opc.Ua.Types.bsd
+    file: Opc.Ua.Types.bsd
     output_dir: async-opcua-types/src/generated/types
     enums_single_file: true
     types_import_map:
@@ -25,14 +25,14 @@ targets:
       - AnonymousIdentityToken
       - HistoryUpdateType
   - type: nodes
-    file_path: schemas/1.05/Opc.Ua.NodeSet2.xml
+    file: Opc.Ua.NodeSet2.xml
     output_dir: async-opcua-core-namespace/src/generated
     max_nodes_per_file: 100
     extra_header: |
       #[allow(unused)]
       mod opcua { pub use opcua_types as types; pub use opcua_nodes as nodes; }
     types:
-      - file_path: schemas/1.05/Opc.Ua.Types.xsd
+      - file: Opc.Ua.Types.xsd
         root_path: opcua::types
     own_namespaces:
       - "http://opcfoundation.org/UA/"
@@ -50,3 +50,8 @@ targets:
     extra_header: |
       mod opcua { pub use crate as types; }
     output_file: async-opcua-types/src/generated/node_ids.rs
+
+sources:
+  - schemas/1.05/Opc.Ua.Types.bsd
+  - schemas/1.05/Opc.Ua.NodeSet2.xml
+  - schemas/1.05/Opc.Ua.Types.xsd

--- a/samples/custom-codegen/code_gen_config.yml
+++ b/samples/custom-codegen/code_gen_config.yml
@@ -4,7 +4,7 @@ extra_header: |
   // Copyright (C) 2017-2024 Einar Omang
 targets:
   - type: types
-    file_path: schema/Opc.Ua.Pn.Types.bsd
+    file: Opc.Ua.Pn.Types.bsd
     output_dir: src/generated/types
     enums_single_file: true
     structs_single_file: true
@@ -12,13 +12,13 @@ targets:
       #![allow(non_camel_case_types)]
       #![allow(clippy::upper_case_acronyms)]
   - type: nodes
-    file_path: schema/Opc.Ua.Pn.NodeSet2.xml
+    file: Opc.Ua.Pn.NodeSet2.xml
     output_dir: src/generated/nodeset
     max_nodes_per_file: 100
     types:
-      - file_path: schema/Opc.Ua.Pn.Types.xsd
+      - file: Opc.Ua.Pn.Types.xsd
         root_path: crate::generated::types
-      - file_path: ../../schemas/1.05/Opc.Ua.Types.xsd
+      - file: Opc.Ua.Types.xsd
         root_path: opcua::types
     own_namespaces:
       - "http://opcfoundation.org/UA/PROFINET/"
@@ -28,7 +28,7 @@ targets:
     events:
       output_dir: src/generated/events
       dependent_nodesets:
-        - path: ../../schemas/1.05/Opc.Ua.NodeSet2.xml
+        - file: Opc.Ua.NodeSet2.xml
           import_path: "opcua::core_namespace::events::"
       extra_header: |
         #[allow(unused)]
@@ -39,3 +39,8 @@ targets:
   - type: ids
     file_path: schema/Opc.Ua.Pn.NodeIds.csv
     output_file: src/generated/node_ids.rs
+
+sources:
+  - schema
+  - ../../schemas/1.05/Opc.Ua.Types.xsd
+  - ../../schemas/1.05/Opc.Ua.NodeSet2.xml


### PR DESCRIPTION
Add a centralized schema cache when doing code generation, to avoid loading the same schema twice.

This is not really a big improvement yet, but it's increasingly necessary. It also now helps by automatically identifying dependent nodesets, it also makes it easier to name the schemas, and may help us simplify future code gen config.

Note that as intended, nothing has changed in the generated code.