### PR TITLE
Handle zero-padding in legacy encrypted token secrets

### DIFF
--- a/async-opcua-crypto/src/user_identity.rs
+++ b/async-opcua-crypto/src/user_identity.rs
@@ -190,9 +190,11 @@ pub fn legacy_password_decrypt(
              * zeroes according to the 1.04.1 specification errata, chapter 3.
              */
             if !padding_bytes.iter().all(|&x| x == 0) {
-                return Err(Error::decoding("Non-zero padding bytes in decrypted password"));
+                return Err(Error::decoding(
+                    "Non-zero padding bytes in decrypted password",
+                ));
             } else {
-                dst = dst[..plaintext_size + 4].to_vec();
+                dst.truncate(plaintext_size + 4);
                 actual_size = dst.len();
             }
         }


### PR DESCRIPTION
First of all thanks for the work you put into the library, it's been a pleasure working with it.

While investigating interop issues between async-opcua server and legacy application client that uses open62541 when using `SignAndEncrypt` security mode, I discovered that open62541 pads token secret with zero bytes before encrypting, while async-opcua does not account for this when decrypting.

[Relevant section ](https://github.com/open62541/open62541/blob/cae846b1e4504af6ee4953a131bb5fe96eaf38af/src/client/ua_client_connect.c#L283C1-L292) in open62541 code (where I took comments from).

This PR adds a check for such padding and trims it before proceeding with password extraction, which makes server compatible with clients that do padding before secret encryption.