### PR TITLE
Make fuzz targets build without the nightly feature

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,13 @@
+# Fuzzing async-opcua
+
+We have a few basic fuzz targets, more are welcome.
+
+In order to have the fuzz targets be part of the workspace, and still compile normally, we require a feature `nightly`.
+
+To run the fuzz targets you will need to install [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) along with its dependencies.
+
+You will need a nightly compiler, `rustup default nightly`, then, run the fuzz target with
+
+```
+cargo fuzz run [TARGET] --features nightly
+```

--- a/fuzz/fuzz_targets/fuzz_comms.rs
+++ b/fuzz/fuzz_targets/fuzz_comms.rs
@@ -1,15 +1,17 @@
-#![no_main]
-#![cfg(feature = "nightly")]
+#![cfg_attr(feature = "nightly", no_main)]
 
-use libfuzzer_sys::fuzz_target;
+#[cfg(not(feature = "nightly"))]
+fn main() {
+    panic!("Fuzzing requires the nightly feature to be enabled.");
+}
 
-use bytes::BytesMut;
-use tokio_util::codec::Decoder;
+#[cfg(feature = "nightly")]
+libfuzzer_sys::fuzz_target!(|data: &[u8]| {
+    use bytes::BytesMut;
+    use tokio_util::codec::Decoder;
 
-use opcua::core::comms::tcp_codec::TcpCodec;
-use opcua::types::DecodingOptions;
-
-fuzz_target!(|data: &[u8]| {
+    use opcua::core::comms::tcp_codec::TcpCodec;
+    use opcua::types::DecodingOptions;
     // With some random data, just try and deserialize it
     let decoding_options = DecodingOptions::default();
     let mut codec = TcpCodec::new(decoding_options);

--- a/fuzz/fuzz_targets/fuzz_deserialize.rs
+++ b/fuzz/fuzz_targets/fuzz_deserialize.rs
@@ -1,18 +1,22 @@
-#![no_main]
-#![cfg(feature = "nightly")]
-use libfuzzer_sys::fuzz_target;
+#![cfg_attr(feature = "nightly", no_main)]
 
-use opcua::types::{BinaryDecodable, ContextOwned, Error, Variant};
-use std::io::Cursor;
-
-pub fn deserialize(data: &[u8]) -> Result<Variant, Error> {
-    // Decode this, don't expect panics or whatever
-    let mut stream = Cursor::new(data);
-    let ctx_f = ContextOwned::default();
-    Variant::decode(&mut stream, &ctx_f.context())
+#[cfg(not(feature = "nightly"))]
+fn main() {
+    panic!("Fuzzing requires the nightly feature to be enabled.");
 }
 
-fuzz_target!(|data: &[u8]| {
+#[cfg(feature = "nightly")]
+libfuzzer_sys::fuzz_target!(|data: &[u8]| {
+    use opcua::types::{BinaryDecodable, ContextOwned, Error, Variant};
+    use std::io::Cursor;
+
+    pub fn deserialize(data: &[u8]) -> Result<Variant, Error> {
+        // Decode this, don't expect panics or whatever
+        let mut stream = Cursor::new(data);
+        let ctx_f = ContextOwned::default();
+        Variant::decode(&mut stream, &ctx_f.context())
+    }
+
     // With some random data, just try and deserialize it. The deserialize should either return
     // a Variant or an error. It shouldn't panic.
     let _ = deserialize(data);


### PR DESCRIPTION
This was a workaround that didn't work that well. I don't love the solution, since it makes the code harder to read, but it works, and now you can run `cargo build` without it failing on master.