### PR TITLE
More diagnostics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,4 @@ This is a list of things that are known to be missing, or ideas that could be im
  - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
  - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.
  - Look into running certain services concurrently. Currently they are sequential because that makes everything much simpler, but the services that don't have any cross node-manager interaction could run on all node managers concurrently.
- - Use NodeSet2 file for types code gen instead of the .bsd file. There is some info here (like data types being abstract), that you can't get from anywhere else.
-   - In general, the codegen could use some more work. The current approach isn't really ideal. We should probably unify all the different code gen targets, since they generally depend on a lot of the same data and we risk reading the same data multiple times.
- - Tracing and detailed logging in the server and client.
+ - Tracing and detailed logging in the client.

--- a/async-opcua-server/src/authenticator.rs
+++ b/async-opcua-server/src/authenticator.rs
@@ -66,6 +66,13 @@ impl UserToken {
     }
 }
 
+/// Permissions for the core and diagnostics node managers.
+#[derive(Default, Debug, Clone)]
+pub struct CoreServerPermissions {
+    /// Whether the user can read the server diagnostics.
+    pub read_diagnostics: bool,
+}
+
 #[allow(unused)]
 #[async_trait]
 /// The AuthManager trait is used to let servers control access to the server.
@@ -158,6 +165,11 @@ pub trait AuthManager: Send + Sync + 'static {
         self.user_token_policies(endpoint)
             .iter()
             .any(|e| e.token_type == UserTokenType::Certificate)
+    }
+
+    /// Return the permissions for the core server for the given user.
+    fn core_permissions(&self, token: &UserToken) -> CoreServerPermissions {
+        CoreServerPermissions::default()
     }
 }
 
@@ -302,6 +314,15 @@ impl AuthManager for DefaultAuthenticator {
         }
 
         user_identity_tokens
+    }
+
+    fn core_permissions(&self, token: &UserToken) -> CoreServerPermissions {
+        self.users
+            .get(token.0.as_str())
+            .map(|r| CoreServerPermissions {
+                read_diagnostics: r.read_diagnostics,
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/async-opcua-server/src/builder.rs
+++ b/async-opcua-server/src/builder.rs
@@ -45,7 +45,7 @@ impl Default for ServerBuilder {
                         super::node_manager::memory::CoreNodeManagerBuilder,
                     ),
                 )
-                .with_node_manager(super::node_manager::memory::DiagnosticsNodeManagerBuilder)
+                .with_node_manager(super::diagnostics::DiagnosticsNodeManagerBuilder)
         }
         #[cfg(not(feature = "generated-address-space"))]
         builder

--- a/async-opcua-server/src/builder.rs
+++ b/async-opcua-server/src/builder.rs
@@ -549,4 +549,11 @@ impl ServerBuilder {
         self.type_loaders.add(loader);
         self
     }
+
+    /// Set whether to enable diagnostics on the server or not.
+    /// Only users with the right permissions can read the diagnostics
+    pub fn diagnostics_enabled(mut self, enabled: bool) -> Self {
+        self.config.diagnostics = enabled;
+        self
+    }
 }

--- a/async-opcua-server/src/config/server.rs
+++ b/async-opcua-server/src/config/server.rs
@@ -49,6 +49,9 @@ pub struct ServerUserToken {
     /// X509 thumbprint.
     #[serde(skip)]
     pub thumbprint: Option<Thumbprint>,
+    #[serde(default)]
+    /// Access to read diagnostics on the server.
+    pub read_diagnostics: bool,
 }
 
 impl ServerUserToken {
@@ -62,6 +65,7 @@ impl ServerUserToken {
             pass: Some(pass.into()),
             x509: None,
             thumbprint: None,
+            read_diagnostics: false,
         }
     }
 
@@ -75,6 +79,7 @@ impl ServerUserToken {
             pass: None,
             x509: Some(cert_path.to_string_lossy().to_string()),
             thumbprint: None,
+            read_diagnostics: false,
         }
     }
 
@@ -131,6 +136,12 @@ impl ServerUserToken {
     /// Return `true` if this token is for X509-based auth.
     pub fn is_x509(&self) -> bool {
         self.x509.is_some()
+    }
+
+    /// Set the ability for the user to read diagnostics on the server.
+    pub fn read_diagnostics(mut self, read: bool) -> Self {
+        self.read_diagnostics = read;
+        self
     }
 }
 
