### PR TITLE
Use tracing instead of log in the library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,12 +182,12 @@ dependencies = [
  "chrono",
  "futures",
  "hashbrown 0.15.2",
- "log",
  "parking_lot",
  "rsa",
  "serde",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -199,7 +199,6 @@ dependencies = [
  "chrono",
  "convert_case",
  "env_logger 0.11.7",
- "log",
  "pathdiff",
  "prettyplease",
  "proc-macro2",
@@ -211,6 +210,7 @@ dependencies = [
  "serde_yaml",
  "syn 2.0.100",
  "thiserror",
+ "tracing",
  "uuid",
 ]
 
@@ -222,13 +222,13 @@ dependencies = [
  "async-opcua-types",
  "bytes",
  "chrono",
- "log",
  "parking_lot",
  "serde",
  "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
 ]
 
@@ -251,13 +251,13 @@ dependencies = [
  "const-oid",
  "gethostname",
  "hmac",
- "log",
  "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
  "sha2",
  "tempdir",
+ "tracing",
  "x509-cert",
 ]
 
@@ -339,9 +339,9 @@ dependencies = [
  "async-opcua-xml",
  "bitflags",
  "hashbrown 0.15.2",
- "log",
  "regex",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -361,13 +361,13 @@ dependencies = [
  "chrono",
  "futures",
  "hashbrown 0.15.2",
- "log",
  "parking_lot",
  "postcard",
  "regex",
  "serde",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -404,12 +404,12 @@ dependencies = [
  "byteorder",
  "chrono",
  "hashbrown 0.15.2",
- "log",
  "percent-encoding-rfc3986",
  "regex",
  "serde_json",
  "struson",
  "thiserror",
+ "tracing",
  "uuid",
 ]
 
@@ -2593,6 +2593,38 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ syn = { version = "^2", features = ["full"] }
 thiserror = "^1"
 tokio = { version = "^1", features = ["full"] }
 tokio-util = { version = "^0.7", features = ["codec"] }
+tracing = { version = "0.1.41", features = ["log"] }
 url = "^2"
 uuid = { version = "^1", features = ["v4"] }
 

--- a/async-opcua-client/Cargo.toml
+++ b/async-opcua-client/Cargo.toml
@@ -21,12 +21,12 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 hashbrown = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 rsa = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tracing = { workspace = true }
 
 async-opcua-core = { path = "../async-opcua-core", version = "0.14.0" }
 async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.14.0" }

--- a/async-opcua-client/src/builder.rs
+++ b/async-opcua-client/src/builder.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, time::Duration};
 
-use log::error;
 use opcua_core::config::{Config, ConfigError};
+use tracing::error;
 
 use super::{Client, ClientConfig, ClientEndpoint, ClientUserToken, ANONYMOUS_USER_TOKEN_ID};
 

--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -13,8 +13,8 @@ use std::{
 };
 
 use chrono::TimeDelta;
-use log::warn;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use opcua_core::config::Config;
 use opcua_crypto::SecurityPolicy;

--- a/async-opcua-client/src/custom_types/mod.rs
+++ b/async-opcua-client/src/custom_types/mod.rs
@@ -5,7 +5,6 @@
 use std::collections::{HashMap, HashSet};
 
 use futures::TryStreamExt;
-use log::warn;
 use opcua_types::{
     custom::{DataTypeTree, DataTypeVariant, EncodingIds, ParentIds, TypeInfo},
     match_extension_object_owned, AttributeId, BrowseDescription, BrowseDirection,
@@ -14,6 +13,7 @@ use opcua_types::{
     TimestampsToReturn, Variant,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::{
     browser::{BrowseFilter, BrowserConfig, NoneBrowserPolicy},

--- a/async-opcua-client/src/session/client.rs
+++ b/async-opcua-client/src/session/client.rs
@@ -1,8 +1,8 @@
 use std::{str::FromStr, sync::Arc};
 
 use chrono::Duration;
-use log::{debug, error};
 use tokio::{pin, select};
+use tracing::{debug, error};
 
 use crate::{
     transport::{

--- a/async-opcua-client/src/session/connect.rs
+++ b/async-opcua-client/src/session/connect.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use log::info;
 use tokio::{pin, select};
+use tracing::info;
 
 use crate::transport::{SecureChannelEventLoop, TransportPollResult};
 use opcua_types::{NodeId, StatusCode};

--- a/async-opcua-client/src/session/connection.rs
+++ b/async-opcua-client/src/session/connection.rs
@@ -1,11 +1,11 @@
 use std::{str::FromStr, sync::Arc};
 
-use log::error;
 use opcua_core::{comms::url::is_opc_ua_binary_url, config::Config, sync::RwLock};
 use opcua_crypto::{CertificateStore, SecurityPolicy};
 use opcua_types::{
     EndpointDescription, MessageSecurityMode, NodeId, StatusCode, TypeLoader, UserTokenType,
 };
+use tracing::error;
 
 use crate::{
     transport::{tcp::TcpConnector, Connector},

--- a/async-opcua-client/src/session/event_loop.rs
+++ b/async-opcua-client/src/session/event_loop.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt, TryStreamExt};
-use log::warn;
+use tracing::warn;
 
 use crate::{
     retry::{ExponentialBackoff, SessionRetryPolicy},

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -47,7 +47,6 @@ pub use client::Client;
 pub use connect::SessionConnectMode;
 pub use connection::SessionBuilder;
 pub use event_loop::{SessionActivity, SessionEventLoop, SessionPollResult};
-use log::{error, info};
 use opcua_core::handle::AtomicHandle;
 use opcua_core::sync::{Mutex, RwLock};
 use opcua_crypto::CertificateStore;
@@ -70,11 +69,12 @@ pub use services::subscriptions::{
 pub use services::view::{
     Browse, BrowseNext, RegisterNodes, TranslateBrowsePaths, UnregisterNodes,
 };
+use tracing::{error, info};
 
 #[allow(unused)]
 macro_rules! session_warn {
     ($session: expr, $($arg:tt)*) =>  {
-        log::warn!("session:{} {}", $session.session_id(), format!($($arg)*));
+        tracing::warn!("session:{} {}", $session.session_id(), format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -83,7 +83,7 @@ pub(crate) use session_warn;
 #[allow(unused)]
 macro_rules! session_error {
     ($session: expr, $($arg:tt)*) =>  {
-        log::error!("session:{} {}", $session.session_id(), format!($($arg)*));
+        tracing::error!("session:{} {}", $session.session_id(), format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -92,7 +92,7 @@ pub(crate) use session_error;
 #[allow(unused)]
 macro_rules! session_debug {
     ($session: expr, $($arg:tt)*) =>  {
-        log::debug!("session:{} {}", $session.session_id(), format!($($arg)*));
+        tracing::debug!("session:{} {}", $session.session_id(), format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -101,7 +101,7 @@ pub(crate) use session_debug;
 #[allow(unused)]
 macro_rules! session_trace {
     ($session: expr, $($arg:tt)*) =>  {
-        log::trace!("session:{} {}", $session.session_id(), format!($($arg)*));
+        tracing::trace!("session:{} {}", $session.session_id(), format!($($arg)*));
     }
 }
 #[allow(unused)]

--- a/async-opcua-client/src/session/request_builder.rs
+++ b/async-opcua-client/src/session/request_builder.rs
@@ -102,7 +102,7 @@ pub(crate) use builder_base;
 #[allow(unused)]
 macro_rules! builder_warn {
     ($session: expr, $($arg:tt)*) =>  {
-        log::warn!("session:{} {}", $session.header.session_id, format!($($arg)*));
+        tracing::warn!("session:{} {}", $session.header.session_id, format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -111,7 +111,7 @@ pub(crate) use builder_warn;
 #[allow(unused)]
 macro_rules! builder_error {
     ($session: expr, $($arg:tt)*) =>  {
-        log::error!("session:{} {}", $session.header.session_id, format!($($arg)*));
+        tracing::error!("session:{} {}", $session.header.session_id, format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -120,7 +120,7 @@ pub(crate) use builder_error;
 #[allow(unused)]
 macro_rules! builder_debug {
     ($session: expr, $($arg:tt)*) =>  {
-        log::debug!("session:{} {}", $session.header.session_id, format!($($arg)*));
+        tracing::debug!("session:{} {}", $session.header.session_id, format!($($arg)*));
     }
 }
 #[allow(unused)]
@@ -129,7 +129,7 @@ pub(crate) use builder_debug;
 #[allow(unused)]
 macro_rules! builder_trace {
     ($session: expr, $($arg:tt)*) =>  {
-        log::trace!("session:{} {}", $session.header.session_id, format!($($arg)*));
+        tracing::trace!("session:{} {}", $session.header.session_id, format!($($arg)*));
     }
 }
 #[allow(unused)]

--- a/async-opcua-client/src/session/services/session.rs
+++ b/async-opcua-client/src/session/services/session.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, time::Duration};
 
-use log::error;
 use opcua_core::{
     comms::{secure_channel::SecureChannel, url::hostname_from_url},
     sync::RwLock,
@@ -18,6 +17,7 @@ use opcua_types::{
     UAString, UserTokenType, X509IdentityToken,
 };
 use rsa::RsaPrivateKey;
+use tracing::error;
 
 use crate::{
     session::{
@@ -179,7 +179,7 @@ impl UARequest for CreateSession<'_> {
         let response = channel.send(request, self.header.timeout).await?;
 
         if let ResponseMessage::CreateSession(response) = response {
-            log::debug!("create_session, success");
+            tracing::debug!("create_session, success");
             process_service_result(&response.response_header)?;
 
             let security_policy = channel.security_policy();
@@ -212,7 +212,7 @@ impl UARequest for CreateSession<'_> {
 
             Ok(*response)
         } else {
-            log::error!("create_session failed");
+            tracing::error!("create_session failed");
             Err(process_unexpected_response(response))
         }
     }
@@ -485,12 +485,12 @@ impl UARequest for ActivateSession {
         let response = channel.send(request, timeout).await?;
 
         if let ResponseMessage::ActivateSession(response) = response {
-            log::debug!("activate_session success");
+            tracing::debug!("activate_session success");
             // trace!("ActivateSessionResponse = {:#?}", response);
             process_service_result(&response.response_header)?;
             Ok(*response)
         } else {
-            log::error!("activate_session failed");
+            tracing::error!("activate_session failed");
             Err(process_unexpected_response(response))
         }
     }

--- a/async-opcua-client/src/session/services/subscriptions/event_loop.rs
+++ b/async-opcua-client/src/session/services/subscriptions/event_loop.rs
@@ -1,8 +1,8 @@
 use std::{sync::Arc, time::Instant};
 
 use futures::{future::Either, stream::FuturesUnordered, Future, Stream, StreamExt};
-use log::debug;
 use opcua_types::StatusCode;
+use tracing::debug;
 
 use crate::{
     session::{session_debug, session_error},

--- a/async-opcua-client/src/session/services/subscriptions/service.rs
+++ b/async-opcua-client/src/session/services/subscriptions/service.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     Session, UARequest,
 };
-use log::{debug, log_enabled};
 use opcua_core::{handle::AtomicHandle, sync::Mutex, trace_lock, ResponseMessage};
 use opcua_types::{
     AttributeId, CreateMonitoredItemsRequest, CreateMonitoredItemsResponse,
@@ -27,6 +26,7 @@ use opcua_types::{
     SetTriggeringResponse, StatusCode, TimestampsToReturn, TransferResult,
     TransferSubscriptionsRequest, TransferSubscriptionsResponse,
 };
+use tracing::{debug, enabled};
 
 use super::{state::SubscriptionState, OnSubscriptionNotification};
 
@@ -1906,7 +1906,7 @@ impl Session {
             }
         };
 
-        if log_enabled!(log::Level::Debug) {
+        if enabled!(tracing::Level::DEBUG) {
             let sequence_nrs: Vec<u32> = acks
                 .iter()
                 .flatten()

--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -2,7 +2,6 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 
 use crate::{session::SessionInfo, transport::core::TransportPollResult};
 use arc_swap::{ArcSwap, ArcSwapOption};
-use log::{debug, error};
 use opcua_core::{
     comms::secure_channel::{Role, SecureChannel},
     sync::RwLock,
@@ -13,6 +12,7 @@ use opcua_types::{
     ByteString, CloseSecureChannelRequest, ContextOwned, IntegerId, NodeId, RequestHeader,
     SecurityTokenRequestType, StatusCode,
 };
+use tracing::{debug, error};
 
 use super::{
     connect::{Connector, Transport},

--- a/async-opcua-client/src/transport/core.rs
+++ b/async-opcua-client/src/transport/core.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use futures::future::Either;
-use log::{debug, error, trace, warn};
 use opcua_core::{trace_read_lock, trace_write_lock, RequestMessage, ResponseMessage};
 use parking_lot::RwLock;
+use tracing::{debug, error, trace, warn};
 
 use opcua_core::comms::buffer::SendBuffer;
 use opcua_core::comms::message_chunk::MessageIsFinalType;

--- a/async-opcua-client/src/transport/state.rs
+++ b/async-opcua-client/src/transport/state.rs
@@ -3,8 +3,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::{debug, trace};
 use tokio::sync::mpsc::error::SendTimeoutError;
+use tracing::{debug, trace};
 
 use crate::{session::process_unexpected_response, transport::OutgoingMessage};
 use arc_swap::ArcSwap;

--- a/async-opcua-codegen/Cargo.toml
+++ b/async-opcua-codegen/Cargo.toml
@@ -19,7 +19,6 @@ base64 = "0.22.1"
 chrono = "0.4.38"
 convert_case = "0.6.0"
 env_logger = "0.11.7"
-log = { workspace = true }
 pathdiff = "0.2.3"
 prettyplease = "0.2.20"
 proc-macro2 = "1.0.86"
@@ -31,6 +30,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 syn = { version = "2.0.71", features = ["full"] }
 thiserror = "1.0.63"
+tracing = { workspace = true }
 uuid = "1.10.0"
 
 async-opcua-xml = { path = "../async-opcua-xml", version = "0.14.0" }

--- a/async-opcua-codegen/src/input/mod.rs
+++ b/async-opcua-codegen/src/input/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::Path};
 
-use log::warn;
 use pathdiff::diff_paths;
+use tracing::warn;
 
 use crate::CodeGenError;
 

--- a/async-opcua-codegen/src/input/nodeset.rs
+++ b/async-opcua-codegen/src/input/nodeset.rs
@@ -3,7 +3,6 @@ use std::{
     sync::OnceLock,
 };
 
-use log::{info, warn};
 use opcua_xml::{
     load_nodeset2_file,
     schema::{
@@ -12,6 +11,7 @@ use opcua_xml::{
     },
     XmlElement,
 };
+use tracing::{info, warn};
 
 use crate::{
     utils::{split_qualified_name, ParsedNodeId},

--- a/async-opcua-codegen/src/lib.rs
+++ b/async-opcua-codegen/src/lib.rs
@@ -15,10 +15,10 @@ use std::{
 use config::{load_schemas, CodeGenSource};
 pub use error::CodeGenError;
 use ids::{generate_node_ids, NodeIdCodeGenTarget};
-use log::info;
 use nodeset::{generate_events, generate_target, make_root_module, NodeSetCodeGenTarget};
 use serde::{Deserialize, Serialize};
 use syn::{parse_str, File};
+use tracing::info;
 pub use types::{
     base_ignored_types, base_native_type_mappings, basic_types_import_map, BsdTypeLoader,
     CodeGenItemConfig, GeneratedItem, ItemDefinition, LoadedType, LoadedTypes,

--- a/async-opcua-codegen/src/nodeset/mod.rs
+++ b/async-opcua-codegen/src/nodeset/mod.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 
 pub use events::generate_events;
 pub use gen::{NodeGenMethod, NodeSetCodeGenerator};
-use log::info;
 use opcua_xml::schema::{
     ua_node_set::UANodeSet,
     xml_schema::{XsdFileItem, XsdFileType},
@@ -15,6 +14,7 @@ use proc_macro2::Span;
 use quote::quote;
 use serde::{Deserialize, Serialize};
 use syn::{parse_quote, parse_str, File, Ident, Item, ItemFn, Path};
+use tracing::info;
 
 use crate::{input::SchemaCache, CodeGenError, GeneratedOutput};
 

--- a/async-opcua-codegen/src/nodeset/value.rs
+++ b/async-opcua-codegen/src/nodeset/value.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use convert_case::{Case, Casing};
-use log::warn;
 use opcua_xml::schema::{
     opc_ua_types::{ExtensionObject, Variant, XmlElement},
     ua_node_set::Value,
@@ -13,6 +12,7 @@ use opcua_xml::schema::{
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::Path;
+use tracing::warn;
 
 use crate::{
     utils::{safe_ident, RenderExpr},

--- a/async-opcua-codegen/src/types/gen.rs
+++ b/async-opcua-codegen/src/types/gen.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
 use convert_case::{Case, Casing};
-use log::warn;
 use proc_macro2::Span;
 use syn::{
     parse_quote, parse_str, punctuated::Punctuated, FieldsNamed, File, Generics, Item, ItemEnum,
     ItemMacro, ItemStruct, Lit, LitByte, Path, Token, Type, Visibility,
 };
+use tracing::warn;
 
 use crate::{
     error::CodeGenError,

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -8,10 +8,10 @@ pub use encoding_ids::EncodingIds;
 pub use gen::{CodeGenItemConfig, CodeGenerator, GeneratedItem, ItemDefinition};
 use loaders::NodeSetTypeLoader;
 pub use loaders::{BsdTypeLoader, LoadedType, LoadedTypes};
-use log::info;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_quote, parse_str, Item, Path};
+use tracing::info;
 
 use crate::{
     input::{BinarySchemaInput, NodeSetInput, SchemaCache},

--- a/async-opcua-core/Cargo.toml
+++ b/async-opcua-core/Cargo.toml
@@ -18,13 +18,13 @@ name = "opcua_core"
 [dependencies]
 bytes = { workspace = true }
 chrono = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 
 async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.14.0" }

--- a/async-opcua-core/src/comms/buffer.rs
+++ b/async-opcua-core/src/comms/buffer.rs
@@ -6,8 +6,8 @@ use std::{
     io::{BufRead, Cursor},
 };
 
-use log::trace;
 use tokio::io::AsyncWriteExt;
+use tracing::trace;
 
 use crate::{
     comms::{chunker::Chunker, message_chunk::MessageChunk, secure_channel::SecureChannel},

--- a/async-opcua-core/src/comms/chunker.rs
+++ b/async-opcua-core/src/comms/chunker.rs
@@ -14,12 +14,12 @@ use crate::{
     Message,
 };
 
-use log::{debug, error, trace};
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
     encoding::BinaryEncodable, node_id::NodeId, status_code::StatusCode, BinaryDecodable,
     EncodingResult, Error, ObjectId,
 };
+use tracing::{debug, error, trace};
 
 use super::message_chunk::MessageChunkType;
 

--- a/async-opcua-core/src/comms/message_chunk.rs
+++ b/async-opcua-core/src/comms/message_chunk.rs
@@ -7,12 +7,12 @@
 
 use std::io::{Cursor, Read, Write};
 
-use log::{error, trace};
 use opcua_types::{
     process_decode_io_result, process_encode_io_result, read_u32, read_u8, status_code::StatusCode,
     write_u32, write_u8, DecodingOptions, EncodingResult, Error, SimpleBinaryDecodable,
     SimpleBinaryEncodable,
 };
+use tracing::{error, trace};
 
 use super::{
     message_chunk_info::ChunkInfo,

--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -14,7 +14,7 @@ use std::{
 
 use bytes::Buf;
 use chrono::Duration;
-use log::{error, trace};
+use tracing::{error, trace};
 
 use opcua_crypto::{
     aeskey::AesKey,

--- a/async-opcua-core/src/comms/tcp_codec.rs
+++ b/async-opcua-core/src/comms/tcp_codec.rs
@@ -14,8 +14,8 @@
 use std::io;
 
 use bytes::{BufMut, BytesMut};
-use log::error;
 use tokio_util::codec::{Decoder, Encoder};
+use tracing::error;
 
 use opcua_types::{
     encoding::{DecodingOptions, SimpleBinaryDecodable, SimpleBinaryEncodable},

--- a/async-opcua-core/src/comms/tcp_types.rs
+++ b/async-opcua-core/src/comms/tcp_types.rs
@@ -6,12 +6,12 @@
 
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
 
-use log::error;
 use opcua_types::{
     process_decode_io_result, process_encode_io_result, read_u32, status_code::StatusCode,
     string::UAString, write_u32, write_u8, DecodingOptions, EncodingResult, EndpointDescription,
     SimpleBinaryDecodable, SimpleBinaryEncodable,
 };
+use tracing::error;
 
 use super::url::url_matches_except_host;
 

--- a/async-opcua-core/src/comms/url.rs
+++ b/async-opcua-core/src/comms/url.rs
@@ -4,7 +4,7 @@
 
 //! Provides functions for parsing Urls from strings.
 
-use log::error;
+use tracing::error;
 use url::Url;
 
 use opcua_types::status_code::StatusCode;

--- a/async-opcua-core/src/lib.rs
+++ b/async-opcua-core/src/lib.rs
@@ -9,13 +9,13 @@
 
 /// Contains debugging utility helper functions
 pub mod debug {
-    use log::{log_enabled, trace};
+    use tracing::{enabled, trace};
 
     /// Prints out the content of a slice in hex and visible char format to aid debugging. Format
     /// is similar to corresponding functionality in node-opcua
     pub fn log_buffer(message: &str, buf: &[u8]) {
         // No point doing anything unless debug level is on
-        if !log_enabled!(target: "hex", log::Level::Trace) {
+        if !enabled!(target: "hex", tracing::Level::TRACE) {
             return;
         }
 

--- a/async-opcua-core/src/tests/chunk.rs
+++ b/async-opcua-core/src/tests/chunk.rs
@@ -1,11 +1,11 @@
 use std::io::{Cursor, Write};
 
-use log::trace;
 use opcua_types::{
     BinaryDecodable, ByteString, DataValue, DateTime, DecodingOptions, DiagnosticBits,
     ExtensionObject, MessageSecurityMode, NodeId, OpenSecureChannelRequest, ReadResponse,
     RequestHeader, ResponseHeader, SecurityTokenRequestType, UAString,
 };
+use tracing::trace;
 
 use crate::{
     comms::{chunker::*, message_chunk::*, secure_channel::*, tcp_types::MIN_CHUNK_SIZE},

--- a/async-opcua-core/src/tests/secure_channel.rs
+++ b/async-opcua-core/src/tests/secure_channel.rs
@@ -1,8 +1,8 @@
 //! These tests are specifically testing secure channel behaviour of signing, encrypting, decrypting and verifying
 //! chunks containing messages
 
-use log::{error, trace};
 use opcua_crypto::SecurityPolicy;
+use tracing::{error, trace};
 
 use crate::{
     comms::{chunker::*, secure_channel::*},

--- a/async-opcua-crypto/Cargo.toml
+++ b/async-opcua-crypto/Cargo.toml
@@ -18,8 +18,8 @@ name = "opcua_crypto"
 [dependencies]
 chrono = { workspace = true }
 gethostname = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 
 async-opcua-types = { path = "../async-opcua-types", version = "0.14.0" }
 

--- a/async-opcua-crypto/src/certificate_store.rs
+++ b/async-opcua-crypto/src/certificate_store.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use log::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use opcua_types::status_code::StatusCode;
 

--- a/async-opcua-crypto/src/hash.rs
+++ b/async-opcua-crypto/src/hash.rs
@@ -7,9 +7,9 @@
 use std::result::Result;
 
 use hmac::{digest, Hmac, Mac};
-use log::error;
 use sha1::Sha1;
 use sha2::Sha256;
+use tracing::error;
 
 use opcua_types::status_code::StatusCode;
 

--- a/async-opcua-crypto/src/lib.rs
+++ b/async-opcua-crypto/src/lib.rs
@@ -10,10 +10,10 @@
 
 use std::fmt;
 
-use log::{error, trace};
 use opcua_types::{
     status_code::StatusCode, ByteString, EncodingResult, Error, SignatureData, UAString,
 };
+use tracing::{error, trace};
 pub use {
     aeskey::*, certificate_store::*, hash::*, pkey::*, security_policy::*, thumbprint::*,
     user_identity::*, x509::*,

--- a/async-opcua-crypto/src/security_policy.rs
+++ b/async-opcua-crypto/src/security_policy.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use log::error;
+use tracing::error;
 
 use opcua_types::{constants, status_code::StatusCode, ByteString, Error};
 
@@ -589,7 +589,7 @@ impl SecurityPolicy {
             #[cfg(debug_assertions)]
             if let Some(their_key) = their_private_key {
                 use crate::pkey::KeySize;
-                use log::trace;
+                use tracing::trace;
                 // Calculate the signature using their key, see what we were expecting versus theirs
                 let mut their_signature = vec![0u8; their_key.size()];
                 self.asymmetric_sign(&their_key, data, their_signature.as_mut_slice())?;

--- a/async-opcua-crypto/src/user_identity.rs
+++ b/async-opcua-crypto/src/user_identity.rs
@@ -10,7 +10,6 @@
 use std::io::{Cursor, Write};
 use std::str::FromStr;
 
-use log::{error, warn};
 use opcua_types::Error;
 use opcua_types::{
     encoding::{read_u32, write_u32},
@@ -18,6 +17,7 @@ use opcua_types::{
     ByteString, UAString,
     {SignatureData, UserNameIdentityToken, UserTokenPolicy, X509IdentityToken},
 };
+use tracing::{error, warn};
 
 use super::{KeySize, PrivateKey, RsaPadding, SecurityPolicy, X509};
 

--- a/async-opcua-crypto/src/x509.rs
+++ b/async-opcua-crypto/src/x509.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use log::{error, info, trace, warn};
+use tracing::{error, info, trace, warn};
 type ChronoUtc = DateTime<Utc>;
 
 use rsa;

--- a/async-opcua-nodes/Cargo.toml
+++ b/async-opcua-nodes/Cargo.toml
@@ -21,7 +21,7 @@ xml = ["async-opcua-types/xml", "async-opcua-xml"]
 [dependencies]
 bitflags = { workspace = true }
 hashbrown = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 

--- a/async-opcua-nodes/src/data_type.rs
+++ b/async-opcua-nodes/src/data_type.rs
@@ -4,11 +4,11 @@
 
 //! Contains the implementation of `Method` and `MethodBuilder`.
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataTypeAttributes, DataTypeDefinition, DataValue,
     NumericRange, StatusCode, TimestampsToReturn, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/events/evaluate.rs
+++ b/async-opcua-nodes/src/events/evaluate.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
-use log::error;
 use regex::Regex;
+use tracing::error;
 
 use opcua_types::{
     AttributeId, EventFieldList, FilterOperator, NodeId, NumericRange, QualifiedName, Variant,

--- a/async-opcua-nodes/src/lib.rs
+++ b/async-opcua-nodes/src/lib.rs
@@ -72,8 +72,8 @@ pub trait NodeInsertTarget {
 // variables etc.
 macro_rules! node_builder_impl {
     ( $node_builder_ty:ident, $node_ty:ident ) => {
-        use log::trace;
         use opcua_types::{LocalizedText, NodeId, QualifiedName, ReferenceTypeId};
+        use tracing::trace;
         use $crate::ReferenceDirection;
         // use $crate::{address_space::AddressSpace, ReferenceDirection};
 

--- a/async-opcua-nodes/src/method.rs
+++ b/async-opcua-nodes/src/method.rs
@@ -4,12 +4,12 @@
 
 //! Contains the implementation of `Method` and `MethodBuilder`.
 
-use log::error;
 use opcua_types::{
     Argument, AttributeId, AttributesMask, DataEncoding, DataTypeId, DataValue, ExtensionObject,
     MethodAttributes, NumericRange, StatusCode, TimestampsToReturn, VariableTypeId, Variant,
     VariantScalarTypeId,
 };
+use tracing::error;
 
 use crate::{FromAttributesError, NodeInsertTarget};
 

--- a/async-opcua-nodes/src/object.rs
+++ b/async-opcua-nodes/src/object.rs
@@ -4,11 +4,11 @@
 
 //! Contains the implementation of `Object` and `ObjectBuilder`.
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataValue, NumericRange, ObjectAttributes,
     ObjectTypeId, StatusCode, TimestampsToReturn, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/object_type.rs
+++ b/async-opcua-nodes/src/object_type.rs
@@ -4,11 +4,11 @@
 
 //! Contains the implementation of `ObjectType` and `ObjectTypeBuilder`.
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataValue, NumericRange, ObjectTypeAttributes,
     StatusCode, TimestampsToReturn, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/reference_type.rs
+++ b/async-opcua-nodes/src/reference_type.rs
@@ -4,11 +4,11 @@
 
 //! Contains the implementation of `ReferenceType` and `ReferenceTypeBuilder`.
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataValue, NumericRange, ReferenceTypeAttributes,
     StatusCode, TimestampsToReturn, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/variable.rs
+++ b/async-opcua-nodes/src/variable.rs
@@ -6,11 +6,11 @@
 
 use std::convert::Into;
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataTypeId, DataValue, DateTime, NumericRange,
     StatusCode, TimestampsToReturn, TryFromVariant, VariableAttributes, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/variable_type.rs
+++ b/async-opcua-nodes/src/variable_type.rs
@@ -4,11 +4,11 @@
 
 //! Contains the implementation of `VariableType` and `VariableTypeBuilder`.
 
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataValue, NumericRange, StatusCode,
     TimestampsToReturn, TryFromVariant, VariableTypeAttributes, Variant,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/view.rs
+++ b/async-opcua-nodes/src/view.rs
@@ -3,11 +3,11 @@
 // Copyright (C) 2017-2024 Adam Lock
 
 //! Contains the implementation of `View` and `ViewBuilder`.
-use log::error;
 use opcua_types::{
     AttributeId, AttributesMask, DataEncoding, DataValue, NumericRange, StatusCode,
     TimestampsToReturn, Variant, ViewAttributes,
 };
+use tracing::error;
 
 use crate::FromAttributesError;
 

--- a/async-opcua-nodes/src/xml.rs
+++ b/async-opcua-nodes/src/xml.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use hashbrown::HashMap;
-use log::warn;
 use opcua_types::{
     Context, DataTypeDefinition, DataValue, DecodingOptions, EnumDefinition, EnumField, Error,
     LocalizedText, NodeClass, NodeId, QualifiedName, StructureDefinition, StructureField,
@@ -20,6 +19,7 @@ use opcua_xml::{
     XmlError,
 };
 use regex::Regex;
+use tracing::warn;
 
 use crate::{
     Base, DataType, EventNotifier, ImportedItem, ImportedReference, Method, NodeSetImport, Object,

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -34,13 +34,13 @@ bitflags = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 hashbrown = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 postcard = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tracing = { workspace = true }
 
 async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.14.0" }
 async-opcua-core = { path = "../async-opcua-core", version = "0.14.0" }

--- a/async-opcua-server/src/address_space/mod.rs
+++ b/async-opcua-server/src/address_space/mod.rs
@@ -11,7 +11,7 @@ pub use opcua_core_namespace::CoreNamespace;
 use std::collections::VecDeque;
 
 use hashbrown::{HashMap, HashSet};
-use log::{debug, error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::node_manager::{ParsedReadValueId, ParsedWriteValue, RequestContext};
 use opcua_types::{

--- a/async-opcua-server/src/address_space/utils.rs
+++ b/async-opcua-server/src/address_space/utils.rs
@@ -1,10 +1,10 @@
 use crate::node_manager::{ParsedReadValueId, ParsedWriteValue, RequestContext, ServerContext};
-use log::debug;
 use opcua_nodes::TypeTree;
 use opcua_types::{
     AttributeId, DataEncoding, DataTypeId, DataValue, DateTime, NumericRange, StatusCode,
     TimestampsToReturn, Variant, WriteMask,
 };
+use tracing::debug;
 
 use super::{AccessLevel, AddressSpace, HasNodeId, NodeType, Variable};
 

--- a/async-opcua-server/src/authenticator.rs
+++ b/async-opcua-server/src/authenticator.rs
@@ -2,11 +2,11 @@
 
 use async_trait::async_trait;
 
-use log::{debug, error};
 use opcua_crypto::{SecurityPolicy, Thumbprint};
 use opcua_types::{
     Error, MessageSecurityMode, NodeId, StatusCode, UAString, UserTokenPolicy, UserTokenType,
 };
+use tracing::{debug, error};
 
 use crate::identity_token::{
     POLICY_ID_ANONYMOUS, POLICY_ID_USER_PASS_NONE, POLICY_ID_USER_PASS_RSA_15,

--- a/async-opcua-server/src/builder.rs
+++ b/async-opcua-server/src/builder.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
-use log::warn;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::{constants, node_manager::TypeTreeForUser};
 use opcua_core::config::Config;

--- a/async-opcua-server/src/config/server.rs
+++ b/async-opcua-server/src/config/server.rs
@@ -9,8 +9,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::{trace, warn};
 use serde::{Deserialize, Serialize};
+use tracing::{trace, warn};
 
 use crate::constants;
 use opcua_core::{comms::url::url_matches_except_host, config::Config};

--- a/async-opcua-server/src/discovery.rs
+++ b/async-opcua-server/src/discovery.rs
@@ -1,7 +1,7 @@
-use log::{debug, error};
 use opcua_client::{Client, ClientBuilder};
 use opcua_types::RegisteredServer;
 use std::{path::PathBuf, time::Duration};
+use tracing::{debug, error};
 
 use futures::never::Never;
 

--- a/async-opcua-server/src/info.rs
+++ b/async-opcua-server/src/info.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use log::{debug, error, warn};
 use opcua_nodes::DefaultTypeTree;
+use tracing::{debug, error, warn};
 
 use crate::authenticator::{user_pass_security_policy_id, Password};
 use crate::node_manager::TypeTreeForUser;

--- a/async-opcua-server/src/node_manager/memory/diagnostics.rs
+++ b/async-opcua-server/src/node_manager/memory/diagnostics.rs
@@ -654,7 +654,7 @@ impl NodeManager for DiagnosticsNodeManager {
                 }
             } else if node.node_id().namespace == self.namespace_index {
                 let Some(node_desc) = from_opaque_node_id::<DiagnosticsNode>(node.node_id()) else {
-                    log::warn!("Unknown node...");
+                    tracing::warn!("Unknown node...");
                     node.set_status(StatusCode::BadNodeIdUnknown);
                     continue;
                 };

--- a/async-opcua-server/src/node_manager/memory/mod.rs
+++ b/async-opcua-server/src/node_manager/memory/mod.rs
@@ -13,10 +13,10 @@ mod core;
 pub use core::{CoreNodeManager, CoreNodeManagerBuilder, CoreNodeManagerImpl};
 
 pub use diagnostics::{DiagnosticsNodeManager, DiagnosticsNodeManagerBuilder, NamespaceMetadata};
-use log::warn;
 pub use memory_mgr_impl::*;
 use opcua_core::{trace_read_lock, trace_write_lock};
 pub use simple::*;
+use tracing::warn;
 
 use std::{
     collections::{HashSet, VecDeque},

--- a/async-opcua-server/src/node_manager/view.rs
+++ b/async-opcua-server/src/node_manager/view.rs
@@ -7,7 +7,6 @@ use crate::{
         instance::Session,
     },
 };
-use log::warn;
 use opcua_crypto::random;
 use opcua_nodes::TypeTree;
 use opcua_types::{
@@ -15,6 +14,7 @@ use opcua_types::{
     BrowseResultMask, ByteString, ExpandedNodeId, LocalizedText, NodeClass, NodeClassMask, NodeId,
     QualifiedName, ReferenceDescription, RelativePathElement, StatusCode,
 };
+use tracing::warn;
 
 use super::{NodeManager, RequestContext};
 

--- a/async-opcua-server/src/server.rs
+++ b/async-opcua-server/src/server.rs
@@ -10,7 +10,6 @@ use std::{
 
 use arc_swap::ArcSwap;
 use futures::{future::Either, never::Never, stream::FuturesUnordered, FutureExt, StreamExt};
-use log::{error, info, warn};
 use opcua_core::{sync::RwLock, trace_read_lock, trace_write_lock};
 use opcua_nodes::DefaultTypeTree;
 use tokio::{
@@ -20,6 +19,7 @@ use tokio::{
     task::{JoinError, JoinHandle},
 };
 use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
 
 use opcua_core::{config::Config, handle::AtomicHandle};
 use opcua_crypto::CertificateStore;

--- a/async-opcua-server/src/server_handle.rs
+++ b/async-opcua-server/src/server_handle.rs
@@ -3,9 +3,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::info;
 use opcua_nodes::{DefaultTypeTree, TypeTree};
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 use opcua_core::sync::RwLock;
 use opcua_types::{AttributeId, DataValue, LocalizedText, ServerState, VariableId};

--- a/async-opcua-server/src/session/controller.rs
+++ b/async-opcua-server/src/session/controller.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use futures::{future::Either, stream::FuturesUnordered, Future, StreamExt};
-use log::{debug, error, trace, warn};
 use opcua_core::{trace_read_lock, trace_write_lock, Message, RequestMessage, ResponseMessage};
+use tracing::{debug, error, trace, warn};
 
 use opcua_core::{
     comms::{
@@ -133,7 +133,7 @@ impl<T: Connector> SessionStarter<T> {
                 match r {
                     Ok(t) => t,
                     Err(e) => {
-                        log::error!("Connection failed while waiting for channel to be established: {e}");
+                        tracing::error!("Connection failed while waiting for channel to be established: {e}");
                         return;
                     }
                 }

--- a/async-opcua-server/src/session/instance.rs
+++ b/async-opcua-server/src/session/instance.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
-use log::error;
+use tracing::error;
 
 use super::continuation_points::ContinuationPoint;
 use super::manager::next_session_id;

--- a/async-opcua-server/src/session/manager.rs
+++ b/async-opcua-server/src/session/manager.rs
@@ -7,11 +7,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::{error, info};
 use opcua_core::{comms::secure_channel::SecureChannel, trace_read_lock, trace_write_lock};
 use opcua_crypto::{random, security_policy::SecurityPolicy, CertificateStore};
 use parking_lot::RwLock;
 use tokio::sync::Notify;
+use tracing::{error, info};
 
 use crate::{identity_token::IdentityToken, info::ServerInfo};
 use opcua_types::{

--- a/async-opcua-server/src/session/message_handler.rs
+++ b/async-opcua-server/src/session/message_handler.rs
@@ -1,10 +1,10 @@
 use std::{sync::Arc, time::Instant};
 
 use chrono::Utc;
-use log::{debug, warn};
 use opcua_core::{Message, RequestMessage, ResponseMessage};
 use parking_lot::RwLock;
 use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 use crate::{
     authenticator::UserToken,

--- a/async-opcua-server/src/session/services/query.rs
+++ b/async-opcua-server/src/session/services/query.rs
@@ -1,6 +1,6 @@
-use log::info;
 use opcua_core::trace_write_lock;
 use opcua_nodes::ParsedContentFilter;
+use tracing::info;
 
 use crate::{
     node_manager::{NodeManagers, ParsedNodeTypeDescription, QueryRequest},

--- a/async-opcua-server/src/session/services/view.rs
+++ b/async-opcua-server/src/session/services/view.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use log::{error, info};
 use opcua_core::trace_write_lock;
+use tracing::{error, info};
 
 use crate::{
     node_manager::{

--- a/async-opcua-server/src/subscriptions/mod.rs
+++ b/async-opcua-server/src/subscriptions/mod.rs
@@ -6,13 +6,13 @@ use std::{sync::Arc, time::Instant};
 
 use chrono::Utc;
 use hashbrown::{Equivalent, HashMap};
-use log::error;
 pub use monitored_item::{CreateMonitoredItem, MonitoredItem};
 use opcua_core::{trace_read_lock, trace_write_lock, ResponseMessage};
 use opcua_nodes::{Event, TypeTree};
 pub use session_subscriptions::SessionSubscriptions;
 use subscription::TickReason;
 pub use subscription::{MonitoredItemHandle, Subscription, SubscriptionState};
+use tracing::error;
 
 use opcua_core::sync::{Mutex, RwLock};
 
@@ -715,7 +715,7 @@ impl SubscriptionCache {
                 }
 
                 if let (Some(sub), notifs) = session_lck.remove(*sub_id) {
-                    log::debug!(
+                    tracing::debug!(
                         "Transfer subscription {} to session {}",
                         sub.id(),
                         session_id

--- a/async-opcua-server/src/subscriptions/monitored_item.rs
+++ b/async-opcua-server/src/subscriptions/monitored_item.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, VecDeque};
 
-use log::error;
 use opcua_nodes::{Event, ParsedEventFilter, TypeTree};
+use tracing::error;
 
 use super::MonitoredItemHandle;
 use crate::{info::ServerInfo, node_manager::ParsedReadValueId};

--- a/async-opcua-server/src/subscriptions/subscription.rs
+++ b/async-opcua-server/src/subscriptions/subscription.rs
@@ -3,10 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::{debug, trace, warn};
 use opcua_core::handle::Handle;
 use opcua_nodes::Event;
 use opcua_types::{DataValue, DateTime, DateTimeUtc, NotificationMessage, StatusCode};
+use tracing::{debug, trace, warn};
 
 use super::monitored_item::{MonitoredItem, Notification};
 

--- a/async-opcua-server/src/transport/tcp.rs
+++ b/async-opcua-server/src/transport/tcp.rs
@@ -3,7 +3,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::error;
 use opcua_core::{
     comms::{
         buffer::SendBuffer,
@@ -16,6 +15,7 @@ use opcua_core::{
     },
     RequestMessage, ResponseMessage,
 };
+use tracing::error;
 
 use crate::info::ServerInfo;
 use opcua_types::{DecodingOptions, Error, ResponseHeader, ServiceFault, StatusCode};
@@ -269,7 +269,7 @@ impl TcpTransport {
         match self.send_buffer.write(request_id, message, channel) {
             Ok(_) => Ok(()),
             Err(e) => {
-                log::warn!("Failed to encode outgoing message: {e:?}");
+                tracing::warn!("Failed to encode outgoing message: {e:?}");
                 if let Some((request_id, request_handle)) = e.full_context() {
                     self.send_buffer.write(
                         request_id,

--- a/async-opcua-types/Cargo.toml
+++ b/async-opcua-types/Cargo.toml
@@ -25,11 +25,11 @@ bitflags = { workspace = true }
 byteorder = { workspace = true }
 chrono = { workspace = true }
 hashbrown = { workspace = true }
-log = { workspace = true }
 percent-encoding-rfc3986 = "0.1.3"
 regex = { workspace = true }
 struson = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 async-opcua-macros = { path = "../async-opcua-macros", version = "0.14.0" }

--- a/async-opcua-types/src/array.rs
+++ b/async-opcua-types/src/array.rs
@@ -1,8 +1,8 @@
 //! The [`Array`] type, used to contain OPC-UA arrays, which are potentially
 //! multi-dimensional, but stored as a single vector of Variants.
 
-use log::error;
 use thiserror::Error;
+use tracing::error;
 
 use crate::variant::*;
 

--- a/async-opcua-types/src/attribute.rs
+++ b/async-opcua-types/src/attribute.rs
@@ -10,7 +10,7 @@
 
 use std::{error::Error, fmt};
 
-use log::debug;
+use tracing::debug;
 
 #[derive(Debug)]
 /// Error returned when working with an Attribute ID.

--- a/async-opcua-types/src/date_time.rs
+++ b/async-opcua-types/src/date_time.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use chrono::{Duration, SecondsFormat, TimeDelta, TimeZone, Timelike, Utc};
-use log::error;
+use tracing::error;
 
 use crate::{encoding::*, Context};
 

--- a/async-opcua-types/src/encoding.rs
+++ b/async-opcua-types/src/encoding.rs
@@ -14,7 +14,7 @@ use std::{
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use chrono::Duration;
-use log::error;
+use tracing::error;
 
 use crate::{constants, status_code::StatusCode, Context, QualifiedName};
 

--- a/async-opcua-types/src/extension_object.rs
+++ b/async-opcua-types/src/extension_object.rs
@@ -353,7 +353,7 @@ mod json {
                     }
                     #[cfg(not(feature = "xml"))]
                     {
-                        log::warn!("XML feature is not enabled, deserializing XML payloads in JSON extension objects is not supported");
+                        tracing::warn!("XML feature is not enabled, deserializing XML payloads in JSON extension objects is not supported");
                         Ok(ExtensionObject::null())
                     }
                 } else {
@@ -559,7 +559,7 @@ impl BinaryDecodable for ExtensionObject {
 
                 #[cfg(not(feature = "xml"))]
                 {
-                    log::warn!("XML feature is not enabled, deserializing XML payloads in JSON extension objects is not supported");
+                    tracing::warn!("XML feature is not enabled, deserializing XML payloads in JSON extension objects is not supported");
                     let size = i32::decode(stream, ctx)?;
                     if size > 0 {
                         crate::encoding::skip_bytes(stream, size as u64)?;

--- a/async-opcua-types/src/impls.rs
+++ b/async-opcua-types/src/impls.rs
@@ -1,6 +1,6 @@
 use std::{self, fmt};
 
-use log::error;
+use tracing::error;
 
 use crate::{
     argument::Argument,

--- a/async-opcua-types/src/node_id.rs
+++ b/async-opcua-types/src/node_id.rs
@@ -181,7 +181,7 @@ mod json {
     use std::io::{Read, Write};
     use std::str::FromStr;
 
-    use log::warn;
+    use tracing::warn;
 
     use crate::{json::*, ByteString, Error, Guid};
 

--- a/async-opcua-types/src/notification_message.rs
+++ b/async-opcua-types/src/notification_message.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock
 //! Helpers for NotificationMessage types
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use crate::{
     date_time::DateTime, diagnostic_info::DiagnosticInfo, extension_object::ExtensionObject,

--- a/async-opcua-types/src/relative_path.rs
+++ b/async-opcua-types/src/relative_path.rs
@@ -9,9 +9,9 @@
 
 use std::sync::LazyLock;
 
-use log::error;
 use regex::Regex;
 use thiserror::Error;
+use tracing::error;
 
 use crate::{
     node_id::{Identifier, NodeId},

--- a/async-opcua-types/src/variant/mod.rs
+++ b/async-opcua-types/src/variant/mod.rs
@@ -28,7 +28,7 @@ use std::{
     str::FromStr,
 };
 
-use log::error;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::{

--- a/async-opcua-types/src/variant/type_id.rs
+++ b/async-opcua-types/src/variant/type_id.rs
@@ -149,7 +149,7 @@ impl TryFrom<u32> for VariantScalarTypeId {
             24 => Self::Variant,
             25 => Self::DiagnosticInfo,
             r => {
-                log::error!("Got unexpected vlaue for enum VariantScalarTypeId: {r}");
+                tracing::error!("Got unexpected vlaue for enum VariantScalarTypeId: {r}");
                 return Err(StatusCode::BadDecodingError);
             }
         })

--- a/async-opcua-types/src/xml/mod.rs
+++ b/async-opcua-types/src/xml/mod.rs
@@ -14,8 +14,8 @@ use std::{
     str::FromStr,
 };
 
-use log::warn;
 pub use opcua_xml::schema::opc_ua_types::XmlElement;
+use tracing::warn;
 
 use crate::{
     Array, ByteString, ExpandedNodeId, ExtensionObject, LocalizedText, NodeId, QualifiedName,

--- a/async-opcua/Cargo.toml
+++ b/async-opcua/Cargo.toml
@@ -46,7 +46,6 @@ xml = ["async-opcua-types/xml", "async-opcua-nodes/xml", "async-opcua-xml"]
 
 [dependencies]
 chrono = { workspace = true }
-log = { workspace = true }
 
 async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.14.0" }
 async-opcua-core = { path = "../async-opcua-core", version = "0.14.0" }
@@ -66,6 +65,7 @@ tempdir = "0.3"
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 env_logger = { workspace = true }
+log = { workspace = true }
 
 # Include json when building tests
 async-opcua = { path = ".", features = ["all", "json", "xml"] }


### PR DESCRIPTION
This lays the foundation for much more thorough tracing support in the main libraries. Tracing supports more or less drop-in support for log, just replacing any use of the log macros with the same tracing macros. Using the `log` feature, we can also emit tracing events as log events, so consumers can consume them via normal logging. Hence, this should not be a breaking change. We are still producing the same log events as before.

Next up is actually using tracing to properly trace methods on the server and client, both informative tracing and timing traces.