### PR TITLE
Fix build of types module with only json or only xml

### DIFF
--- a/.github/workflows/ci_clippy.yml
+++ b/.github/workflows/ci_clippy.yml
@@ -12,3 +12,9 @@ jobs:
       
       - name: No default features
         run: cargo clippy --locked --no-default-features -- -D warnings
+
+      - name: Just xml
+        run: cargo clippy --locked --no-default-features --features xml -- -D warnings
+
+      - name: Just json
+        run: cargo clippy --locked --no-default-features --features json -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.15.1] - 2025-04-23
+
+Fix to a build issue in `types` when compiling with the `xml` feature but not the `json` feature,
+or only `json` and not `xml`.
+
+### Common
+
+#### Fixed
+ - Fix build of `async-opcua-types` when only one of the `json` or `xml` features are enabled.
+
 ## [0.15.0] - 2025-04-22
 
 Further changes and polish of the library. This release adds more comprehensive support for XML and JSON encoding, fixes a few bugs, and improves the ergonomics of defining custom types on servers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-opcua"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-opcua",
  "async-opcua-client",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-client"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arc-swap",
  "async-opcua-core",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-opcua-crypto",
  "async-opcua-types",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-core-namespace"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-opcua-nodes",
  "async-opcua-types",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-crypto"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "async-opcua-types",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-macros"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "base64 0.22.1",
  "convert_case",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-nodes"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-opcua-macros",
  "async-opcua-nodes",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-server"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arc-swap",
  "async-opcua-client",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-types"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-opcua-macros",
  "async-opcua-types",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "async-opcua-xml"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "quick-xml",

--- a/async-opcua-client/Cargo.toml
+++ b/async-opcua-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-client"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA client API"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -28,7 +28,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 
-async-opcua-core = { path = "../async-opcua-core", version = "0.15.0" }
-async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.0" }
-async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.0" }
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
+async-opcua-core = { path = "../async-opcua-core", version = "0.15.1" }
+async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.1" }
+async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.1" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }

--- a/async-opcua-codegen/Cargo.toml
+++ b/async-opcua-codegen/Cargo.toml
@@ -33,4 +33,4 @@ thiserror = "1.0.63"
 tracing = { workspace = true }
 uuid = "1.10.0"
 
-async-opcua-xml = { path = "../async-opcua-xml", version = "0.15.0" }
+async-opcua-xml = { path = "../async-opcua-xml", version = "0.15.1" }

--- a/async-opcua-core-namespace/Cargo.toml
+++ b/async-opcua-core-namespace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-core-namespace"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA generated code for the core namespace"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -16,5 +16,5 @@ edition = "2021"
 name = "opcua_core_namespace"
 
 [dependencies]
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
-async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.0" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
+async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.1" }

--- a/async-opcua-core/Cargo.toml
+++ b/async-opcua-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-core"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA core utils for client and server"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -27,8 +27,8 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
-async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.0" }
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
+async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.1" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/async-opcua-crypto/Cargo.toml
+++ b/async-opcua-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-crypto"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA cryptography library"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -21,7 +21,7 @@ gethostname = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
 
 aes = { workspace = true }
 cbc = { workspace = true }