@@ -223,6 +234,9 @@ pub struct ServerConfig {
     /// we will instantly time out.
     #[serde(default = "defaults::max_session_timeout_ms")]
     pub max_session_timeout_ms: u64,
+    /// Enable server diagnostics.
+    #[serde(default)]
+    pub diagnostics: bool,
 }
 
 mod defaults {
@@ -375,6 +389,7 @@ impl Default for ServerConfig {
             max_timeout_ms: defaults::max_timeout_ms(),
             max_secure_channel_token_lifetime_ms: defaults::max_secure_channel_token_lifetime_ms(),
             max_session_timeout_ms: defaults::max_session_timeout_ms(),
+            diagnostics: false,
         }
     }
 }

--- a/async-opcua-server/src/diagnostics/diagnostics.rs
+++ b/async-opcua-server/src/diagnostics/diagnostics.rs
@@ -6,20 +6,16 @@ use std::{
 
 use async_trait::async_trait;
 use opcua_core::trace_read_lock;
+use opcua_nodes::DefaultTypeTree;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     address_space::AccessLevel,
     node_manager::{
-        as_opaque_node_id,
-        build::NodeManagerBuilder,
-        from_opaque_node_id,
-        view::{
-            impl_translate_browse_paths_using_browse, AddReferenceResult, ExternalReferenceRequest,
-            NodeMetadata,
-        },
-        BrowseNode, BrowsePathItem, DefaultTypeTree, DynNodeManager, NodeManager, NodeManagersRef,
-        ReadNode, RequestContext, ServerContext, SyncSampler,
+        as_opaque_node_id, from_opaque_node_id, impl_translate_browse_paths_using_browse,
+        AddReferenceResult, BrowseNode, BrowsePathItem, DynNodeManager, ExternalReferenceRequest,
+        NodeManager, NodeManagerBuilder, NodeManagersRef, NodeMetadata, ReadNode, RequestContext,
+        ServerContext, SyncSampler,
     },
 };
 use opcua_types::{

--- a/async-opcua-server/src/diagnostics/mod.rs
+++ b/async-opcua-server/src/diagnostics/mod.rs
@@ -1,0 +1,4 @@
+//! This module contains the diagnostics node manager, and related types.
+
+mod diagnostics;
+pub use diagnostics::{DiagnosticsNodeManager, DiagnosticsNodeManagerBuilder, NamespaceMetadata};

--- a/async-opcua-server/src/diagnostics/mod.rs
+++ b/async-opcua-server/src/diagnostics/mod.rs
@@ -1,4 +1,80 @@
 //! This module contains the diagnostics node manager, and related types.
 
-mod diagnostics;
-pub use diagnostics::{DiagnosticsNodeManager, DiagnosticsNodeManagerBuilder, NamespaceMetadata};
+mod node_manager;
+mod server;
+pub use node_manager::{DiagnosticsNodeManager, DiagnosticsNodeManagerBuilder, NamespaceMetadata};
+use opcua_core::sync::Mutex;
+use opcua_types::{DataValue, DateTime, IntoVariant};
+pub use server::{ServerDiagnostics, ServerDiagnosticsSummary};
+
+#[derive(Default)]
+/// Wrapper around a value in memory, used for metrics.
+/// We need to use a mutex to keep track of when the value was last
+/// updated.
+pub struct LocalValue<T> {
+    inner: Mutex<LocalValueInner<T>>,
+}
+
+#[derive(Default)]
+struct LocalValueInner<T> {
+    pub value: T,
+    pub timestamp: DateTime,
+}
+
+impl<T: Clone + IntoVariant> LocalValue<T> {
+    /// Create a new LocalValue with the given value.
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Mutex::new(LocalValueInner {
+                value,
+                timestamp: DateTime::now(),
+            }),
+        }
+    }
+
+    /// Update the value and set the timestamp.
+    pub fn modify(&self, fun: impl FnOnce(&mut T)) {
+        let mut inner = self.inner.lock();
+        fun(&mut inner.value);
+        inner.timestamp = DateTime::now();
+    }
+
+    /// Set the value and update the timestamp.
+    pub fn set(&self, value: T) {
+        let mut inner = self.inner.lock();
+        inner.value = value;
+        inner.timestamp = DateTime::now();
+    }
+
+    /// Get the current value as a datavalue.
+    pub fn sample(&self) -> DataValue {
+        let inner = self.inner.lock();
+        DataValue::new_at(inner.value.clone().into_variant(), inner.timestamp)
+    }
+
+    /// Get the current value.
+    pub fn get(&self) -> T {
+        let inner = self.inner.lock();
+        inner.value.clone()
+    }
+
+    /// Get the current value and timestamp.
+    pub fn get_with_time(&self) -> (T, DateTime) {
+        let inner = self.inner.lock();
+        (inner.value.clone(), inner.timestamp)
+    }
+}
+
+impl LocalValue<u32> {
+    /// Convenience function to increment the value.
+    pub fn increment(&self) {
+        self.modify(|v| *v += 1);
+    }
+
+    /// Convenience function to decrement the value.
+    pub fn decrement(&self) {
+        self.modify(|v| {
+            *v = v.saturating_sub(1);
+        });
+    }
+}

