### PR TITLE
Use log for logging in codegen

### DIFF
--- a/async-opcua-codegen/src/input/nodeset.rs
+++ b/async-opcua-codegen/src/input/nodeset.rs
@@ -3,7 +3,7 @@ use std::{
     sync::OnceLock,
 };
 
-use log::warn;
+use log::{info, warn};
 use opcua_xml::{
     load_nodeset2_file,
     schema::{
@@ -142,7 +142,7 @@ impl NodeSetInput {
         };
 
         if models.models.len() > 1 {
-            println!("Warning, multiple models found in nodeset file, this is not supported, and only the first will be used.");
+            warn!("Multiple models found in nodeset file, this is not supported, and only the first will be used.");
         }
 
         let Some(model) = models.models.first() else {
@@ -155,7 +155,7 @@ impl NodeSetInput {
             .map(|v| v.model_uri.clone())
             .collect();
 
-        println!(
+        info!(
             "Loaded nodeset {} with {} nodes",
             model.model_uri,
             nodeset.nodes.len(),
@@ -308,7 +308,7 @@ impl NodeSetInput {
                     let id = ParsedNodeId::parse(self.resolve_alias(&object.base.base.node_id.0))?;
                     known_encoding_nodes.insert(id.clone(), kind);
                     let Some(encodes) = encodes else {
-                        println!("{id:?} is missing an inverse encoding ref");
+                        warn!("{id:?} is missing an inverse encoding ref");
                         continue;
                     };
 

--- a/async-opcua-codegen/src/main.rs
+++ b/async-opcua-codegen/src/main.rs
@@ -1,3 +1,4 @@
+use env_logger::Env;
 use opcua_codegen::{run_codegen, CodeGenConfig, CodeGenError};
 
 fn main() -> Result<(), CodeGenError> {
@@ -6,9 +7,10 @@ fn main() -> Result<(), CodeGenError> {
 
 fn run_cli() -> Result<(), CodeGenError> {
     let mut args = std::env::args();
-    env_logger::init();
+    env_logger::init_from_env(Env::new().filter_or("RUST_OPCUA_LOG", "debug"));
 
     if args.len() != 2 {
+        // Deliberately println instead of using the logger.
         println!(
             r#"Usage:
 async-opcua-codegen [config].yml

--- a/async-opcua-codegen/src/nodeset/mod.rs
+++ b/async-opcua-codegen/src/nodeset/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 pub use events::generate_events;
 pub use gen::{NodeGenMethod, NodeSetCodeGenerator};
+use log::info;
 use opcua_xml::schema::{
     ua_node_set::UANodeSet,
     xml_schema::{XsdFileItem, XsdFileType},
@@ -164,7 +165,7 @@ pub fn generate_target(
         );
     }
     fns.sort_by(|a, b| a.name.cmp(&b.name));
-    println!("Generated {} node creation methods", fns.len());
+    info!("Generated {} node creation methods", fns.len());
 
     let iter = fns.into_iter();
 

--- a/async-opcua-codegen/src/nodeset/value.rs
+++ b/async-opcua-codegen/src/nodeset/value.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use convert_case::{Case, Casing};
+use log::warn;
 use opcua_xml::schema::{
     opc_ua_types::{ExtensionObject, Variant, XmlElement},
     ua_node_set::Value,
@@ -123,7 +124,7 @@ impl<'a> ValueBuilder<'a> {
                 }
             }
             Variant::XmlElement(_) | Variant::ListOfXmlElement(_) => {
-                println!("XmlElement not yet supported in codegen");
+                warn!("XmlElement not yet supported in codegen");
                 return Ok(quote::quote! {
                     opcua::types::Variant::Empty
                 });

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -9,6 +9,7 @@ pub use base_constants::*;
 pub use enum_type::{EnumType, EnumValue};
 pub use gen::{CodeGenItemConfig, CodeGenerator, EncodingIds, GeneratedItem, ItemDefinition};
 pub use loader::{BsdTypeLoader, LoadedType, LoadedTypes};
+use log::info;
 use proc_macro2::TokenStream;
 use quote::quote;
 pub use structure::{StructureField, StructureFieldType, StructuredType};
@@ -27,7 +28,7 @@ pub fn generate_types(
         return Err(CodeGenError::other("Invalid config. node_ids_from_nodeset is not valid when using a BSD file for code generation."));
     }
 
-    println!(
+    info!(
         "Found {} raw elements in the type dictionary.",
         input.xml.elements.len()
     );
@@ -43,7 +44,7 @@ pub fn generate_types(
     )?;
     let target_namespace = type_loader.target_namespace();
     let types = type_loader.from_bsd().map_err(|e| e.in_file(&input.path))?;
-    println!("Loaded {} types", types.len());
+    info!("Loaded {} types", types.len());
 
     generate_types_inner(target, target_namespace, types)
 }
@@ -67,7 +68,7 @@ pub fn generate_types_nodeset(
     );
     let target_namespace = input.uri.clone();
     let types = type_loader.load_types(cache)?;
-    println!("Loaded {} types", types.len());
+    info!("Loaded {} types", types.len());
 
     generate_types_inner(target, target_namespace, types)
 }


### PR DESCRIPTION
Also set the log level to debug by default. Users can override it if they want, but for must usage we just want all the logs always.

There isn't a ton of logging yet, but we should standardize on using `log` for everything.