### PR TITLE
Add tracing to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1648,6 +1649,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ thiserror = "^1"
 tokio = { version = "^1", features = ["full"] }
 tokio-util = { version = "^0.7", features = ["codec"] }
 tracing = { version = "0.1.41", features = ["log"] }
+tracing-futures = "0.2.5"
 url = "^2"
 uuid = { version = "^1", features = ["v4"] }
 

--- a/async-opcua-client/src/session/services/subscriptions/service.rs
+++ b/async-opcua-client/src/session/services/subscriptions/service.rs
@@ -1743,7 +1743,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<MonitoredItemCreateResult>)` - A list of [`MonitoredItemCreateResult`] corresponding to the items to create.
-    ///    The size and order of the list matches the size and order of the `items_to_create` request parameter.
+    ///   The size and order of the list matches the size and order of the `items_to_create` request parameter.
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn create_monitored_items(
@@ -1774,7 +1774,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<MonitoredItemModifyResult>)` - A list of [`MonitoredItemModifyResult`] corresponding to the MonitoredItems to modify.
-    ///    The size and order of the list matches the size and order of the `items_to_modify` request parameter.
+    ///   The size and order of the list matches the size and order of the `items_to_modify` request parameter.
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn modify_monitored_items(

--- a/async-opcua-client/src/session/services/view.rs
+++ b/async-opcua-client/src/session/services/view.rs
@@ -453,7 +453,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<BrowseResult>)` - A list [`BrowseResult`] corresponding to each node to browse. A browse result
-    ///                                    may contain a continuation point, for use with `browse_next()`.
+    ///   may contain a continuation point, for use with `browse_next()`.
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn browse(
@@ -485,7 +485,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Option<Vec<BrowseResult>)` - A list [`BrowseResult`] corresponding to each node to browse. A browse result
-    ///                                    may contain a continuation point, for use with `browse_next()`.
+    ///   may contain a continuation point, for use with `browse_next()`.
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn browse_next(
@@ -516,8 +516,8 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<BrowsePathResult>>)` - List of [`BrowsePathResult`] for the list of browse
-    ///                       paths. The size and order of the list matches the size and order of the `browse_paths`
-    ///                       parameter.
+    ///   paths. The size and order of the list matches the size and order of the `browse_paths`
+    ///   parameter.
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn translate_browse_paths_to_node_ids(
@@ -545,7 +545,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<NodeId>)` - A list of [`NodeId`] corresponding to size and order of the input. The
-    ///                       server may return an alias for the input `NodeId`
+    ///   server may return an alias for the input `NodeId`
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn register_nodes(

--- a/async-opcua-core/src/comms/buffer.rs
+++ b/async-opcua-core/src/comms/buffer.rs
@@ -81,7 +81,6 @@ impl SendBuffer {
             return Ok(());
         };
 
-        trace!("Sending chunk {:?}", next_chunk);
         let size = match next_chunk {
             PendingPayload::Chunk(c) => secure_channel.apply_security(&c, self.buffer.get_mut())?,
             PendingPayload::Ack(a) => {

--- a/async-opcua-core/src/messages/request.rs
+++ b/async-opcua-core/src/messages/request.rs
@@ -42,6 +42,13 @@ macro_rules! request_enum {
                     $( Self::$name(value) => &value.request_header, )*
                 }
             }
+
+            /// Get the name of the request variant, for debugging and logging.
+            pub fn type_name(&self) -> &'static str {
+                match self {
+                    $( Self::$name(_) => stringify!($name), )*
+                }
+            }
         }
 
         impl Message for RequestMessage {

--- a/async-opcua-core/src/messages/response.rs
+++ b/async-opcua-core/src/messages/response.rs
@@ -42,6 +42,13 @@ macro_rules! response_enum {
                     $( Self::$name(value) => &value.response_header, )*
                 }
             }
+
+            /// Get the name of the request variant, for debugging and logging.
+            pub fn type_name(&self) -> &'static str {
+                match self {
+                    $( Self::$name(_) => stringify!($name), )*
+                }
+            }
         }
 
         impl Message for ResponseMessage {

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -41,6 +41,7 @@ serde = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-futures = { workspace = true }
 
 async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.14.0" }
 async-opcua-core = { path = "../async-opcua-core", version = "0.14.0" }

--- a/async-opcua-server/src/node_manager/context.rs
+++ b/async-opcua-server/src/node_manager/context.rs
@@ -10,6 +10,8 @@ use opcua_core::{sync::RwLock, trace_read_lock};
 use opcua_nodes::TypeTree;
 use opcua_types::{BrowseDescriptionResultMask, NodeId};
 use parking_lot::lock_api::{RawRwLock, RwLockReadGuard};
+use tracing::debug_span;
+use tracing_futures::Instrument;
 
 use super::{
     view::{ExternalReferenceRequest, NodeMetadata},
@@ -104,7 +106,9 @@ pub(crate) async fn resolve_external_references(
             .filter(|r| nm.owns_node(r.node_id()))
             .collect();
 
-        nm.resolve_external_references(context, &mut items).await;
+        nm.resolve_external_references(context, &mut items)
+            .instrument(debug_span!("resolve external references", node_manager = %nm.name()))
+            .await;
     }
 
     res.into_iter().map(|r| r.into_inner()).collect()

--- a/async-opcua-server/src/session/services/subscriptions.rs
+++ b/async-opcua-server/src/session/services/subscriptions.rs
@@ -7,6 +7,8 @@ use crate::{
 use opcua_types::{
     DeleteSubscriptionsRequest, DeleteSubscriptionsResponse, ResponseHeader, StatusCode,
 };
+use tracing::debug_span;
+use tracing_futures::Instrument;
 
 pub async fn delete_subscriptions(
     node_managers: NodeManagers,
@@ -62,7 +64,9 @@ pub async fn delete_subscriptions_inner(
             continue;
         }
 
-        mgr.delete_monitored_items(context, &owned).await;
+        mgr.delete_monitored_items(context, &owned)
+            .instrument(debug_span!("DeleteMonitoredItems", node_manager = %mgr.name()))
+            .await;
     }
 
     Ok(results.into_iter().map(|r| r.0).collect())

--- a/async-opcua-server/src/transport/tcp.rs
+++ b/async-opcua-server/src/transport/tcp.rs
@@ -16,6 +16,7 @@ use opcua_core::{
     RequestMessage, ResponseMessage,
 };
 use tracing::error;
+use tracing_futures::Instrument;
 
 use crate::info::ServerInfo;
 use opcua_types::{DecodingOptions, Error, ResponseHeader, ServiceFault, StatusCode};
@@ -210,7 +211,7 @@ impl Connector for TcpConnector {
             _ = token.cancelled() => {
                 ErrorMessage::new(StatusCode::BadServerHalted, "Server closed")
             }
-            r = self.connect_inner(info) => {
+            r = self.connect_inner(info).instrument(tracing::info_span!("OPC-UA TCP handshake")) => {
                 match r {
                     Ok(r) => return Ok(TcpTransport::new(self.read, self.write, r)),
                     Err(e) => e,


### PR DESCRIPTION
This adds layered tracing to the server, and cleans up what we log a bit (logging the message chunks is insane).

Tracing is nice and automatic, though you do have to be careful about tracing over await points. This should make it possible (with the correct subscriber) to produce structured spans for each request on the server. When not using tracing, it provides decent debug-level logs with some level of detail.

We trace connection establishment, requests on the top level, as well as per call to a node manager. Node managers can do their own tracing and logging, which will automatically be part of the top level span.