### PR TITLE
More types codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +143,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "env_logger",
+ "env_logger 0.10.2",
  "log",
  "serde_json",
  "tempdir",
@@ -147,6 +197,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "convert_case",
+ "env_logger 0.11.7",
  "log",
  "pathdiff",
  "prettyplease",
@@ -157,7 +208,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn 2.0.96",
+ "syn 2.0.100",
  "thiserror",
  "uuid",
 ]
@@ -260,7 +311,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "uuid",
 ]
 
@@ -375,7 +426,7 @@ checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -526,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,7 +671,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -625,7 +682,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -649,7 +706,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -699,7 +756,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -726,6 +783,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +803,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -877,7 +957,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1158,7 +1238,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1232,10 +1312,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "jobserver"
@@ -1562,6 +1672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,7 +1721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1616,7 +1741,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "version_check",
  "yansi",
 ]
@@ -1978,7 +2103,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2029,7 +2154,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2167,7 +2292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2278,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,7 +2420,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2334,7 +2459,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2406,7 +2531,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2435,7 +2560,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2548,6 +2673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,7 +2756,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2647,7 +2778,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2832,7 +2963,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2854,7 +2985,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2874,7 +3005,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2895,7 +3026,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2917,5 +3048,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]

--- a/async-opcua-codegen/Cargo.toml
+++ b/async-opcua-codegen/Cargo.toml
@@ -18,6 +18,7 @@ name = "opcua_codegen"
 base64 = "0.22.1"
 chrono = "0.4.38"
 convert_case = "0.6.0"
+env_logger = "0.11.7"
 log = { workspace = true }
 pathdiff = "0.2.3"
 prettyplease = "0.2.20"

--- a/async-opcua-codegen/src/input/mod.rs
+++ b/async-opcua-codegen/src/input/mod.rs
@@ -10,7 +10,7 @@ mod nodeset;
 mod xml_schema;
 
 pub use binary_schema::BinarySchemaInput;