--- a/async-opcua-macros/Cargo.toml
+++ b/async-opcua-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-macros"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA support proc macros"
 authors = ["Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"

--- a/async-opcua-nodes/Cargo.toml
+++ b/async-opcua-nodes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-nodes"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA node representation and import framework"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -25,9 +25,9 @@ tracing = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 
-async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.0" }
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
-async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.0" }
+async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.1" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
+async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.1" }
 
 [dev-dependencies]
 async-opcua-nodes = { path = ".", features = ["xml"] }

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-server"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA server API"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -43,12 +43,12 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 
-async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.15.0" }
-async-opcua-core = { path = "../async-opcua-core", version = "0.15.0" }
-async-opcua-core-namespace = { path = "../async-opcua-core-namespace", optional = true, version = "0.15.0" }
-async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.0" }
-async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.0" }
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
+async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.15.1" }
+async-opcua-core = { path = "../async-opcua-core", version = "0.15.1" }
+async-opcua-core-namespace = { path = "../async-opcua-core-namespace", optional = true, version = "0.15.1" }
+async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.1" }
+async-opcua-nodes = { path = "../async-opcua-nodes", version = "0.15.1" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
 
 [dev-dependencies]
 async-opcua-server = { path = ".", features = [

--- a/async-opcua-types/Cargo.toml
+++ b/async-opcua-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-types"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA data types"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -32,8 +32,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
-async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.0" }
-async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.0" }
+async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.1" }
+async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.1" }
 
 [dev-dependencies]
 async-opcua-types = { path = ".", features = ["xml", "json"] }

--- a/async-opcua-types/src/encoding.rs
+++ b/async-opcua-types/src/encoding.rs
@@ -9,6 +9,7 @@ use std::{
     error::Error as StdError,
     fmt::{Debug, Display},
     io::{Cursor, Read, Result, Write},
+    num::{ParseFloatError, ParseIntError},
     sync::atomic::{AtomicU64, Ordering},
 };
 
@@ -163,6 +164,18 @@ impl From<Error> for std::io::Error {
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
+        Self::decoding(value)
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(value: ParseIntError) -> Self {
+        Self::decoding(value)
+    }
+}
+
+impl From<ParseFloatError> for Error {
+    fn from(value: ParseFloatError) -> Self {
         Self::decoding(value)
     }
 }

--- a/async-opcua-types/src/extension_object.rs
+++ b/async-opcua-types/src/extension_object.rs
@@ -230,7 +230,7 @@ impl UaNullable for ExtensionObject {}
 mod json {
     use std::io::{Cursor, Read};
 
-    use crate::{json::*, xml::enter_first_tag, ByteString, Error, NodeId};
+    use crate::{json::*, ByteString, Error, NodeId};
 
     use super::ExtensionObject;
 
@@ -345,7 +345,7 @@ mod json {
                         let mut cursor = Cursor::new(string_body.as_bytes());
                         let mut inner_stream =
                             crate::xml::XmlStreamReader::new(&mut cursor as &mut dyn Read);
-                        if enter_first_tag(&mut inner_stream)? {
+                        if crate::xml::enter_first_tag(&mut inner_stream)? {
                             Ok(ctx.load_from_xml(&type_id, &mut inner_stream)?)
                         } else {
                             Ok(ExtensionObject::null())

--- a/async-opcua-types/src/json.rs
+++ b/async-opcua-types/src/json.rs
@@ -2,10 +2,7 @@
 //!
 //! Core utilities for JSON encoding and decoding from OPC-UA JSON.
 
-use std::{
-    io::{Cursor, Read, Write},
-    num::{ParseFloatError, ParseIntError},
-};
+use std::io::{Cursor, Read, Write};
 
 pub use crate::Context;
 use struson::writer::JsonNumberError;
@@ -30,18 +27,6 @@ pub trait JsonEncodable: UaNullable {
 
 impl From<struson::reader::ReaderError> for Error {
     fn from(value: struson::reader::ReaderError) -> Self {
-        Self::decoding(value)
-    }
-}
-
-impl From<ParseIntError> for Error {
-    fn from(value: ParseIntError) -> Self {
-        Self::decoding(value)
-    }
-}
-
-impl From<ParseFloatError> for Error {
-    fn from(value: ParseFloatError) -> Self {
         Self::decoding(value)
     }
 }

--- a/async-opcua-xml/Cargo.toml
+++ b/async-opcua-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua-xml"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "OPC UA XML loading library"
 authors = ["Einar Omang <einar@omang.com>"]

--- a/async-opcua/Cargo.toml
+++ b/async-opcua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-opcua"
-version = "0.15.0"
+version = "0.15.1"
 description = "OPC UA client and server API"
 authors = ["Adam Lock <locka99@gmail.com>", "Einar Omang <einar@omang.com>"]
 homepage = "https://github.com/freeopcua/async-opcua"
@@ -47,15 +47,15 @@ xml = ["async-opcua-types/xml", "async-opcua-nodes/xml", "async-opcua-xml"]
 [dependencies]
 chrono = { workspace = true }
 
-async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.15.0" }
-async-opcua-core = { path = "../async-opcua-core", version = "0.15.0" }
-async-opcua-core-namespace = { path = "../async-opcua-core-namespace", optional = true, version = "0.15.0" }
-async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.0" }
-async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.0" }
-async-opcua-nodes = { path = "../async-opcua-nodes", optional = true, version = "0.15.0" }
-async-opcua-server = { path = "../async-opcua-server", optional = true, default-features = false, version = "0.15.0" }
-async-opcua-types = { path = "../async-opcua-types", version = "0.15.0" }
-async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.0" }
+async-opcua-client = { path = "../async-opcua-client", optional = true, version = "0.15.1" }
+async-opcua-core = { path = "../async-opcua-core", version = "0.15.1" }
+async-opcua-core-namespace = { path = "../async-opcua-core-namespace", optional = true, version = "0.15.1" }
+async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.1" }
+async-opcua-macros = { path = "../async-opcua-macros", version = "0.15.1" }
+async-opcua-nodes = { path = "../async-opcua-nodes", optional = true, version = "0.15.1" }
+async-opcua-server = { path = "../async-opcua-server", optional = true, default-features = false, version = "0.15.1" }
+async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
+async-opcua-xml = { path = "../async-opcua-xml", optional = true, version = "0.15.1" }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/samples/custom-structures-client/Cargo.toml
+++ b/samples/custom-structures-client/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = { workspace = true }
 
 [dependencies.async-opcua]
 path = "../../async-opcua"
-version = "0.15.0"
+version = "0.15.1"
 features = ["client"]
 default-features = false
 


### PR DESCRIPTION
The release failed halfway through. I yanked the 0.15.0 version, and released a 0.15.1 version instead.

This fixes the build issues, and also adds steps to our build pipeline to hopefully prevent this in the future.