### PR TITLE
Fix client docs and export SessionBuilder

### DIFF
--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -129,8 +129,8 @@ pub use retry::{ExponentialBackoff, SessionRetryPolicy};
 pub use session::{
     Client, DataChangeCallback, DefaultRetryPolicy, EventCallback, HistoryReadAction,
     HistoryUpdateAction, MonitoredItem, OnSubscriptionNotification, RequestRetryPolicy, Session,
-    SessionActivity, SessionConnectMode, SessionEventLoop, SessionPollResult, Subscription,
-    SubscriptionActivity, SubscriptionCallbacks, UARequest,
+    SessionActivity, SessionBuilder, SessionConnectMode, SessionEventLoop, SessionPollResult,
+    Subscription, SubscriptionActivity, SubscriptionCallbacks, UARequest,
 };
 pub use transport::AsyncSecureChannel;
 

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -45,6 +45,7 @@ use std::time::{Duration, Instant};
 use arc_swap::ArcSwap;
 pub use client::Client;
 pub use connect::SessionConnectMode;
+pub use connection::SessionBuilder;
 pub use event_loop::{SessionActivity, SessionEventLoop, SessionPollResult};
 use log::{error, info};
 use opcua_core::handle::AtomicHandle;

--- a/docs/client.md
+++ b/docs/client.md
@@ -188,7 +188,7 @@ async fn main() {
     ).into();
 
     // Create the session
-    let (session, event_loop) = client.new_session_from_endpoint(endpoint, IdentityToken::Anonymous).await.unwrap();
+    let (session, event_loop) = client.connect_to_matching_endpoint(endpoint, IdentityToken::Anonymous).await.unwrap();
 
     // Spawn the event loop on a tokio task.
     let mut handle = event_loop.spawn();


### PR DESCRIPTION
The method has a different name now, and I noticed SessionBuilder was missing from the generated docs.