--- a/async-opcua-server/src/diagnostics/node_manager.rs
+++ b/async-opcua-server/src/diagnostics/node_manager.rs
@@ -650,7 +650,6 @@ impl NodeManager for DiagnosticsNodeManager {
                 }
             } else if node.node_id().namespace == self.namespace_index {
                 let Some(node_desc) = from_opaque_node_id::<DiagnosticsNode>(node.node_id()) else {
-                    tracing::warn!("Unknown node...");
                     node.set_status(StatusCode::BadNodeIdUnknown);
                     continue;
                 };

--- a/async-opcua-server/src/diagnostics/server.rs
+++ b/async-opcua-server/src/diagnostics/server.rs
@@ -1,0 +1,211 @@
+use opcua_types::{DataValue, ServerDiagnosticsSummaryDataType, VariableId};
+
+use super::LocalValue;
+
+/// The server diagnostics struct, containing shared
+/// types for various forms of server diagnostics.
+#[derive(Default)]
+pub struct ServerDiagnostics {
+    /// Server diagnostics summary.
+    pub summary: ServerDiagnosticsSummary,
+    /// Whether diagnostics are enabled or not.
+    /// Set on server startup.
+    pub enabled: bool,
+}
+
+impl ServerDiagnostics {
+    /// Check if the given variable ID is managed by this object.
+    pub fn is_mapped(&self, variable_id: VariableId) -> bool {
+        self.enabled && self.summary.is_mapped(variable_id)
+    }
+
+    /// Get the value of a diagnostics element by its ID.
+    pub fn get(&self, variable_id: VariableId) -> Option<DataValue> {
+        self.summary.get(variable_id)
+    }
+
+    /// Set the current session count.
+    pub fn set_current_session_count(&self, count: u32) {
+        if self.enabled {
+            self.summary.current_session_count.set(count);
+        }
+    }
+
+    /// Set the current subscription count.
+    pub fn set_current_subscription_count(&self, count: u32) {
+        if self.enabled {
+            self.summary.current_subscription_count.set(count);
+        }
+    }
+
+    /// Increment the cumulated session count.
+    pub fn inc_session_count(&self) {
+        if self.enabled {
+            self.summary.cumulated_session_count.increment();
+        }
+    }
+
+    /// Increment the cumulated subscription count.
+    pub fn inc_subscription_count(&self) {
+        if self.enabled {
+            self.summary.cumulated_subscription_count.increment();
+        }
+    }
+
+    /// Increment the rejected requests count.
+    pub fn inc_rejected_requests(&self) {
+        if self.enabled {
+            self.summary.rejected_requests_count.increment();
+        }
+    }
+
+    /// Increment the security rejected requests count.
+    pub fn inc_security_rejected_requests(&self) {
+        if self.enabled {
+            self.summary.security_rejected_requests_count.increment();
+        }
+    }
+
+    /// Increment the security rejected session count.
+    pub fn inc_security_rejected_session_count(&self) {
+        if self.enabled {
+            self.summary.security_rejected_session_count.increment();
+        }
+    }
+
+    /// Set the number of server-created views.
+    pub fn set_server_view_count(&self, count: u32) {
+        if self.enabled {
+            self.summary.server_view_count.set(count);
+        }
+    }
+
+    /// Increment the session abort count.
+    pub fn inc_session_abort_count(&self) {
+        if self.enabled {
+            self.summary.session_abort_count.increment();
+        }
+    }
+
+    /// Increment the session timeout count.
+    pub fn inc_session_timeout_count(&self) {
+        if self.enabled {
+            self.summary.session_timeout_count.increment();
+        }
+    }
+
+    /// Set the number of publishing intervals supported by the server.
+    pub fn set_publishing_interval_count(&self, count: u32) {
+        if self.enabled {
+            self.summary.publishing_interval_count.set(count);
+        }
+    }
+}
+
+/// The server diagnostics summary type. Users with approparite
+/// permissions can read these values.
+#[derive(Default)]
+pub struct ServerDiagnosticsSummary {
+    /// The number of sessions that have been created since the server started.
+    cumulated_session_count: LocalValue<u32>,
+    /// The number of subscriptions that have been created since the server started.
+    cumulated_subscription_count: LocalValue<u32>,
+    /// The number of sessions that are currently active.
+    current_session_count: LocalValue<u32>,
+    /// The number of subscriptions that are currently active.
+    current_subscription_count: LocalValue<u32>,
+    /// The number of publishing intervals that have been created since the server started.
+    publishing_interval_count: LocalValue<u32>,
+    /// The number of rejected requests since the server started.
+    rejected_requests_count: LocalValue<u32>,
+    /// The number of rejected sessions since the server started.
+    rejected_session_count: LocalValue<u32>,
+    /// The number of security rejected requests since the server started.
+    security_rejected_requests_count: LocalValue<u32>,
+    /// The number of security rejected sessions since the server started.
+    security_rejected_session_count: LocalValue<u32>,
+    /// The number of server-created views in the server.
+    server_view_count: LocalValue<u32>,
+    /// The number of sessions that were closed due to errors since the server started.
+    session_abort_count: LocalValue<u32>,
+    /// The number of sessions that timed out since the server started.
+    session_timeout_count: LocalValue<u32>,
+}
+
+impl ServerDiagnosticsSummary {
+    /// Check if the given variable ID is managed by this object.
+    pub fn is_mapped(&self, variable_id: VariableId) -> bool {
+        matches!(variable_id,
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_ServerViewCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CurrentSessionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CumulatedSessionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SecurityRejectedSessionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_RejectedSessionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SessionTimeoutCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SessionAbortCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CurrentSubscriptionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CumulatedSubscriptionCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_PublishingIntervalCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SecurityRejectedRequestsCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_RejectedRequestsCount
+            | VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary
+        )
+    }
+
+    /// Get the value of a variable by its ID.
+    pub fn get(&self, variable_id: VariableId) -> Option<DataValue> {
+        match variable_id {
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_ServerViewCount => Some(self.server_view_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CurrentSessionCount => Some(self.current_session_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CumulatedSessionCount => Some(self.cumulated_session_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SecurityRejectedSessionCount => Some(self.security_rejected_session_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_RejectedSessionCount => Some(self.rejected_session_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SessionTimeoutCount => Some(self.session_timeout_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SessionAbortCount => Some(self.session_abort_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CurrentSubscriptionCount => Some(self.current_subscription_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_CumulatedSubscriptionCount => Some(self.cumulated_subscription_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_PublishingIntervalCount => Some(self.publishing_interval_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_SecurityRejectedRequestsCount => Some(self.security_rejected_requests_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary_RejectedRequestsCount => Some(self.rejected_requests_count.sample()),
+            VariableId::Server_ServerDiagnostics_ServerDiagnosticsSummary => Some(self.sample()),
+            _ => None,
+        }
+    }
+
+    /// Get the current value of the server diagnostics summary.
+    pub fn sample(&self) -> DataValue {
+        let values = [
+            self.server_view_count.get_with_time(),
+            self.current_session_count.get_with_time(),
+            self.cumulated_session_count.get_with_time(),
+            self.security_rejected_session_count.get_with_time(),
+            self.rejected_session_count.get_with_time(),
+            self.session_timeout_count.get_with_time(),
+            self.session_abort_count.get_with_time(),
+            self.current_subscription_count.get_with_time(),
+            self.cumulated_subscription_count.get_with_time(),
+            self.publishing_interval_count.get_with_time(),
+            self.security_rejected_requests_count.get_with_time(),
+            self.rejected_requests_count.get_with_time(),
+        ];
+        let ts = values.iter().map(|v| v.1).max().unwrap();
+
+        DataValue::new_at(
+            ServerDiagnosticsSummaryDataType {
+                server_view_count: values[0].0,
+                current_session_count: values[1].0,
+                cumulated_session_count: values[2].0,
+                security_rejected_session_count: values[3].0,
+                rejected_session_count: values[4].0,
+                session_timeout_count: values[5].0,
+                session_abort_count: values[6].0,
+                current_subscription_count: values[7].0,
+                cumulated_subscription_count: values[8].0,
+                publishing_interval_count: values[9].0,
+                security_rejected_requests_count: values[10].0,
+                rejected_requests_count: values[11].0,
+            },
+            ts,
+        )
+    }
+}

--- a/async-opcua-server/src/info.rs
+++ b/async-opcua-server/src/info.rs
@@ -12,6 +12,7 @@ use opcua_nodes::DefaultTypeTree;
 use tracing::{debug, error, warn};
 
 use crate::authenticator::{user_pass_security_policy_id, Password};
+use crate::diagnostics::{ServerDiagnostics, ServerDiagnosticsSummary};
 use crate::node_manager::TypeTreeForUser;
 use opcua_core::comms::url::{hostname_from_url, url_matches_except_host};
 use opcua_core::handle::AtomicHandle;
@@ -85,6 +86,8 @@ pub struct ServerInfo {
     pub port: AtomicU16,
     /// List of active type loaders
     pub type_loaders: RwLock<TypeLoaderCollection>,
+    /// Current server diagnostics.
+    pub diagnostics: ServerDiagnostics,
 }
 
 impl ServerInfo {
@@ -548,6 +551,11 @@ impl ServerInfo {
     /// work, but there will be a small performance overhead.
     pub fn add_type_loader(&self, type_loader: Arc<dyn TypeLoader>) {
         self.type_loaders.write().add(type_loader);
+    }
+
+    /// Convenience method to get the diagnostics summary.
+    pub fn summary(&self) -> &ServerDiagnosticsSummary {
+        &self.diagnostics.summary
     }
 
     /* pub(crate) fn raise_and_log<T>(&self, event: T) -> Result<NodeId, ()>

--- a/async-opcua-server/src/lib.rs
+++ b/async-opcua-server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod address_space;
 pub mod authenticator;
 mod builder;
 mod config;
+pub mod diagnostics;
 #[cfg(feature = "discovery-server-registration")]
 mod discovery;
 mod identity_token;

--- a/async-opcua-server/src/node_manager/memory/core.rs
+++ b/async-opcua-server/src/node_manager/memory/core.rs
@@ -7,6 +7,7 @@ use opcua_nodes::NodeType;
 
 use crate::{
     address_space::{read_node_value, AddressSpace, CoreNamespace},
+    diagnostics::NamespaceMetadata,
     load_method_args,
     node_manager::{
         MethodCall, MonitoredItemRef, MonitoredItemUpdateRef, NodeManagersRef, ParsedReadValueId,
@@ -22,9 +23,7 @@ use opcua_types::{
     VariableId, Variant, VariantScalarTypeId, VariantTypeId,
 };
 
-use super::{
-    InMemoryNodeManager, InMemoryNodeManagerImpl, InMemoryNodeManagerImplBuilder, NamespaceMetadata,
-};
+use super::{InMemoryNodeManager, InMemoryNodeManagerImpl, InMemoryNodeManagerImplBuilder};
 
 /// Node manager impl for the core namespace.
 pub struct CoreNodeManagerImpl {

--- a/async-opcua-server/src/node_manager/memory/memory_mgr_impl.rs
+++ b/async-opcua-server/src/node_manager/memory/memory_mgr_impl.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     address_space::AddressSpace,
+    diagnostics::NamespaceMetadata,
     node_manager::{
         AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem, HistoryNode,
         HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef, ParsedReadValueId,
@@ -15,8 +16,6 @@ use opcua_types::{
     ReadAtTimeDetails, ReadEventDetails, ReadProcessedDetails, ReadRawModifiedDetails, StatusCode,
     TimestampsToReturn,
 };
-
-use super::NamespaceMetadata;
 
 /// Trait for constructing an [InMemoryNodeManagerImpl].
 ///

--- a/async-opcua-server/src/node_manager/memory/mod.rs
+++ b/async-opcua-server/src/node_manager/memory/mod.rs
@@ -2,7 +2,6 @@
 //! all its nodes in memory, and delegates implementing
 //! details to a type implementing [InMemoryNodeManagerImpl].
 
-mod diagnostics;
 mod memory_mgr_impl;
 mod simple;
 
@@ -12,7 +11,6 @@ mod core;
 #[cfg(feature = "generated-address-space")]
 pub use core::{CoreNodeManager, CoreNodeManagerBuilder, CoreNodeManagerImpl};
 
-pub use diagnostics::{DiagnosticsNodeManager, DiagnosticsNodeManagerBuilder, NamespaceMetadata};
 pub use memory_mgr_impl::*;
 use opcua_core::{trace_read_lock, trace_write_lock};
 pub use simple::*;
@@ -31,6 +29,7 @@ use crate::{
         read_node_value, user_access_level, AccessLevel, EventNotifier, NodeType,
         ReferenceDirection,
     },
+    diagnostics::NamespaceMetadata,
     subscriptions::CreateMonitoredItem,
     SubscriptionCache,
 };

--- a/async-opcua-server/src/node_manager/mod.rs
+++ b/async-opcua-server/src/node_manager/mod.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use memory::NamespaceMetadata;
 use opcua_core::sync::RwLock;
 use opcua_nodes::DefaultTypeTree;
 use opcua_types::{
@@ -31,9 +30,7 @@ mod query;
 mod utils;
 mod view;
 
-use crate::ServerStatusWrapper;
-
-use self::view::ExternalReferenceRequest;
+use crate::{diagnostics::NamespaceMetadata, ServerStatusWrapper};
 
 use super::{
     authenticator::AuthManager, info::ServerInfo, subscriptions::CreateMonitoredItem,
@@ -50,7 +47,10 @@ pub use {
     node_management::{AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem},
     query::{ParsedNodeTypeDescription, ParsedQueryDataDescription, QueryRequest},
     utils::*,
-    view::{AddReferenceResult, BrowseNode, BrowsePathItem, ExternalReference, RegisterNodeItem},
+    view::{
+        impl_translate_browse_paths_using_browse, AddReferenceResult, BrowseNode, BrowsePathItem,
+        ExternalReference, ExternalReferenceRequest, NodeMetadata, RegisterNodeItem,
+    },
 };
 
 pub(crate) use context::resolve_external_references;

--- a/async-opcua-server/src/node_manager/view.rs
+++ b/async-opcua-server/src/node_manager/view.rs
@@ -35,6 +35,8 @@ pub struct NodeMetadata {
 }
 
 impl NodeMetadata {
+    /// Convert this metadata into a ReferenceDescription with given
+    /// direction and reference type ID.
     pub fn into_ref_desc(
         self,
         is_forward: bool,

--- a/async-opcua-server/src/server.rs
+++ b/async-opcua-server/src/server.rs
@@ -25,6 +25,7 @@ use opcua_core::{config::Config, handle::AtomicHandle};
 use opcua_crypto::CertificateStore;
 
 use crate::{
+    diagnostics::ServerDiagnostics,
     node_manager::{DefaultTypeTreeGetter, ServerContext},
     session::controller::{ControllerCommand, SessionStarter},
     transport::tcp::{TcpConnector, TransportConfig},
@@ -162,6 +163,10 @@ impl Server {
                 .type_tree_getter
                 .unwrap_or_else(|| Arc::new(DefaultTypeTreeGetter)),
             type_loaders: RwLock::new(builder.type_loaders),
+            diagnostics: ServerDiagnostics {
+                enabled: config.diagnostics,
+                ..Default::default()
+            },
         };
 
         let certificate_store = Arc::new(RwLock::new(certificate_store));

--- a/async-opcua-server/src/session/services/subscriptions.rs
+++ b/async-opcua-server/src/session/services/subscriptions.rs
@@ -50,7 +50,8 @@ pub async fn delete_subscriptions_inner(
     subscriptions: &SubscriptionCache,
     context: &mut RequestContext,
 ) -> Result<Vec<StatusCode>, StatusCode> {
-    let results = subscriptions.delete_subscriptions(context.session_id, &to_delete)?;
+    let results =
+        subscriptions.delete_subscriptions(context.session_id, &to_delete, &context.info)?;
 
     for (idx, mgr) in node_managers.iter().enumerate() {
         context.current_node_manager_index = idx;

--- a/async-opcua/tests/utils/node_manager.rs
+++ b/async-opcua/tests/utils/node_manager.rs
@@ -11,10 +11,7 @@ use opcua::{
         },
         node_manager::{
             get_node_metadata,
-            memory::{
-                InMemoryNodeManager, InMemoryNodeManagerBuilder, InMemoryNodeManagerImpl,
-                NamespaceMetadata,
-            },
+            memory::{InMemoryNodeManager, InMemoryNodeManagerBuilder, InMemoryNodeManagerImpl},
             AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem, HistoryNode,
             HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef,
             NodeManagerBuilder, NodeManagersRef, ParsedReadValueId, RequestContext, ServerContext,
@@ -31,7 +28,7 @@ use opcua::{
 };
 use opcua_core::{trace_read_lock, trace_write_lock};
 use opcua_nodes::{DefaultTypeTree, TypeTree, TypeTreeNode};
-use opcua_server::address_space::add_namespaces;
+use opcua_server::{address_space::add_namespaces, diagnostics::NamespaceMetadata};
 use opcua_types::DataEncoding;
 
 #[allow(unused)]

--- a/async-opcua/tests/utils/tester.rs
+++ b/async-opcua/tests/utils/tester.rs
@@ -97,7 +97,8 @@ pub fn default_server() -> ServerBuilder {
             ServerUserToken::user_pass(
                 CLIENT_USERPASS_ID,
                 &format!("{CLIENT_USERPASS_ID}_password"),
-            ),
+            )
+            .read_diagnostics(true),
         )
         .add_user_token(
             CLIENT_X509_ID,

--- a/samples/chess-server/src/main.rs
+++ b/samples/chess-server/src/main.rs
@@ -7,9 +7,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use opcua::server::address_space::VariableBuilder;
-use opcua::server::node_manager::memory::{
-    simple_node_manager, NamespaceMetadata, SimpleNodeManager,
-};
+use opcua::server::diagnostics::NamespaceMetadata;
+use opcua::server::node_manager::memory::{simple_node_manager, SimpleNodeManager};
 use opcua::server::{ServerBuilder, SubscriptionCache};
 use opcua::sync::Mutex;
 use opcua::types::*;

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -21,7 +21,8 @@ extern crate log;
 use std::{path::PathBuf, sync::Arc};
 
 use opcua::server::{
-    node_manager::memory::{simple_node_manager, NamespaceMetadata, SimpleNodeManager},
+    diagnostics::NamespaceMetadata,
+    node_manager::memory::{simple_node_manager, SimpleNodeManager},
     ServerBuilder,
 };
 

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -35,6 +35,7 @@ user_tokens:
   sample_password_user:
     user: sample1
     pass: sample1pwd
+    read_diagnostics: true
   sample_x509_user:
     user: sample_x509
     x509: ./users/sample-x509.der

--- a/samples/simple-server/src/main.rs
+++ b/samples/simple-server/src/main.rs
@@ -11,9 +11,9 @@ use std::time::{Duration, Instant};
 
 use log::warn;
 use opcua::server::address_space::Variable;
+use opcua::server::diagnostics::NamespaceMetadata;
 use opcua::server::node_manager::memory::{
-    simple_node_manager, InMemoryNodeManager, NamespaceMetadata, SimpleNodeManager,
-    SimpleNodeManagerImpl,
+    simple_node_manager, InMemoryNodeManager, SimpleNodeManager, SimpleNodeManagerImpl,
 };
 use opcua::server::{ServerBuilder, SubscriptionCache};
 use opcua::types::{BuildInfo, DataValue, DateTime, NodeId, UAString};
@@ -48,6 +48,7 @@ async fn main() {
             "simple",
         ))
         .trust_client_certs(true)
+        .diagnostics_enabled(true)
         .build()
         .unwrap();
     let node_manager = handle


### PR DESCRIPTION
Implement the server diagnostics summary. This all ends up being a little fiddly, since we need to implement both reading these values and subscribing to them, as part of the core node manager. We also need to track timestamps independently for them, if we want accurate source timestamps.

This is hopefully extensible enough to allow implementing some more diagnostics. 

This PR also introduces a new entry in user definitions, and in the auth manager, to indicate whether a user is allowed to read diagnostics.