-pub use nodeset::{NodeSetInput, TypeInfo};
+pub use nodeset::{NodeSetInput, RawEncodingIds, TypeInfo};
 pub use xml_schema::XmlSchemaInput;
 
 struct SchemaCacheInst<T> {

--- a/async-opcua-codegen/src/lib.rs
+++ b/async-opcua-codegen/src/lib.rs
@@ -142,7 +142,7 @@ pub fn run_codegen(config: &CodeGenConfig, root_path: &str) -> Result<(), CodeGe
                 for (name, typ) in t.types_import_map.iter() {
                     if typ.add_to_type_loader {
                         object_ids.push((
-                            EncodingIds::new(id_path.clone(), name),
+                            EncodingIds::new_external(&id_path, name, typ)?,
                             format!("{}::{}", typ.path, name),
                         ));
                     }
@@ -249,6 +249,8 @@ pub struct TypeCodeGenTarget {
     pub extra_header: String,
     #[serde(default = "defaults::id_path")]
     pub id_path: String,
+    #[serde(default)]
+    pub node_ids_from_nodeset: bool,
 }
 
 mod defaults {

--- a/async-opcua-codegen/src/main.rs
+++ b/async-opcua-codegen/src/main.rs
@@ -6,6 +6,7 @@ fn main() -> Result<(), CodeGenError> {
 
 fn run_cli() -> Result<(), CodeGenError> {
     let mut args = std::env::args();
+    env_logger::init();
 
     if args.len() != 2 {
         println!(

--- a/async-opcua-codegen/src/types/base_constants.rs
+++ b/async-opcua-codegen/src/types/base_constants.rs
@@ -42,6 +42,14 @@ pub fn base_ignored_types() -> HashSet<String> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExternalIds {
+    pub binary: Option<String>,
+    pub xml: Option<String>,
+    pub json: Option<String>,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExternalType {
     /// Relative path in the OPC-UA types library.
     pub path: String,
@@ -52,6 +60,7 @@ pub struct ExternalType {
     /// Add to type loader impl
     #[serde(default)]
     pub add_to_type_loader: bool,
+    pub ids: Option<ExternalIds>,
 }
 
 impl ExternalType {
@@ -61,6 +70,7 @@ impl ExternalType {
             has_default: Some(has_default),
             base_type: None,
             add_to_type_loader: false,
+            ids: None,
         }
     }
 }

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -93,6 +93,7 @@ fn generate_types_inner(
             structs_single_file: target.structs_single_file,
         },
         target_namespace.clone(),
+        target.id_path.clone(),
     );
 
     Ok((generator.generate_types()?, target_namespace))
@@ -172,10 +173,11 @@ fn binary_loader_impl(
         let dt_ident = &ids.data_type;
         let enc_ident = &ids.binary;
         let typ_path: Path = parse_str(typ).unwrap();
+        let id_path = &ids.id_path;
         fields.extend(quote! {
             inst.add_binary_type(
-                crate::DataTypeId::#dt_ident as u32,
-                crate::ObjectId::#enc_ident as u32,
+                #id_path::DataTypeId::#dt_ident as u32,
+                #id_path::ObjectId::#enc_ident as u32,
                 opcua::types::binary_decode_to_enc::<#typ_path>
             );
         });
@@ -225,10 +227,11 @@ fn json_loader_impl(ids: &[&(EncodingIds, String)], namespace: &str) -> (TokenSt
         let dt_ident = &ids.data_type;
         let enc_ident = &ids.json;
         let typ_path: Path = parse_str(typ).unwrap();
+        let id_path = &ids.id_path;
         fields.extend(quote! {
             inst.add_json_type(
-                crate::DataTypeId::#dt_ident as u32,
-                crate::ObjectId::#enc_ident as u32,
+                #id_path::DataTypeId::#dt_ident as u32,
+                #id_path::ObjectId::#enc_ident as u32,
                 opcua::types::json_decode_to_enc::<#typ_path>
             );
         });
@@ -279,10 +282,11 @@ fn xml_loader_impl(ids: &[&(EncodingIds, String)], namespace: &str) -> (TokenStr
         let dt_ident = &ids.data_type;
         let enc_ident = &ids.xml;
         let typ_path: Path = parse_str(typ).unwrap();
+        let id_path = &ids.id_path;
         fields.extend(quote! {
             inst.add_xml_type(
-                crate::DataTypeId::#dt_ident as u32,
-                crate::ObjectId::#enc_ident as u32,
+                #id_path::DataTypeId::#dt_ident as u32,
+                #id_path::ObjectId::#enc_ident as u32,
                 opcua::types::xml_decode_to_enc::<#typ_path>
             );
         });

--- a/async-opcua-codegen/src/types/structure.rs
+++ b/async-opcua-codegen/src/types/structure.rs
@@ -1,10 +1,12 @@
-#[derive(serde::Serialize, Debug)]
+use crate::{input::RawEncodingIds, utils::ParsedNodeId};
+
+#[derive(Debug)]
 pub enum StructureFieldType {
     Field(FieldType),
     Array(FieldType),
 }
 
-#[derive(serde::Serialize, Debug)]
+#[derive(Debug)]
 pub struct StructureField {
     pub name: String,
     pub original_name: String,
@@ -12,25 +14,26 @@ pub struct StructureField {
     pub documentation: Option<String>,
 }
 
-#[derive(serde::Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum FieldType {
     Abstract(String),
-    ExtensionObject,
+    ExtensionObject(Option<RawEncodingIds>),
     Normal(String),
 }
 
 impl FieldType {
     pub fn as_type_str(&self) -> &str {
         match self {
-            FieldType::Abstract(_) | FieldType::ExtensionObject => "ExtensionObject",
+            FieldType::Abstract(_) | FieldType::ExtensionObject(_) => "ExtensionObject",
             FieldType::Normal(s) => s,
         }
     }
 }
 
-#[derive(serde::Serialize, Debug)]
+#[derive(Debug)]
 pub struct StructuredType {
     pub name: String,
+    pub id: Option<ParsedNodeId>,
     pub fields: Vec<StructureField>,
     pub hidden_fields: Vec<String>,
     pub documentation: Option<String>,

--- a/async-opcua-codegen/src/utils.rs
+++ b/async-opcua-codegen/src/utils.rs
@@ -59,8 +59,11 @@ where
 pub fn safe_ident(val: &str) -> (Ident, bool) {
     let mut val = val.to_string();
     let mut changed = false;
-    if val.starts_with(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']) || val == "type" {
-        val = format!("__{val}");
+    if val.starts_with(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+        || val == "type"
+        || val.contains(['/'])
+    {
+        val = format!("__{}", val.replace(['/'], "_"));
         changed = true;
     }
 

--- a/async-opcua-types/src/expanded_node_id.rs
+++ b/async-opcua-types/src/expanded_node_id.rs
@@ -426,11 +426,14 @@ impl From<(NodeId, u32)> for ExpandedNodeId {
     }
 }
 
-impl From<(NodeId, &str)> for ExpandedNodeId {
-    fn from(v: (NodeId, &str)) -> Self {
+impl<T> From<(T, &str)> for ExpandedNodeId
+where
+    T: Into<NodeId>,
+{
+    fn from(value: (T, &str)) -> Self {
         ExpandedNodeId {
-            node_id: v.0,
-            namespace_uri: v.1.into(),
+            node_id: value.0.into(),
+            namespace_uri: value.1.into(),
             server_index: 0,
         }
     }

--- a/async-opcua-types/src/node_id.rs
+++ b/async-opcua-types/src/node_id.rs
@@ -530,6 +530,36 @@ impl FromStr for NodeId {
     }
 }
 
+impl<'a> From<&'a str> for NodeId {
+    fn from(value: &'a str) -> Self {
+        (0u16, value).into()
+    }
+}
+
+impl From<UAString> for NodeId {
+    fn from(value: UAString) -> Self {
+        (0u16, value).into()
+    }
+}
+
+impl From<u32> for NodeId {
+    fn from(value: u32) -> Self {
+        (0, value).into()
+    }
+}
+
+impl From<Guid> for NodeId {
+    fn from(value: Guid) -> Self {
+        (0, value).into()
+    }
+}
+
+impl From<ByteString> for NodeId {
+    fn from(value: ByteString) -> Self {
+        (0, value).into()
+    }
+}
+
 impl From<&NodeId> for NodeId {
     fn from(v: &NodeId) -> Self {
         v.clone()


### PR DESCRIPTION
The primary thing this PR does is allow users to generate types without having a valid ID enum, as well as let them pick a custom path to their ID enums.

This is necessary because some companion standards don't have full (or valid) ID CSVs, and some don't set encoding IDs for all three encodings, which we currently require with the enum-based approach.

We don't need this for our codegen, so this isn't used in either codegen setup we have right now (the enum approach is preferable as it is more obviously correct).

Next up for me is probably a cleanup of the codegen codebase, it's a bit of a mess and keeps getting worse as new features are added on. I also want to move to using `log` everywhere. (I added a logger crate in this PR as part of debugging, since I have used the log crate some places, for warnings and the like).

I've verified that this works with AutoID (which was the standard that wasn't possible to generate before). There are some minor issues related to opaque types, which I see now that we are lacking a proper story for.

While working on this I also fixed two bugs:

 - Use `SymbolicName` when it is present on data type fields, instead of just the name.
 - Replace `/` in names.