### PR TITLE
Add unused pub lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ members = [
   "fuzz",
 ]
 
+[workspace.lints.rust]
+missing_docs = "warn"
+unreachable_pub = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
 [workspace.dependencies]
 arc-swap = "^1"
 async-trait = "^0.1"

--- a/async-opcua-client/Cargo.toml
+++ b/async-opcua-client/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-client/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 name = "opcua_client"
 

--- a/async-opcua-client/src/browser/browse.rs
+++ b/async-opcua-client/src/browser/browse.rs
@@ -332,7 +332,7 @@ impl<
         }
     }
 
-    pub fn process_result(
+    pub(crate) fn process_result(
         &mut self,
         next: Vec<InnerResultItem>,
     ) -> Result<Vec<BrowseNextItem>, Error> {

--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -144,7 +144,7 @@ impl ClientEndpoint {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub struct DecodingOptions {
+pub(crate) struct DecodingOptions {
     /// Maximum size of a message chunk in bytes. 0 means no limit
     #[serde(default = "defaults::max_message_size")]
     pub(crate) max_message_size: usize,
@@ -169,7 +169,7 @@ pub struct DecodingOptions {
 }
 
 impl DecodingOptions {
-    pub fn as_comms_decoding_options(&self) -> opcua_types::DecodingOptions {
+    pub(crate) fn as_comms_decoding_options(&self) -> opcua_types::DecodingOptions {
         opcua_types::DecodingOptions {
             max_chunk_count: self.max_chunk_count,
             max_message_size: self.max_message_size,
@@ -197,7 +197,7 @@ impl Default for DecodingOptions {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub struct Performance {
+pub(crate) struct Performance {
     /// Ignore clock skew allows the client to make a successful connection to the server, even
     /// when the client and server clocks are out of sync.
     #[serde(default)]
@@ -474,83 +474,83 @@ mod defaults {
 
     use crate::retry::SessionRetryPolicy;
 
-    pub fn verify_server_certs() -> bool {
+    pub(super) fn verify_server_certs() -> bool {
         true
     }
 
-    pub fn channel_lifetime() -> u32 {
+    pub(super) fn channel_lifetime() -> u32 {
         60_000
     }
 
-    pub fn session_retry_limit() -> i32 {
+    pub(super) fn session_retry_limit() -> i32 {
         SessionRetryPolicy::DEFAULT_RETRY_LIMIT as i32
     }
 
-    pub fn session_retry_initial() -> Duration {
+    pub(super) fn session_retry_initial() -> Duration {
         Duration::from_secs(1)
     }
 
-    pub fn session_retry_max() -> Duration {
+    pub(super) fn session_retry_max() -> Duration {
         Duration::from_secs(30)
     }
 
-    pub fn keep_alive_interval() -> Duration {
+    pub(super) fn keep_alive_interval() -> Duration {
         Duration::from_secs(10)
     }
 
-    pub fn max_array_length() -> usize {
+    pub(super) fn max_array_length() -> usize {
         opcua_types::constants::MAX_ARRAY_LENGTH
     }
 
-    pub fn max_byte_string_length() -> usize {
+    pub(super) fn max_byte_string_length() -> usize {
         opcua_types::constants::MAX_BYTE_STRING_LENGTH
     }
 
-    pub fn max_chunk_count() -> usize {
+    pub(super) fn max_chunk_count() -> usize {
         opcua_types::constants::MAX_CHUNK_COUNT
     }
 
-    pub fn max_chunk_size() -> usize {
+    pub(super) fn max_chunk_size() -> usize {
         65535
     }
 
-    pub fn max_failed_keep_alive_count() -> u64 {
+    pub(super) fn max_failed_keep_alive_count() -> u64 {
         0
     }
 
-    pub fn max_incoming_chunk_size() -> usize {
+    pub(super) fn max_incoming_chunk_size() -> usize {
         65535
     }
 
-    pub fn max_message_size() -> usize {
+    pub(super) fn max_message_size() -> usize {
         opcua_types::constants::MAX_MESSAGE_SIZE
     }
 
-    pub fn max_string_length() -> usize {
+    pub(super) fn max_string_length() -> usize {
         opcua_types::constants::MAX_STRING_LENGTH
     }
 
-    pub fn request_timeout() -> Duration {
+    pub(super) fn request_timeout() -> Duration {
         Duration::from_secs(60)
     }
 
-    pub fn publish_timeout() -> Duration {
+    pub(super) fn publish_timeout() -> Duration {
         Duration::from_secs(60)
     }
 
-    pub fn min_publish_interval() -> Duration {
+    pub(super) fn min_publish_interval() -> Duration {
         Duration::from_millis(100)
     }
 
-    pub fn recreate_monitored_items_chunk() -> usize {
+    pub(super) fn recreate_monitored_items_chunk() -> usize {
         1000
     }
 
-    pub fn recreate_subscriptions() -> bool {
+    pub(super) fn recreate_subscriptions() -> bool {
         true
     }
 
-    pub fn session_timeout() -> u32 {
+    pub(super) fn session_timeout() -> u32 {
         60_000
     }
 }
@@ -613,7 +613,7 @@ mod tests {
         path
     }
 
-    pub fn sample_builder() -> ClientBuilder {
+    fn sample_builder() -> ClientBuilder {
         ClientBuilder::new()
             .application_name("OPC UA Sample Client")
             .application_uri("urn:SampleClient")
@@ -671,7 +671,7 @@ mod tests {
             )
     }
 
-    pub fn default_sample_config() -> ClientConfig {
+    fn default_sample_config() -> ClientConfig {
         sample_builder().config()
     }
 

--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock
 
-#![warn(missing_docs)]
-
 //! The OPC UA Client module contains the functionality necessary for a client to connect to an OPC UA server,
 //! authenticate itself, send messages, receive responses, get values, browse the address space and
 //! provide callbacks for things to be propagated to the client.
@@ -119,7 +117,7 @@ mod config;
 pub mod custom_types;
 mod retry;
 mod session;
-mod transport;
+pub mod transport;
 
 use std::path::PathBuf;
 

--- a/async-opcua-client/src/session/connect.rs
+++ b/async-opcua-client/src/session/connect.rs
@@ -25,11 +25,11 @@ pub enum SessionConnectMode {
 }
 
 impl SessionConnector {
-    pub fn new(session: Arc<Session>) -> Self {
+    pub(super) fn new(session: Arc<Session>) -> Self {
         Self { inner: session }
     }
 
-    pub async fn try_connect(
+    pub(super) async fn try_connect(
         &self,
     ) -> Result<(SecureChannelEventLoop, SessionConnectMode), StatusCode> {
         self.connect_and_activate().await

--- a/async-opcua-client/src/session/event_loop.rs
+++ b/async-opcua-client/src/session/event_loop.rs
@@ -290,14 +290,14 @@ struct SessionIntervals {
 }
 
 impl SessionIntervals {
-    pub fn new(keep_alive_interval: Duration) -> Self {
+    fn new(keep_alive_interval: Duration) -> Self {
         let mut keep_alive = tokio::time::interval(keep_alive_interval);
         keep_alive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         Self { keep_alive }
     }
 
-    pub async fn next(&mut self) -> SessionTickEvent {
+    async fn next(&mut self) -> SessionTickEvent {
         tokio::select! {
             _ = self.keep_alive.tick() => SessionTickEvent::KeepAlive
         }
@@ -310,14 +310,14 @@ struct SessionActivityLoop {
 }
 
 impl SessionActivityLoop {
-    pub fn new(inner: Arc<Session>, keep_alive_interval: Duration) -> Self {
+    fn new(inner: Arc<Session>, keep_alive_interval: Duration) -> Self {
         Self {
             inner,
             tick_gen: SessionIntervals::new(keep_alive_interval),
         }
     }
 
-    pub fn run(self) -> impl Stream<Item = SessionActivity> {
+    fn run(self) -> impl Stream<Item = SessionActivity> {
         futures::stream::unfold(self, |mut slf| async move {
             match slf.tick_gen.next().await {
                 SessionTickEvent::KeepAlive => {

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn process_unexpected_response(response: ResponseMessage) -> StatusCo
 }
 
 #[derive(Clone, Copy)]
-pub enum SessionState {
+pub(super) enum SessionState {
     Disconnected,
     Connected,
     Connecting,

--- a/async-opcua-client/src/session/request_builder.rs
+++ b/async-opcua-client/src/session/request_builder.rs
@@ -28,7 +28,9 @@ pub(crate) struct RequestHeaderBuilder {
 }
 
 impl RequestHeaderBuilder {
-    pub fn new_from_session(session: &Session) -> Self {
+    /// Create a new request header builder from a session.
+    /// This will use the session's authentication token and timeout.
+    pub(super) fn new_from_session(session: &Session) -> Self {
         Self {
             header: session.make_request_header(),
             timeout: session.request_timeout,
@@ -36,7 +38,10 @@ impl RequestHeaderBuilder {
         }
     }
 
-    pub fn new(
+    /// Create a new request header builder for a request without an associated session object.
+    /// This makes it possible to manually implement OPC-UA clients without relying on the
+    /// session event loop for automatic connect/reconnect/keep-alive.
+    pub(super) fn new(
         session_id: u32,
         timeout: Duration,
         auth_token: NodeId,

--- a/async-opcua-client/src/session/services/mod.rs
+++ b/async-opcua-client/src/session/services/mod.rs
@@ -1,6 +1,6 @@
-pub mod attributes;
-pub mod method;
-pub mod node_management;
-pub mod session;
-pub mod subscriptions;
-pub mod view;
+pub(super) mod attributes;
+pub(super) mod method;
+pub(super) mod node_management;
+pub(super) mod session;
+pub(super) mod subscriptions;
+pub(super) mod view;

--- a/async-opcua-client/src/session/services/subscriptions/event_loop.rs
+++ b/async-opcua-client/src/session/services/subscriptions/event_loop.rs
@@ -23,7 +23,7 @@ pub enum SubscriptionActivity {
 ///
 /// This handles publshing on a fixed interval, republishing failed requests,
 /// and subscription keep-alive.
-pub struct SubscriptionEventLoop {
+pub(crate) struct SubscriptionEventLoop {
     session: Arc<Session>,
     trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
     last_external_trigger: Instant,
@@ -41,7 +41,7 @@ impl SubscriptionEventLoop {
     ///  * `trigger_publish_recv` - A channel used to transmit external publish triggers.
     ///    This is used to trigger publish outside of the normal schedule, for example when
     ///    a new subscription is created.
-    pub fn new(
+    pub(crate) fn new(
         session: Arc<Session>,
         trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
     ) -> Self {
@@ -56,7 +56,7 @@ impl SubscriptionEventLoop {
 
     /// Run the subscription event loop, returning a stream that produces
     /// [SubscriptionActivity] enums, reporting activity to the session event loop.
-    pub fn run(self) -> impl Stream<Item = SubscriptionActivity> {
+    pub(crate) fn run(self) -> impl Stream<Item = SubscriptionActivity> {
         futures::stream::unfold(
             (self, FuturesUnordered::new()),
             |(mut slf, mut futures)| async move {

--- a/async-opcua-client/src/session/services/subscriptions/mod.rs
+++ b/async-opcua-client/src/session/services/subscriptions/mod.rs
@@ -1,8 +1,8 @@
-pub mod event_loop;
+pub(crate) mod event_loop;
 pub use event_loop::SubscriptionActivity;
 
 mod service;
-pub mod state;
+pub(crate) mod state;
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -474,7 +474,7 @@ impl PublishLimits {
     const MIN_MESSAGE_ROUNDTRIP: Duration = Duration::from_millis(10);
     const REQUESTS_PER_SUBSCRIPTION: usize = 2;
 
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             message_roundtrip: Self::MIN_MESSAGE_ROUNDTRIP,
             publish_interval: Duration::ZERO,
@@ -484,12 +484,16 @@ impl PublishLimits {
         }
     }
 
-    pub fn update_message_roundtrip(&mut self, message_roundtrip: Duration) {
+    pub(crate) fn update_message_roundtrip(&mut self, message_roundtrip: Duration) {
         self.message_roundtrip = message_roundtrip.max(Self::MIN_MESSAGE_ROUNDTRIP);
         self.calculate_publish_limits();
     }
 
-    pub fn update_subscriptions(&mut self, subscriptions: usize, publish_interval: Duration) {
+    pub(crate) fn update_subscriptions(
+        &mut self,
+        subscriptions: usize,
+        publish_interval: Duration,
+    ) {
         self.subscriptions = subscriptions;
         self.publish_interval = publish_interval;
         self.calculate_publish_limits();

--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -45,11 +45,14 @@ pub struct AsyncSecureChannel {
     request_send: ArcSwapOption<RequestSend>,
 }
 
+/// Event loop for a secure channel. This must be polled to make progress.
 pub struct SecureChannelEventLoop {
     transport: TcpTransport,
 }
 
 impl SecureChannelEventLoop {
+    /// Poll the channel, processing any pending incoming or outgoing messages and returning the
+    /// action that was taken.
     pub async fn poll(&mut self) -> TransportPollResult {
         self.transport.poll().await
     }

--- a/async-opcua-client/src/transport/connect.rs
+++ b/async-opcua-client/src/transport/connect.rs
@@ -50,5 +50,8 @@ pub trait Connector: Send + Sync {
 ///
 /// Streams are also cancellation safe, a pattern frequently used in this library.
 pub trait Transport: Send + Sync + 'static {
+    /// Poll the transport, processing any pending incoming or outgoing messages and returning the
+    /// action that was taken.
+    /// Note that this method _must_ be cancellation safe.
     fn poll(&mut self) -> impl Future<Output = TransportPollResult> + Send + Sync;
 }

--- a/async-opcua-client/src/transport/mod.rs
+++ b/async-opcua-client/src/transport/mod.rs
@@ -1,10 +1,13 @@
+//! Types for low-level OPC-UA transport implementations.
+
 mod channel;
 mod connect;
 mod core;
 mod state;
-pub mod tcp;
+pub(super) mod tcp;
 
 pub use channel::{AsyncSecureChannel, SecureChannelEventLoop};
-pub use connect::Connector;
+pub use connect::{Connector, Transport};
 pub(crate) use core::OutgoingMessage;
 pub use core::TransportPollResult;
+pub use tcp::TcpConnector;

--- a/async-opcua-client/src/transport/tcp.rs
+++ b/async-opcua-client/src/transport/tcp.rs
@@ -48,6 +48,7 @@ pub struct TransportConfiguration {
     pub max_chunk_count: usize,
 }
 
+/// Connector for `opc.tcp` transport.
 pub struct TcpConnector;
 
 impl TcpConnector {

--- a/async-opcua-core-namespace/src/events/generated.rs
+++ b/async-opcua-core-namespace/src/events/generated.rs
@@ -7,9 +7,9 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use opcua_nodes as nodes;
-    pub use opcua_nodes::{Event, EventField};
-    pub use opcua_types as types;
+    pub(super) use opcua_nodes as nodes;
+    pub(super) use opcua_nodes::{Event, EventField};
+    pub(super) use opcua_types as types;
 }
 #[allow(unused)]
 use opcua_types as types;

--- a/async-opcua-core-namespace/src/events/mod.rs
+++ b/async-opcua-core-namespace/src/events/mod.rs
@@ -7,9 +7,9 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use opcua_nodes as nodes;
-    pub use opcua_nodes::{Event, EventField};
-    pub use opcua_types as types;
+    pub(super) use opcua_nodes as nodes;
+    pub(super) use opcua_nodes::{Event, EventField};
+    pub(super) use opcua_types as types;
 }
 #[allow(unused)]
 use opcua_types as types;

--- a/async-opcua-core/Cargo.toml
+++ b/async-opcua-core/Cargo.toml
@@ -30,5 +30,5 @@ url = { workspace = true }
 async-opcua-crypto = { path = "../async-opcua-crypto", version = "0.15.1" }
 async-opcua-types = { path = "../async-opcua-types", version = "0.15.1" }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+[lints]
+workspace = true

--- a/async-opcua-core/src/comms/chunker.rs
+++ b/async-opcua-core/src/comms/chunker.rs
@@ -37,7 +37,7 @@ struct ReceiveStream<'a, T> {
     index: usize,
 }
 impl<'a, T: Iterator<Item = &'a MessageChunk>> ReceiveStream<'a, T> {
-    pub fn new(channel: &'a SecureChannel, mut items: T, num_items: usize) -> Result<Self, Error> {
+    fn new(channel: &'a SecureChannel, mut items: T, num_items: usize) -> Result<Self, Error> {
         let Some(chunk) = items.next() else {
             return Err(Error::new(
                 StatusCode::BadUnexpectedError,
@@ -116,7 +116,7 @@ struct ChunkingStream<'a> {
 }
 
 impl<'a> ChunkingStream<'a> {
-    pub fn new(
+    fn new(
         message_type: MessageChunkType,
         secure_channel: &'a SecureChannel,
         max_chunk_size: usize,

--- a/async-opcua-core/src/comms/tcp_types.rs
+++ b/async-opcua-core/src/comms/tcp_types.rs
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    pub fn hello() {
+    fn hello() {
         let mut stream = Cursor::new(hello_data());
         let decoding_options = DecodingOptions::test();
         let hello = HelloMessage::decode(&mut stream, &decoding_options).unwrap();
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[test]
-    pub fn acknowledge() {
+    fn acknowledge() {
         let mut stream = Cursor::new(ack_data());
         let decoding_options = DecodingOptions::test();
         let ack = AcknowledgeMessage::decode(&mut stream, &decoding_options).unwrap();

--- a/async-opcua-core/src/tests/comms.rs
+++ b/async-opcua-core/src/tests/comms.rs
@@ -4,7 +4,7 @@ use opcua_types::{ByteString, MessageSecurityMode};
 use crate::comms::secure_channel::*;
 
 #[test]
-pub fn secure_channel_nonce_basic128rsa15() {
+fn secure_channel_nonce_basic128rsa15() {
     let mut sc = SecureChannel::new_no_certificate_store();
     sc.set_security_mode(MessageSecurityMode::SignAndEncrypt);
     sc.set_security_policy(SecurityPolicy::Basic128Rsa15);
@@ -36,7 +36,7 @@ pub fn secure_channel_nonce_basic128rsa15() {
 }
 
 #[test]
-pub fn secure_channel_nonce_basic256() {
+fn secure_channel_nonce_basic256() {
     let mut sc = SecureChannel::new_no_certificate_store();
     sc.set_security_mode(MessageSecurityMode::SignAndEncrypt);
     sc.set_security_policy(SecurityPolicy::Basic256);
@@ -65,7 +65,7 @@ pub fn secure_channel_nonce_basic256() {
 }
 
 #[test]
-pub fn secure_channel_nonce_none() {
+fn secure_channel_nonce_none() {
     // When the security policy is none, you can set the nonce, but it doesn't care what length it is
     let mut sc = SecureChannel::new_no_certificate_store();
     sc.set_security_mode(MessageSecurityMode::None);

--- a/async-opcua-core/src/tests/mod.rs
+++ b/async-opcua-core/src/tests/mod.rs
@@ -167,7 +167,7 @@ fn make_test_cert_4096() -> (X509, PrivateKey) {
 struct Test;
 
 impl Test {
-    pub fn setup() -> Test {
+    fn setup() -> Test {
         Test {}
     }
 }

--- a/async-opcua-crypto/Cargo.toml
+++ b/async-opcua-crypto/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-crypto/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 name = "opcua_crypto"
 

--- a/async-opcua-crypto/src/lib.rs
+++ b/async-opcua-crypto/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock
 
-#![warn(missing_docs)]
-
 //! Crypto related functionality. It is used for establishing
 //! trust between a client and server via certificate exchange and validation. It also used for
 //! encrypting / decrypting messages and signing messages.
@@ -46,31 +44,33 @@ pub(crate) mod algorithms {
     //pub const ENC_AES256_CBC: &str = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
 
     /// Asymmetric encryption algorithm RSA15
-    pub const ENC_RSA_15: &str = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+    pub(crate) const ENC_RSA_15: &str = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
 
     /// Asymmetric encryption algorithm RSA-OAEP
-    pub const ENC_RSA_OAEP: &str = "http://www.w3.org/2001/04/xmlenc#rsa-oaep";
+    pub(crate) const ENC_RSA_OAEP: &str = "http://www.w3.org/2001/04/xmlenc#rsa-oaep";
 
     /// Asymmetrric encrypttion
-    pub const ENC_RSA_OAEP_SHA256: &str = "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256";
+    pub(crate) const ENC_RSA_OAEP_SHA256: &str =
+        "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256";
 
     // Asymmetric encryption algorithm RSA-OAEP-MGF1P
     //pub const ENC_RSA_OAEP_MGF1P: &str = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
 
     /// SymmetricSignatureAlgorithm – HmacSha1 – (http://www.w3.org/2000/09/xmldsig#hmac-sha1).
-    pub const DSIG_HMAC_SHA1: &str = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+    pub(crate) const DSIG_HMAC_SHA1: &str = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
 
     /// SymmetricSignatureAlgorithm – HmacSha256 – (http://www.w3.org/2000/09/xmldsig#hmac-sha256).
-    pub const DSIG_HMAC_SHA256: &str = "http://www.w3.org/2000/09/xmldsig#hmac-sha256";
+    pub(crate) const DSIG_HMAC_SHA256: &str = "http://www.w3.org/2000/09/xmldsig#hmac-sha256";
 
     /// Asymmetric digital signature algorithm using RSA-SHA1
-    pub const DSIG_RSA_SHA1: &str = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    pub(crate) const DSIG_RSA_SHA1: &str = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 
     /// Asymmetric digital signature algorithm using RSA-SHA256
-    pub const DSIG_RSA_SHA256: &str = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    pub(crate) const DSIG_RSA_SHA256: &str = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
 
     /// Asymmetric digital signature algorithm using RSA-PSS_SHA2-256
-    pub const DSIG_RSA_PSS_SHA2_256: &str = "http://opcfoundation.org/UA/security/rsa-pss-sha2-256";
+    pub(crate) const DSIG_RSA_PSS_SHA2_256: &str =
+        "http://opcfoundation.org/UA/security/rsa-pss-sha2-256";
 
     // Key derivation algorithm P_SHA1
     //pub const KEY_P_SHA1: &str = "http://docs.oasis-open.org/ws-sx/ws-secureconversation/200512/dk/p_sha1";

--- a/async-opcua-crypto/src/security_policy.rs
+++ b/async-opcua-crypto/src/security_policy.rs
@@ -18,6 +18,25 @@ use super::{
     random, SHA1_SIZE, SHA256_SIZE,
 };
 
+/// Trait for a security policy supported by the library.
+pub trait SecurityPolicyConstants {
+    /// The name of the policy.
+    const SECURITY_POLICY: &'static str;
+    /// The URI of the policy, as defined in the OPC-UA standard.
+    const SECURITY_POLICY_URI: &'static str;
+
+    /// The algorithm used for symmetric signing.
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &'static str;
+    /// The algorithm used for asymmetric signing.
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &'static str;
+    /// The algorithm used for asymmetric encryption.
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &'static str;
+    /// The length of the derived signature key in bits.
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize;
+    /// The length of the asymmetric key in bits.
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize);
+}
+
 // These are constants that govern the different encryption / signing modes for OPC UA. In some
 // cases these algorithm string constants will be passed over the wire and code needs to test the
 // string to see if the algorithm is supported.
@@ -36,18 +55,17 @@ use super::{
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-mod aes_128_sha_256_rsa_oaep {
-    use crate::algorithms::*;
-
-    pub const SECURITY_POLICY: &str = "Aes128-Sha256-RsaOaep";
-    pub const SECURITY_POLICY_URI: &str =
+pub struct Aes128Sha256RsaOaep;
+impl SecurityPolicyConstants for Aes128Sha256RsaOaep {
+    const SECURITY_POLICY: &str = "Aes128-Sha256-RsaOaep";
+    const SECURITY_POLICY_URI: &str =
         "http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep";
 
-    pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA256;
-    pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_SHA256;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP;
-    pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
-    pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_HMAC_SHA256;
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_RSA_SHA256;
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = crate::algorithms::ENC_RSA_OAEP;
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
 }
 
 /// Aes256-Sha256-RsaPss security policy
@@ -64,18 +82,17 @@ mod aes_128_sha_256_rsa_oaep {
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-mod aes_256_sha_256_rsa_pss {
-    use crate::algorithms::*;
-
-    pub const SECURITY_POLICY: &str = "Aes256-Sha256-RsaPss";
-    pub const SECURITY_POLICY_URI: &str =
+pub struct Aes256Sha256RsaPss;
+impl SecurityPolicyConstants for Aes256Sha256RsaPss {
+    const SECURITY_POLICY: &str = "Aes256-Sha256-RsaPss";
+    const SECURITY_POLICY_URI: &str =
         "http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss";
 
-    pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA256;
-    pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_PSS_SHA2_256;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP_SHA256;
-    pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
-    pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_HMAC_SHA256;
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_RSA_PSS_SHA2_256;
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = crate::algorithms::ENC_RSA_OAEP_SHA256;
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
 }
 
 /// Basic256Sha256 security policy
@@ -92,18 +109,16 @@ mod aes_256_sha_256_rsa_pss {
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-mod basic_256_sha_256 {
-    use crate::algorithms::*;
+pub struct Basic256Sha256;
+impl SecurityPolicyConstants for Basic256Sha256 {
+    const SECURITY_POLICY: &str = "Basic256Sha256";
+    const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256";
 
-    pub const SECURITY_POLICY: &str = "Basic256Sha256";
-    pub const SECURITY_POLICY_URI: &str =
-        "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256";
-
-    pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA256;
-    pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_SHA256;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP;
-    pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
-    pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_HMAC_SHA256;
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_RSA_SHA256;
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = crate::algorithms::ENC_RSA_OAEP;
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
 }
 
 /// Basic128Rsa15 security policy (deprecated in OPC UA 1.04)
@@ -119,18 +134,16 @@ mod basic_256_sha_256 {
 ///   DerivedSignatureKeyLength – 128 bits
 ///   AsymmetricKeyLength - 1024-2048 bits
 ///   SecureChannelNonceLength - 16 bytes
-mod basic_128_rsa_15 {
-    use crate::algorithms::*;
+pub struct Basic128Rsa15;
+impl SecurityPolicyConstants for Basic128Rsa15 {
+    const SECURITY_POLICY: &str = "Basic128Rsa15";
+    const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15";
 
-    pub const SECURITY_POLICY: &str = "Basic128Rsa15";
-    pub const SECURITY_POLICY_URI: &str =
-        "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15";
-
-    pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA1;
-    pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_SHA1;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_15;
-    pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 128;
-    pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (1024, 2048);
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_HMAC_SHA1;
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_RSA_SHA1;
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = crate::algorithms::ENC_RSA_15;
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize = 128;
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (1024, 2048);
 }
 
 /// Basic256 security policy (deprecated in OPC UA 1.04)
@@ -146,17 +159,16 @@ mod basic_128_rsa_15 {
 ///   DerivedSignatureKeyLength – 192 bits
 ///   AsymmetricKeyLength - 1024-2048 bits
 ///   SecureChannelNonceLength - 32 bytes
-mod basic_256 {
-    use crate::algorithms::*;
+pub struct Basic256;
+impl SecurityPolicyConstants for Basic256 {
+    const SECURITY_POLICY: &str = "Basic256";
+    const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic256";
 
-    pub const SECURITY_POLICY: &str = "Basic256";
-    pub const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic256";
-
-    pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA1;
-    pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_SHA1;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP;
-    pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 192;
-    pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (1024, 2048);
+    const SYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_HMAC_SHA1;
+    const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = crate::algorithms::DSIG_RSA_SHA1;
+    const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = crate::algorithms::ENC_RSA_OAEP;
+    const DERIVED_SIGNATURE_KEY_LENGTH: usize = 192;
+    const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (1024, 2048);
 }
 
 /// SecurityPolicy implies what encryption and signing algorithms and their relevant key strengths
@@ -193,17 +205,19 @@ impl FromStr for SecurityPolicy {
             constants::SECURITY_POLICY_NONE | constants::SECURITY_POLICY_NONE_URI => {
                 SecurityPolicy::None
             }
-            basic_128_rsa_15::SECURITY_POLICY | basic_128_rsa_15::SECURITY_POLICY_URI => {
+            Basic128Rsa15::SECURITY_POLICY | Basic128Rsa15::SECURITY_POLICY_URI => {
                 SecurityPolicy::Basic128Rsa15
             }
-            basic_256::SECURITY_POLICY | basic_256::SECURITY_POLICY_URI => SecurityPolicy::Basic256,
-            basic_256_sha_256::SECURITY_POLICY | basic_256_sha_256::SECURITY_POLICY_URI => {
+            Basic256::SECURITY_POLICY | Basic256::SECURITY_POLICY_URI => SecurityPolicy::Basic256,
+            Basic256Sha256::SECURITY_POLICY | Basic256Sha256::SECURITY_POLICY_URI => {
                 SecurityPolicy::Basic256Sha256
             }
-            aes_128_sha_256_rsa_oaep::SECURITY_POLICY
-            | aes_128_sha_256_rsa_oaep::SECURITY_POLICY_URI => SecurityPolicy::Aes128Sha256RsaOaep,
-            aes_256_sha_256_rsa_pss::SECURITY_POLICY
-            | aes_256_sha_256_rsa_pss::SECURITY_POLICY_URI => SecurityPolicy::Aes256Sha256RsaPss,
+            Aes128Sha256RsaOaep::SECURITY_POLICY | Aes128Sha256RsaOaep::SECURITY_POLICY_URI => {
+                SecurityPolicy::Aes128Sha256RsaOaep
+            }
+            Aes256Sha256RsaPss::SECURITY_POLICY | Aes256Sha256RsaPss::SECURITY_POLICY_URI => {
+                SecurityPolicy::Aes256Sha256RsaPss
+            }
             _ => {
                 error!("Specified security policy \"{}\" is not recognized", s);
                 SecurityPolicy::Unknown
@@ -225,11 +239,11 @@ impl SecurityPolicy {
     pub fn to_uri(&self) -> &'static str {
         match self {
             SecurityPolicy::None => constants::SECURITY_POLICY_NONE_URI,
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::SECURITY_POLICY_URI,
-            SecurityPolicy::Basic256 => basic_256::SECURITY_POLICY_URI,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::SECURITY_POLICY_URI,
-            SecurityPolicy::Aes128Sha256RsaOaep => aes_128_sha_256_rsa_oaep::SECURITY_POLICY_URI,
-            SecurityPolicy::Aes256Sha256RsaPss => aes_256_sha_256_rsa_pss::SECURITY_POLICY_URI,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::SECURITY_POLICY_URI,
+            SecurityPolicy::Basic256 => Basic256::SECURITY_POLICY_URI,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::SECURITY_POLICY_URI,
+            SecurityPolicy::Aes128Sha256RsaOaep => Aes128Sha256RsaOaep::SECURITY_POLICY_URI,
+            SecurityPolicy::Aes256Sha256RsaPss => Aes256Sha256RsaPss::SECURITY_POLICY_URI,
             _ => {
                 panic!("Shouldn't be turning an unknown policy into a uri");
             }
@@ -264,11 +278,11 @@ impl SecurityPolicy {
     pub fn to_str(&self) -> &'static str {
         match self {
             SecurityPolicy::None => constants::SECURITY_POLICY_NONE,
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::SECURITY_POLICY,
-            SecurityPolicy::Basic256 => basic_256::SECURITY_POLICY,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::SECURITY_POLICY,
-            SecurityPolicy::Aes128Sha256RsaOaep => aes_128_sha_256_rsa_oaep::SECURITY_POLICY,
-            SecurityPolicy::Aes256Sha256RsaPss => aes_256_sha_256_rsa_pss::SECURITY_POLICY,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::SECURITY_POLICY,
+            SecurityPolicy::Basic256 => Basic256::SECURITY_POLICY,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::SECURITY_POLICY,
+            SecurityPolicy::Aes128Sha256RsaOaep => Aes128Sha256RsaOaep::SECURITY_POLICY,
+            SecurityPolicy::Aes256Sha256RsaPss => Aes256Sha256RsaPss::SECURITY_POLICY,
             _ => {
                 panic!("Shouldn't be turning an unknown policy into a string");
             }
@@ -280,14 +294,14 @@ impl SecurityPolicy {
     /// This will panic if the security policy is `Unknown` or `None`.
     pub fn asymmetric_encryption_algorithm(&self) -> &'static str {
         match self {
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::ASYMMETRIC_ENCRYPTION_ALGORITHM,
-            SecurityPolicy::Basic256 => basic_256::ASYMMETRIC_ENCRYPTION_ALGORITHM,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::ASYMMETRIC_ENCRYPTION_ALGORITHM,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::ASYMMETRIC_ENCRYPTION_ALGORITHM,
+            SecurityPolicy::Basic256 => Basic256::ASYMMETRIC_ENCRYPTION_ALGORITHM,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::ASYMMETRIC_ENCRYPTION_ALGORITHM,
             SecurityPolicy::Aes128Sha256RsaOaep => {
-                aes_128_sha_256_rsa_oaep::ASYMMETRIC_ENCRYPTION_ALGORITHM
+                Aes128Sha256RsaOaep::ASYMMETRIC_ENCRYPTION_ALGORITHM
             }
             SecurityPolicy::Aes256Sha256RsaPss => {
-                aes_256_sha_256_rsa_pss::ASYMMETRIC_ENCRYPTION_ALGORITHM
+                Aes256Sha256RsaPss::ASYMMETRIC_ENCRYPTION_ALGORITHM
             }
             _ => {
                 panic!("Invalid policy");
@@ -300,14 +314,14 @@ impl SecurityPolicy {
     /// This will panic if the security policy is `Unknown` or `None`.
     pub fn asymmetric_signature_algorithm(&self) -> &'static str {
         match self {
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::ASYMMETRIC_SIGNATURE_ALGORITHM,
-            SecurityPolicy::Basic256 => basic_256::ASYMMETRIC_SIGNATURE_ALGORITHM,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::ASYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::ASYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic256 => Basic256::ASYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::ASYMMETRIC_SIGNATURE_ALGORITHM,
             SecurityPolicy::Aes128Sha256RsaOaep => {
-                aes_128_sha_256_rsa_oaep::ASYMMETRIC_SIGNATURE_ALGORITHM
+                Aes128Sha256RsaOaep::ASYMMETRIC_SIGNATURE_ALGORITHM
             }
             SecurityPolicy::Aes256Sha256RsaPss => {
-                aes_256_sha_256_rsa_pss::ASYMMETRIC_SIGNATURE_ALGORITHM
+                Aes256Sha256RsaPss::ASYMMETRIC_SIGNATURE_ALGORITHM
             }
             _ => {
                 panic!("Invalid policy");
@@ -320,15 +334,13 @@ impl SecurityPolicy {
     /// This will panic if the security policy is `Unknown` or `None`.
     pub fn symmetric_signature_algorithm(&self) -> &'static str {
         match self {
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::SYMMETRIC_SIGNATURE_ALGORITHM,
-            SecurityPolicy::Basic256 => basic_256::SYMMETRIC_SIGNATURE_ALGORITHM,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::SYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::SYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic256 => Basic256::SYMMETRIC_SIGNATURE_ALGORITHM,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::SYMMETRIC_SIGNATURE_ALGORITHM,
             SecurityPolicy::Aes128Sha256RsaOaep => {
-                aes_128_sha_256_rsa_oaep::SYMMETRIC_SIGNATURE_ALGORITHM
+                Aes128Sha256RsaOaep::SYMMETRIC_SIGNATURE_ALGORITHM
             }
-            SecurityPolicy::Aes256Sha256RsaPss => {
-                aes_256_sha_256_rsa_pss::SYMMETRIC_SIGNATURE_ALGORITHM
-            }
+            SecurityPolicy::Aes256Sha256RsaPss => Aes256Sha256RsaPss::SYMMETRIC_SIGNATURE_ALGORITHM,
             _ => {
                 panic!("Invalid policy");
             }
@@ -372,15 +384,13 @@ impl SecurityPolicy {
     /// This will panic if the security policy is `Unknown` or `None`.
     pub fn derived_signature_key_size(&self) -> usize {
         let length = match self {
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::DERIVED_SIGNATURE_KEY_LENGTH,
-            SecurityPolicy::Basic256 => basic_256::DERIVED_SIGNATURE_KEY_LENGTH,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::DERIVED_SIGNATURE_KEY_LENGTH,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::DERIVED_SIGNATURE_KEY_LENGTH,
+            SecurityPolicy::Basic256 => Basic256::DERIVED_SIGNATURE_KEY_LENGTH,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::DERIVED_SIGNATURE_KEY_LENGTH,
             SecurityPolicy::Aes128Sha256RsaOaep => {
-                aes_128_sha_256_rsa_oaep::DERIVED_SIGNATURE_KEY_LENGTH
+                Aes128Sha256RsaOaep::DERIVED_SIGNATURE_KEY_LENGTH
             }
-            SecurityPolicy::Aes256Sha256RsaPss => {
-                aes_256_sha_256_rsa_pss::DERIVED_SIGNATURE_KEY_LENGTH
-            }
+            SecurityPolicy::Aes256Sha256RsaPss => Aes256Sha256RsaPss::DERIVED_SIGNATURE_KEY_LENGTH,
             _ => {
                 panic!("Invalid policy");
             }
@@ -391,11 +401,11 @@ impl SecurityPolicy {
     /// Returns the min and max (inclusive) key length in bits
     pub fn min_max_asymmetric_keylength(&self) -> (usize, usize) {
         match self {
-            SecurityPolicy::Basic128Rsa15 => basic_128_rsa_15::ASYMMETRIC_KEY_LENGTH,
-            SecurityPolicy::Basic256 => basic_256::ASYMMETRIC_KEY_LENGTH,
-            SecurityPolicy::Basic256Sha256 => basic_256_sha_256::ASYMMETRIC_KEY_LENGTH,
-            SecurityPolicy::Aes128Sha256RsaOaep => aes_128_sha_256_rsa_oaep::ASYMMETRIC_KEY_LENGTH,
-            SecurityPolicy::Aes256Sha256RsaPss => aes_256_sha_256_rsa_pss::ASYMMETRIC_KEY_LENGTH,
+            SecurityPolicy::Basic128Rsa15 => Basic128Rsa15::ASYMMETRIC_KEY_LENGTH,
+            SecurityPolicy::Basic256 => Basic256::ASYMMETRIC_KEY_LENGTH,
+            SecurityPolicy::Basic256Sha256 => Basic256Sha256::ASYMMETRIC_KEY_LENGTH,
+            SecurityPolicy::Aes128Sha256RsaOaep => Aes128Sha256RsaOaep::ASYMMETRIC_KEY_LENGTH,
+            SecurityPolicy::Aes256Sha256RsaPss => Aes256Sha256RsaPss::ASYMMETRIC_KEY_LENGTH,
             _ => {
                 panic!("Invalid policy");
             }
@@ -436,11 +446,11 @@ impl SecurityPolicy {
     pub fn from_uri(uri: &str) -> SecurityPolicy {
         match uri {
             constants::SECURITY_POLICY_NONE_URI => SecurityPolicy::None,
-            basic_128_rsa_15::SECURITY_POLICY_URI => SecurityPolicy::Basic128Rsa15,
-            basic_256::SECURITY_POLICY_URI => SecurityPolicy::Basic256,
-            basic_256_sha_256::SECURITY_POLICY_URI => SecurityPolicy::Basic256Sha256,
-            aes_128_sha_256_rsa_oaep::SECURITY_POLICY_URI => SecurityPolicy::Aes128Sha256RsaOaep,
-            aes_256_sha_256_rsa_pss::SECURITY_POLICY_URI => SecurityPolicy::Aes256Sha256RsaPss,
+            Basic128Rsa15::SECURITY_POLICY_URI => SecurityPolicy::Basic128Rsa15,
+            Basic256::SECURITY_POLICY_URI => SecurityPolicy::Basic256,
+            Basic256Sha256::SECURITY_POLICY_URI => SecurityPolicy::Basic256Sha256,
+            Aes128Sha256RsaOaep::SECURITY_POLICY_URI => SecurityPolicy::Aes128Sha256RsaOaep,
+            Aes256Sha256RsaPss::SECURITY_POLICY_URI => SecurityPolicy::Aes256Sha256RsaPss,
             _ => {
                 error!(
                     "Specified security policy uri \"{}\" is not recognized",

--- a/async-opcua-macros/Cargo.toml
+++ b/async-opcua-macros/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-macros/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [features]
 json = []
 xml = []

--- a/async-opcua-macros/src/encoding/binary.rs
+++ b/async-opcua-macros/src/encoding/binary.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 use super::{enums::SimpleEnum, unions::AdvancedEnum, EncodingStruct};
 
-pub fn generate_binary_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_binary_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let mut byte_len_body = quote! {};
     let mut encode_body = quote! {};
 
@@ -95,7 +95,7 @@ pub fn generate_binary_encode_impl(strct: EncodingStruct) -> syn::Result<TokenSt
     })
 }
 
-pub fn generate_binary_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_binary_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let mut decode_impl = quote! {};
     let mut decode_build = quote! {};
 
@@ -181,7 +181,7 @@ pub fn generate_binary_decode_impl(strct: EncodingStruct) -> syn::Result<TokenSt
     })
 }
 
-pub fn generate_simple_enum_binary_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_binary_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
     let repr = en.repr;
 
@@ -196,7 +196,7 @@ pub fn generate_simple_enum_binary_decode_impl(en: SimpleEnum) -> syn::Result<To
     })
 }
 
-pub fn generate_simple_enum_binary_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_binary_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
     let repr = en.repr;
 
@@ -218,7 +218,7 @@ pub fn generate_simple_enum_binary_encode_impl(en: SimpleEnum) -> syn::Result<To
     })
 }
 
-pub fn generate_union_binary_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_binary_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut decode_arms = quote! {};
@@ -258,7 +258,7 @@ pub fn generate_union_binary_decode_impl(en: AdvancedEnum) -> syn::Result<TokenS
     })
 }
 
-pub fn generate_union_binary_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_binary_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut byte_len_arms = quote! {};

--- a/async-opcua-macros/src/encoding/enums.rs
+++ b/async-opcua-macros/src/encoding/enums.rs
@@ -6,13 +6,13 @@ use quote::{quote, ToTokens};
 
 use super::attribute::{EncodingItemAttribute, EncodingVariantAttribute};
 
-pub struct SimpleEnumVariant {
+pub(crate) struct SimpleEnumVariant {
     pub value: LitInt,
     pub name: Ident,
     pub attr: EncodingVariantAttribute,
 }
 
-pub struct SimpleEnum {
+pub(crate) struct SimpleEnum {
     pub repr: Type,
     pub variants: Vec<SimpleEnumVariant>,
     pub ident: Ident,
@@ -21,7 +21,7 @@ pub struct SimpleEnum {
 }
 
 impl SimpleEnumVariant {
-    pub fn from_variant(variant: Variant) -> syn::Result<Self> {
+    pub(super) fn from_variant(variant: Variant) -> syn::Result<Self> {
         let Some((_, value)) = variant.discriminant else {
             return Err(syn::Error::new_spanned(
                 variant,
@@ -57,7 +57,7 @@ impl SimpleEnumVariant {
 }
 
 impl SimpleEnum {
-    pub fn from_input(
+    pub(super) fn from_input(
         input: DataEnum,
         attributes: Vec<Attribute>,
         ident: Ident,
@@ -100,7 +100,7 @@ impl SimpleEnum {
     }
 }
 
-pub fn derive_ua_enum_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn derive_ua_enum_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
     let repr = en.repr;
 

--- a/async-opcua-macros/src/encoding/json.rs
+++ b/async-opcua-macros/src/encoding/json.rs
@@ -6,7 +6,7 @@ use quote::quote;
 
 use super::{enums::SimpleEnum, unions::AdvancedEnum, EncodingStruct};
 
-pub fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
     let mut body = quote! {};
 
@@ -88,7 +88,7 @@ pub fn generate_json_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStre
     })
 }
 
-pub fn generate_json_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_json_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
     let mut items = quote! {};
     let mut items_match = quote! {};
@@ -196,7 +196,7 @@ pub fn generate_json_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStre
     })
 }
 
-pub fn generate_simple_enum_json_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_json_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
     let repr = en.repr;
 
@@ -213,7 +213,7 @@ pub fn generate_simple_enum_json_decode_impl(en: SimpleEnum) -> syn::Result<Toke
     })
 }
 
-pub fn generate_simple_enum_json_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_json_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
     let repr = en.repr;
 
@@ -230,7 +230,7 @@ pub fn generate_simple_enum_json_encode_impl(en: SimpleEnum) -> syn::Result<Toke
     })
 }
 
-pub fn generate_union_json_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_json_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut decode_arms = quote! {};
@@ -288,7 +288,7 @@ pub fn generate_union_json_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStr
     })
 }
 
-pub fn generate_union_json_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_json_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut encode_arms = quote! {};

--- a/async-opcua-macros/src/encoding/mod.rs
+++ b/async-opcua-macros/src/encoding/mod.rs
@@ -37,7 +37,7 @@ pub(crate) enum EncodingInput {
 }
 
 impl EncodingInput {
-    pub fn from_derive_input(input: DeriveInput) -> syn::Result<Self> {
+    pub(crate) fn from_derive_input(input: DeriveInput) -> syn::Result<Self> {
         match input.data {
             syn::Data::Struct(data_struct) => Ok(Self::Struct(EncodingStruct::from_input(
                 data_struct,
@@ -67,7 +67,7 @@ impl EncodingInput {
     }
 }
 
-pub enum EncodingToImpl {
+pub(crate) enum EncodingToImpl {
     BinaryEncode,
     BinaryDecode,
     UaEnum,
@@ -83,7 +83,7 @@ pub enum EncodingToImpl {
     XmlType,
 }
 
-pub fn generate_encoding_impl(
+pub(crate) fn generate_encoding_impl(
     input: DeriveInput,
     target: EncodingToImpl,
 ) -> syn::Result<TokenStream> {

--- a/async-opcua-macros/src/encoding/unions.rs
+++ b/async-opcua-macros/src/encoding/unions.rs
@@ -4,14 +4,14 @@ use crate::utils::ItemAttr;
 
 use super::attribute::{EncodingItemAttribute, EncodingVariantAttribute};
 
-pub struct AdvancedEnumVariant {
+pub(crate) struct AdvancedEnumVariant {
     pub name: Ident,
     #[allow(unused)]
     pub attr: EncodingVariantAttribute,
     pub is_null: bool,
 }
 
-pub struct AdvancedEnum {
+pub(crate) struct AdvancedEnum {
     pub variants: Vec<AdvancedEnumVariant>,
     pub ident: Ident,
     pub null_variant: Option<Ident>,
@@ -20,7 +20,7 @@ pub struct AdvancedEnum {
 }
 
 impl AdvancedEnumVariant {
-    pub fn from_variant(variant: Variant) -> syn::Result<Self> {
+    pub(crate) fn from_variant(variant: Variant) -> syn::Result<Self> {
         let mut final_attr = EncodingVariantAttribute::default();
         for attr in variant.attrs {
             if attr.path().segments.len() == 1
@@ -52,7 +52,7 @@ impl AdvancedEnumVariant {
 }
 
 impl AdvancedEnum {
-    pub fn from_input(
+    pub(crate) fn from_input(
         input: syn::DataEnum,
         attributes: Vec<syn::Attribute>,
         ident: Ident,

--- a/async-opcua-macros/src/encoding/xml.rs
+++ b/async-opcua-macros/src/encoding/xml.rs
@@ -8,7 +8,7 @@ use super::{
     attribute::EncodingItemAttribute, enums::SimpleEnum, unions::AdvancedEnum, EncodingStruct,
 };
 
-pub fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
     let mut body = quote! {
         use opcua::types::xml::XmlWriteExt;
@@ -83,7 +83,7 @@ pub fn generate_xml_encode_impl(strct: EncodingStruct) -> syn::Result<TokenStrea
     })
 }
 
-pub fn generate_xml_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
+pub(super) fn generate_xml_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
     let mut items = quote! {};
     let mut items_match = quote! {};
@@ -192,7 +192,7 @@ pub fn generate_xml_decode_impl(strct: EncodingStruct) -> syn::Result<TokenStrea
     })
 }
 
-pub fn generate_simple_enum_xml_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_xml_decode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     Ok(quote! {
@@ -209,7 +209,7 @@ pub fn generate_simple_enum_xml_decode_impl(en: SimpleEnum) -> syn::Result<Token
     })
 }
 
-pub fn generate_simple_enum_xml_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_simple_enum_xml_encode_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     Ok(quote! {
@@ -226,7 +226,10 @@ pub fn generate_simple_enum_xml_encode_impl(en: SimpleEnum) -> syn::Result<Token
     })
 }
 
-pub fn generate_xml_type_impl(idt: Ident, attr: EncodingItemAttribute) -> syn::Result<TokenStream> {
+pub(super) fn generate_xml_type_impl(
+    idt: Ident,
+    attr: EncodingItemAttribute,
+) -> syn::Result<TokenStream> {
     let name = attr.rename.unwrap_or_else(|| idt.to_string());
     Ok(quote! {
         impl opcua::types::xml::XmlType for #idt {
@@ -235,7 +238,7 @@ pub fn generate_xml_type_impl(idt: Ident, attr: EncodingItemAttribute) -> syn::R
     })
 }
 
-pub fn generate_union_xml_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_xml_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut decode_arms = quote! {};
@@ -295,7 +298,7 @@ pub fn generate_union_xml_decode_impl(en: AdvancedEnum) -> syn::Result<TokenStre
     })
 }
 
-pub fn generate_union_xml_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
+pub(super) fn generate_union_xml_encode_impl(en: AdvancedEnum) -> syn::Result<TokenStream> {
     let ident = en.ident;
 
     let mut encode_arms = quote! {};

--- a/async-opcua-macros/src/events/field.rs
+++ b/async-opcua-macros/src/events/field.rs
@@ -8,13 +8,13 @@ use super::parse::EventFieldAttribute;
 
 use quote::quote;
 
-pub type EventFieldStruct = StructItem<EventFieldAttribute, EmptyAttribute>;
+pub(crate) type EventFieldStruct = StructItem<EventFieldAttribute, EmptyAttribute>;
 
-pub fn parse_event_field_struct(input: DeriveInput) -> syn::Result<EventFieldStruct> {
+pub(crate) fn parse_event_field_struct(input: DeriveInput) -> syn::Result<EventFieldStruct> {
     EventFieldStruct::from_input(expect_struct(input.data)?, input.attrs, input.ident)
 }
 
-pub fn generate_event_field_impls(event: EventFieldStruct) -> syn::Result<TokenStream> {
+pub(crate) fn generate_event_field_impls(event: EventFieldStruct) -> syn::Result<TokenStream> {
     let ident = event.ident;
     let mut get_arms = quote! {};
     let mut final_arm = quote! {

--- a/async-opcua-macros/src/events/gen.rs
+++ b/async-opcua-macros/src/events/gen.rs
@@ -3,7 +3,7 @@ use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStream> {
+pub(crate) fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStream> {
     let ident = event.ident;
     let mut get_arms = quote! {};
     let mut init_items = quote! {};

--- a/async-opcua-macros/src/events/mod.rs
+++ b/async-opcua-macros/src/events/mod.rs
@@ -8,12 +8,12 @@ use parse::parse_event_struct;
 use proc_macro2::TokenStream;
 use syn::DeriveInput;
 
-pub fn derive_event_inner(input: DeriveInput) -> syn::Result<TokenStream> {
+pub(crate) fn derive_event_inner(input: DeriveInput) -> syn::Result<TokenStream> {
     let struct_data = parse_event_struct(input)?;
     generate_event_impls(struct_data)
 }
 
-pub fn derive_event_field_inner(input: DeriveInput) -> syn::Result<TokenStream> {
+pub(crate) fn derive_event_field_inner(input: DeriveInput) -> syn::Result<TokenStream> {
     let struct_data = parse_event_field_struct(input)?;
     generate_event_field_impls(struct_data)
 }

--- a/async-opcua-macros/src/events/parse.rs
+++ b/async-opcua-macros/src/events/parse.rs
@@ -134,9 +134,9 @@ impl ItemAttr for EventAttribute {
     }
 }
 
-pub type EventStruct = StructItem<EventFieldAttribute, EventAttribute>;
+pub(crate) type EventStruct = StructItem<EventFieldAttribute, EventAttribute>;
 
-pub fn parse_event_struct(input: DeriveInput) -> syn::Result<EventStruct> {
+pub(crate) fn parse_event_struct(input: DeriveInput) -> syn::Result<EventStruct> {
     let mut parsed = EventStruct::from_input(expect_struct(input.data)?, input.attrs, input.ident)?;
 
     let mut filtered_fields = Vec::with_capacity(parsed.fields.len());

--- a/async-opcua-macros/src/lib.rs
+++ b/async-opcua-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! Crate containing various procedural macros used by rust OPC-UA.
 
 mod encoding;

--- a/async-opcua-macros/src/utils.rs
+++ b/async-opcua-macros/src/utils.rs
@@ -2,7 +2,7 @@ use proc_macro2::Span;
 use syn::{parse::Parse, Attribute, Data, DataStruct, Field, Ident, Type};
 
 #[derive(Debug, Default)]
-pub struct EmptyAttribute;
+pub(crate) struct EmptyAttribute;
 
 impl Parse for EmptyAttribute {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
@@ -17,17 +17,17 @@ impl ItemAttr for EmptyAttribute {
     fn combine(&mut self, _other: Self) {}
 }
 
-pub trait ItemAttr {
+pub(crate) trait ItemAttr {
     fn combine(&mut self, other: Self);
 }
 
-pub struct StructField<T> {
+pub(crate) struct StructField<T> {
     pub ident: Ident,
     pub typ: Type,
     pub attr: T,
 }
 
-pub struct StructItem<TFieldAttr, TAttr> {
+pub(crate) struct StructItem<TFieldAttr, TAttr> {
     pub ident: Ident,
     pub fields: Vec<StructField<TFieldAttr>>,
     pub attribute: TAttr,
@@ -36,7 +36,7 @@ pub struct StructItem<TFieldAttr, TAttr> {
 impl<TFieldAttr: Parse + ItemAttr + Default, TAttr: Parse + ItemAttr + Default>
     StructItem<TFieldAttr, TAttr>
 {
-    pub fn from_input(
+    pub(crate) fn from_input(
         input: DataStruct,
         attributes: Vec<Attribute>,
         ident: Ident,
@@ -70,7 +70,7 @@ impl<TFieldAttr: Parse + ItemAttr + Default, TAttr: Parse + ItemAttr + Default>
 }
 
 impl<T: Parse + ItemAttr + Default> StructField<T> {
-    pub fn from_field(field: Field) -> syn::Result<Self> {
+    pub(crate) fn from_field(field: Field) -> syn::Result<Self> {
         let Some(ident) = field.ident else {
             return Err(syn::Error::new_spanned(
                 field,
@@ -98,7 +98,7 @@ impl<T: Parse + ItemAttr + Default> StructField<T> {
     }
 }
 
-pub fn expect_struct(input: Data) -> syn::Result<DataStruct> {
+pub(crate) fn expect_struct(input: Data) -> syn::Result<DataStruct> {
     match input {
         syn::Data::Struct(s) => Ok(s),
         _ => Err(syn::Error::new(

--- a/async-opcua-nodes/Cargo.toml
+++ b/async-opcua-nodes/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-nodes/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 name = "opcua_nodes"
 

--- a/async-opcua-nodes/src/events/evaluate.rs
+++ b/async-opcua-nodes/src/events/evaluate.rs
@@ -466,8 +466,8 @@ mod tests {
     }
 
     mod opcua {
-        pub use crate as nodes;
-        pub use opcua_types as types;
+        pub(super) use crate as nodes;
+        pub(super) use opcua_types as types;
     }
 
     #[derive(Event)]
@@ -479,7 +479,7 @@ mod tests {
     }
 
     impl TestEvent {
-        pub fn new(
+        pub(super) fn new(
             type_id: impl Into<NodeId>,
             event_id: ByteString,
             message: impl Into<LocalizedText>,

--- a/async-opcua-nodes/src/events/event.rs
+++ b/async-opcua-nodes/src/events/event.rs
@@ -205,8 +205,8 @@ mod method_event_field {
     use opcua_types::NodeId;
 
     mod opcua {
-        pub use crate as nodes;
-        pub use opcua_types as types;
+        pub(super) use crate as nodes;
+        pub(super) use opcua_types as types;
     }
     #[derive(Default, EventField, Debug)]
     /// A field of an event that references a method.
@@ -221,8 +221,8 @@ mod tests {
     use crate::NamespaceMap;
 
     mod opcua {
-        pub use crate as nodes;
-        pub use opcua_types as types;
+        pub(super) use crate as nodes;
+        pub(super) use opcua_types as types;
     }
 
     use crate::{BaseEventType, Event, EventField};

--- a/async-opcua-nodes/src/lib.rs
+++ b/async-opcua-nodes/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! The nodes crate contains core types for generated address spaces.
 //!
 //! This includes types for each node class, some common enums for references,

--- a/async-opcua-nodes/src/references.rs
+++ b/async-opcua-nodes/src/references.rs
@@ -335,7 +335,7 @@ impl<'a> Iterator for ReferenceIterator<'a, '_> {
 }
 
 impl<'a, 'b> ReferenceIterator<'a, 'b> {
-    pub fn new(
+    fn new(
         source_node: &'b NodeId,
         direction: BrowseDirection,
         references: &'a References,

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-server/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 name = "opcua_server"
 

--- a/async-opcua-server/src/config/limits.rs
+++ b/async-opcua-server/src/config/limits.rs
@@ -210,126 +210,126 @@ impl Default for OperationalLimits {
 
 mod defaults {
     use crate::constants;
-    pub fn max_array_length() -> usize {
+    pub(super) fn max_array_length() -> usize {
         opcua_types::constants::MAX_ARRAY_LENGTH
     }
-    pub fn max_string_length() -> usize {
+    pub(super) fn max_string_length() -> usize {
         opcua_types::constants::MAX_STRING_LENGTH
     }
-    pub fn max_byte_string_length() -> usize {
+    pub(super) fn max_byte_string_length() -> usize {
         opcua_types::constants::MAX_BYTE_STRING_LENGTH
     }
-    pub fn max_message_size() -> usize {
+    pub(super) fn max_message_size() -> usize {
         opcua_types::constants::MAX_MESSAGE_SIZE
     }
-    pub fn max_chunk_count() -> usize {
+    pub(super) fn max_chunk_count() -> usize {
         opcua_types::constants::MAX_CHUNK_COUNT
     }
-    pub fn send_buffer_size() -> usize {
+    pub(super) fn send_buffer_size() -> usize {
         constants::SEND_BUFFER_SIZE
     }
-    pub fn receive_buffer_size() -> usize {
+    pub(super) fn receive_buffer_size() -> usize {
         constants::RECEIVE_BUFFER_SIZE
     }
-    pub fn max_browse_continuation_points() -> usize {
+    pub(super) fn max_browse_continuation_points() -> usize {
         constants::MAX_BROWSE_CONTINUATION_POINTS
     }
-    pub fn max_history_continuation_points() -> usize {
+    pub(super) fn max_history_continuation_points() -> usize {
         constants::MAX_HISTORY_CONTINUATION_POINTS
     }
-    pub fn max_query_continuation_points() -> usize {
+    pub(super) fn max_query_continuation_points() -> usize {
         constants::MAX_QUERY_CONTINUATION_POINTS
     }
-    pub fn max_sessions() -> usize {
+    pub(super) fn max_sessions() -> usize {
         constants::MAX_SESSIONS
     }
 
-    pub fn max_subscriptions_per_session() -> usize {
+    pub(super) fn max_subscriptions_per_session() -> usize {
         constants::MAX_SUBSCRIPTIONS_PER_SESSION
     }
-    pub fn max_pending_publish_requests() -> usize {
+    pub(super) fn max_pending_publish_requests() -> usize {
         constants::MAX_PENDING_PUBLISH_REQUESTS
     }
-    pub fn max_publish_requests_per_subscription() -> usize {
+    pub(super) fn max_publish_requests_per_subscription() -> usize {
         constants::MAX_PUBLISH_REQUESTS_PER_SUBSCRIPTION
     }
-    pub fn min_sampling_interval_ms() -> f64 {
+    pub(super) fn min_sampling_interval_ms() -> f64 {
         constants::MIN_SAMPLING_INTERVAL_MS
     }
-    pub fn min_publishing_interval_ms() -> f64 {
+    pub(super) fn min_publishing_interval_ms() -> f64 {
         constants::MIN_PUBLISHING_INTERVAL_MS
     }
-    pub fn max_keep_alive_count() -> u32 {
+    pub(super) fn max_keep_alive_count() -> u32 {
         constants::MAX_KEEP_ALIVE_COUNT
     }
-    pub fn default_keep_alive_count() -> u32 {
+    pub(super) fn default_keep_alive_count() -> u32 {
         constants::DEFAULT_KEEP_ALIVE_COUNT
     }
-    pub fn max_monitored_items_per_sub() -> usize {
+    pub(super) fn max_monitored_items_per_sub() -> usize {
         constants::DEFAULT_MAX_MONITORED_ITEMS_PER_SUB
     }
-    pub fn max_monitored_item_queue_size() -> usize {
+    pub(super) fn max_monitored_item_queue_size() -> usize {
         constants::MAX_DATA_CHANGE_QUEUE_SIZE
     }
-    pub fn max_lifetime_count() -> u32 {
+    pub(super) fn max_lifetime_count() -> u32 {
         constants::MAX_KEEP_ALIVE_COUNT * 3
     }
-    pub fn max_notifications_per_publish() -> u64 {
+    pub(super) fn max_notifications_per_publish() -> u64 {
         constants::MAX_NOTIFICATIONS_PER_PUBLISH
     }
-    pub fn max_queued_notifications() -> usize {
+    pub(super) fn max_queued_notifications() -> usize {
         constants::MAX_QUEUED_NOTIFICATIONS
     }
 
-    pub fn max_nodes_per_translate_browse_paths_to_node_ids() -> usize {
+    pub(super) fn max_nodes_per_translate_browse_paths_to_node_ids() -> usize {
         constants::MAX_NODES_PER_TRANSLATE_BROWSE_PATHS_TO_NODE_IDS
     }
-    pub fn max_nodes_per_read() -> usize {
+    pub(super) fn max_nodes_per_read() -> usize {
         constants::MAX_NODES_PER_READ
     }
-    pub fn max_nodes_per_write() -> usize {
+    pub(super) fn max_nodes_per_write() -> usize {
         constants::MAX_NODES_PER_WRITE
     }
-    pub fn max_nodes_per_method_call() -> usize {
+    pub(super) fn max_nodes_per_method_call() -> usize {
         constants::MAX_NODES_PER_METHOD_CALL
     }
-    pub fn max_nodes_per_browse() -> usize {
+    pub(super) fn max_nodes_per_browse() -> usize {
         constants::MAX_NODES_PER_BROWSE
     }
-    pub fn max_nodes_per_register_nodes() -> usize {
+    pub(super) fn max_nodes_per_register_nodes() -> usize {
         constants::MAX_NODES_PER_REGISTER_NODES
     }
-    pub fn max_monitored_items_per_call() -> usize {
+    pub(super) fn max_monitored_items_per_call() -> usize {
         constants::MAX_MONITORED_ITEMS_PER_CALL
     }
-    pub fn max_nodes_per_history_read_data() -> usize {
+    pub(super) fn max_nodes_per_history_read_data() -> usize {
         constants::MAX_NODES_PER_HISTORY_READ_DATA
     }
-    pub fn max_nodes_per_history_read_events() -> usize {
+    pub(super) fn max_nodes_per_history_read_events() -> usize {
         constants::MAX_NODES_PER_HISTORY_READ_EVENTS
     }
-    pub fn max_nodes_per_history_update() -> usize {
+    pub(super) fn max_nodes_per_history_update() -> usize {
         constants::MAX_NODES_PER_HISTORY_UPDATE
     }
-    pub fn max_references_per_browse_node() -> usize {
+    pub(super) fn max_references_per_browse_node() -> usize {
         constants::MAX_REFERENCES_PER_BROWSE_NODE
     }
-    pub fn max_node_descs_per_query() -> usize {
+    pub(super) fn max_node_descs_per_query() -> usize {
         constants::MAX_NODE_DESCS_PER_QUERY
     }
-    pub fn max_data_sets_query_return() -> usize {
+    pub(super) fn max_data_sets_query_return() -> usize {
         constants::MAX_DATA_SETS_QUERY_RETURN
     }
-    pub fn max_references_query_return() -> usize {
+    pub(super) fn max_references_query_return() -> usize {
         constants::MAX_REFERENCES_QUERY_RETURN
     }
-    pub fn max_nodes_per_node_management() -> usize {
+    pub(super) fn max_nodes_per_node_management() -> usize {
         constants::MAX_NODES_PER_NODE_MANAGEMENT
     }
-    pub fn max_references_per_references_management() -> usize {
+    pub(super) fn max_references_per_references_management() -> usize {
         constants::MAX_REFERENCES_PER_REFERENCE_MANAGEMENT
     }
-    pub fn max_subscriptions_per_call() -> usize {
+    pub(super) fn max_subscriptions_per_call() -> usize {
         constants::MAX_SUBSCRIPTIONS_PER_CALL
     }
 }

--- a/async-opcua-server/src/config/server.rs
+++ b/async-opcua-server/src/config/server.rs
@@ -242,23 +242,23 @@ pub struct ServerConfig {
 mod defaults {
     use crate::constants;
 
-    pub fn subscription_poll_interval_ms() -> u64 {
+    pub(super) fn subscription_poll_interval_ms() -> u64 {
         constants::SUBSCRIPTION_TIMER_RATE_MS
     }
 
-    pub fn publish_timeout_default_ms() -> u64 {
+    pub(super) fn publish_timeout_default_ms() -> u64 {
         constants::DEFAULT_PUBLISH_TIMEOUT_MS
     }
 
-    pub fn max_timeout_ms() -> u32 {
+    pub(super) fn max_timeout_ms() -> u32 {
         300_000
     }
 
-    pub fn max_secure_channel_token_lifetime_ms() -> u32 {
+    pub(super) fn max_secure_channel_token_lifetime_ms() -> u32 {
         300_000
     }
 
-    pub fn max_session_timeout_ms() -> u64 {
+    pub(super) fn max_session_timeout_ms() -> u64 {
         constants::MAX_SESSION_TIMEOUT
     }
 }

--- a/async-opcua-server/src/identity_token.rs
+++ b/async-opcua-server/src/identity_token.rs
@@ -15,10 +15,15 @@ pub(crate) const POLICY_ID_X509: &str = "x509";
 
 /// Identity token representation on the server, decoded from the client.
 pub enum IdentityToken {
+    /// No identity token specified at all.
     None,
+    /// Identity token for anonymous access.
     Anonymous(AnonymousIdentityToken),
+    /// Identity token for user name and password.
     UserName(UserNameIdentityToken),
+    /// Identity token for X.509 certificate.
     X509(X509IdentityToken),
+    /// Invalid identity token with some unknown structure.
     Invalid(ExtensionObject),
 }
 

--- a/async-opcua-server/src/lib.rs
+++ b/async-opcua-server/src/lib.rs
@@ -29,6 +29,7 @@ mod transport;
 
 pub use builder::ServerBuilder;
 pub use config::*;
+pub use identity_token::IdentityToken;
 pub use info::ServerInfo;
 pub use opcua_types::event_field::EventField;
 pub use server::Server;

--- a/async-opcua-server/src/node_manager/history.rs
+++ b/async-opcua-server/src/node_manager/history.rs
@@ -29,7 +29,7 @@ pub(crate) enum HistoryReadDetails {
 }
 
 impl HistoryReadDetails {
-    pub fn from_extension_object(obj: ExtensionObject) -> Result<Self, StatusCode> {
+    pub(crate) fn from_extension_object(obj: ExtensionObject) -> Result<Self, StatusCode> {
         match_extension_object_owned!(obj,
             v: ReadRawModifiedDetails => Ok(Self::RawModified(v)),
             v: ReadAtTimeDetails => Ok(Self::AtTime(v)),

--- a/async-opcua-server/src/node_manager/utils/sync_sampler.rs
+++ b/async-opcua-server/src/node_manager/utils/sync_sampler.rs
@@ -24,7 +24,7 @@ struct SamplerItem {
 }
 
 impl SamplerItem {
-    pub fn refresh_values(&mut self) {
+    fn refresh_values(&mut self) {
         let mut interval = Duration::MAX;
         let mut enabled = false;
         for item in self.items.values() {

--- a/async-opcua-server/src/session/controller.rs
+++ b/async-opcua-server/src/session/controller.rs
@@ -46,7 +46,7 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    pub fn from_result(
+    pub(super) fn from_result(
         result: Result<impl Into<ResponseMessage>, StatusCode>,
         request_handle: u32,
         request_id: u32,
@@ -88,7 +88,7 @@ enum RequestProcessResult {
     Close,
 }
 
-pub struct SessionStarter<T> {
+pub(crate) struct SessionStarter<T> {
     connector: T,
     info: Arc<ServerInfo>,
     session_manager: Arc<RwLock<SessionManager>>,
@@ -98,7 +98,7 @@ pub struct SessionStarter<T> {
 }
 
 impl<T: Connector> SessionStarter<T> {
-    pub fn new(
+    pub(crate) fn new(
         connector: T,
         info: Arc<ServerInfo>,
         session_manager: Arc<RwLock<SessionManager>>,
@@ -116,7 +116,7 @@ impl<T: Connector> SessionStarter<T> {
         }
     }
 
-    pub async fn run(self, mut command: tokio::sync::mpsc::Receiver<ControllerCommand>) {
+    pub(crate) async fn run(self, mut command: tokio::sync::mpsc::Receiver<ControllerCommand>) {
         let token = CancellationToken::new();
         let span = tracing::info_span!("Establish TCP channel");
         let fut = self
@@ -160,7 +160,7 @@ impl<T: Connector> SessionStarter<T> {
 }
 
 impl SessionController {
-    pub fn new(
+    fn new(
         transport: TcpTransport,
         session_manager: Arc<RwLock<SessionManager>>,
         certificate_store: Arc<RwLock<CertificateStore>>,
@@ -188,7 +188,7 @@ impl SessionController {
         }
     }
 
-    pub async fn run(mut self, mut command: tokio::sync::mpsc::Receiver<ControllerCommand>) {
+    async fn run(mut self, mut command: tokio::sync::mpsc::Receiver<ControllerCommand>) {
         loop {
             let resp_fut = if self.pending_messages.is_empty() {
                 Either::Left(futures::future::pending::<Option<Result<Response, String>>>())
@@ -762,7 +762,7 @@ struct SecureChannelState {
 }
 
 impl SecureChannelState {
-    pub fn new(handle: Arc<AtomicHandle>) -> SecureChannelState {
+    fn new(handle: Arc<AtomicHandle>) -> SecureChannelState {
         SecureChannelState {
             secure_channel_id: handle,
             issued: false,
@@ -771,11 +771,11 @@ impl SecureChannelState {
         }
     }
 
-    pub fn create_secure_channel_id(&mut self) -> u32 {
+    fn create_secure_channel_id(&mut self) -> u32 {
         self.secure_channel_id.next()
     }
 
-    pub fn create_token_id(&mut self) -> u32 {
+    fn create_token_id(&mut self) -> u32 {
         self.last_token_id += 1;
         self.last_token_id
     }

--- a/async-opcua-server/src/session/message_handler.rs
+++ b/async-opcua-server/src/session/message_handler.rs
@@ -52,7 +52,7 @@ impl PendingPublishRequest {
     /// Receive a publish request response.
     /// This may take a long time, since publish requests can be open for
     /// arbitrarily long waiting for new data to be produced.
-    pub async fn recv(self) -> Result<Response, String> {
+    pub(super) async fn recv(self) -> Result<Response, String> {
         match self.recv.await {
             Ok(msg) => Ok(Response {
                 message: msg,
@@ -96,7 +96,7 @@ macro_rules! service_fault {
 impl<T> Request<T> {
     /// Create a new request.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    fn new(
         request: Box<T>,
         info: Arc<ServerInfo>,
         request_id: u32,
@@ -119,7 +119,7 @@ impl<T> Request<T> {
     }
 
     /// Get a request context object from this request.
-    pub fn context(&self) -> RequestContext {
+    pub(super) fn context(&self) -> RequestContext {
         RequestContext {
             session: self.session.clone(),
             authenticator: self.info.authenticator.clone(),
@@ -163,7 +163,7 @@ struct RequestData {
 
 impl MessageHandler {
     /// Create a new message handler.
-    pub fn new(
+    pub(super) fn new(
         info: Arc<ServerInfo>,
         node_managers: NodeManagers,
         subscriptions: Arc<SubscriptionCache>,
@@ -179,7 +179,7 @@ impl MessageHandler {
     /// This method returns synchronously, but the returned result object
     /// may take longer to resolve.
     /// Once this returns the request will either be resolved or will have been started.
-    pub fn handle_message(
+    pub(super) fn handle_message(
         &mut self,
         message: RequestMessage,
         session_id: u32,
@@ -351,7 +351,7 @@ impl MessageHandler {
     }
 
     /// Delete the subscriptions from a session.
-    pub async fn delete_session_subscriptions(
+    pub(super) async fn delete_session_subscriptions(
         &mut self,
         session_id: u32,
         session: Arc<RwLock<Session>>,
@@ -387,7 +387,7 @@ impl MessageHandler {
         }
     }
 
-    pub fn get_namespaces_for_user(
+    pub(super) fn get_namespaces_for_user(
         &mut self,
         session: Arc<RwLock<Session>>,
         session_id: u32,

--- a/async-opcua-server/src/session/mod.rs
+++ b/async-opcua-server/src/session/mod.rs
@@ -1,7 +1,7 @@
-pub mod continuation_points;
-pub mod controller;
-pub mod instance;
-pub mod manager;
+pub(crate) mod continuation_points;
+pub(crate) mod controller;
+pub(crate) mod instance;
+pub(crate) mod manager;
 #[macro_use]
-pub mod message_handler;
+pub(crate) mod message_handler;
 mod services;

--- a/async-opcua-server/src/session/services/attribute.rs
+++ b/async-opcua-server/src/session/services/attribute.rs
@@ -13,7 +13,7 @@ use opcua_types::{
     HistoryReadResult, HistoryUpdateRequest, HistoryUpdateResponse, NodeId, ObjectId, ReadRequest,
     ReadResponse, ResponseHeader, StatusCode, TimestampsToReturn, WriteRequest, WriteResponse,
 };
-pub async fn read(node_managers: NodeManagers, request: Request<ReadRequest>) -> Response {
+pub(crate) async fn read(node_managers: NodeManagers, request: Request<ReadRequest>) -> Response {
     let mut context = request.context();
     let nodes_to_read = take_service_items!(
         request,
@@ -76,7 +76,7 @@ pub async fn read(node_managers: NodeManagers, request: Request<ReadRequest>) ->
     }
 }
 
-pub async fn write(node_managers: NodeManagers, request: Request<WriteRequest>) -> Response {
+pub(crate) async fn write(node_managers: NodeManagers, request: Request<WriteRequest>) -> Response {
     let mut context = request.context();
     let nodes_to_write = take_service_items!(
         request,
@@ -128,7 +128,7 @@ pub async fn write(node_managers: NodeManagers, request: Request<WriteRequest>) 
     }
 }
 
-pub async fn history_read(
+pub(crate) async fn history_read(
     node_managers: NodeManagers,
     request: Request<HistoryReadRequest>,
 ) -> Response {
@@ -318,7 +318,7 @@ pub async fn history_read(
     }
 }
 
-pub async fn history_update(
+pub(crate) async fn history_update(
     node_managers: NodeManagers,
     request: Request<HistoryUpdateRequest>,
 ) -> Response {

--- a/async-opcua-server/src/session/services/method.rs
+++ b/async-opcua-server/src/session/services/method.rs
@@ -6,7 +6,7 @@ use opcua_types::{CallRequest, CallResponse, ResponseHeader, StatusCode};
 use tracing::debug_span;
 use tracing_futures::Instrument;
 
-pub async fn call(node_managers: NodeManagers, request: Request<CallRequest>) -> Response {
+pub(crate) async fn call(node_managers: NodeManagers, request: Request<CallRequest>) -> Response {
     let mut context = request.context();
     let method_calls = take_service_items!(
         request,

--- a/async-opcua-server/src/session/services/monitored_items.rs
+++ b/async-opcua-server/src/session/services/monitored_items.rs
@@ -138,7 +138,7 @@ async fn get_eu_range(
     res
 }
 
-pub async fn create_monitored_items(
+pub(crate) async fn create_monitored_items(
     node_managers: NodeManagers,
     request: Request<CreateMonitoredItemsRequest>,
 ) -> Response {
@@ -268,7 +268,7 @@ pub async fn create_monitored_items(
     }
 }
 
-pub async fn modify_monitored_items(
+pub(crate) async fn modify_monitored_items(
     node_managers: NodeManagers,
     request: Request<ModifyMonitoredItemsRequest>,
 ) -> Response {
@@ -323,7 +323,7 @@ pub async fn modify_monitored_items(
     }
 }
 
-pub async fn set_monitoring_mode(
+pub(crate) async fn set_monitoring_mode(
     node_managers: NodeManagers,
     request: Request<SetMonitoringModeRequest>,
 ) -> Response {
@@ -372,7 +372,7 @@ pub async fn set_monitoring_mode(
     }
 }
 
-pub async fn delete_monitored_items(
+pub(crate) async fn delete_monitored_items(
     node_managers: NodeManagers,
     request: Request<DeleteMonitoredItemsRequest>,
 ) -> Response {

--- a/async-opcua-server/src/session/services/node_management.rs
+++ b/async-opcua-server/src/session/services/node_management.rs
@@ -13,7 +13,10 @@ use opcua_types::{
 use tracing::debug_span;
 use tracing_futures::Instrument;
 
-pub async fn add_nodes(node_managers: NodeManagers, request: Request<AddNodesRequest>) -> Response {
+pub(crate) async fn add_nodes(
+    node_managers: NodeManagers,
+    request: Request<AddNodesRequest>,
+) -> Response {
     let mut context = request.context();
 
     let nodes_to_add = take_service_items!(
@@ -75,7 +78,7 @@ pub async fn add_nodes(node_managers: NodeManagers, request: Request<AddNodesReq
     }
 }
 
-pub async fn add_references(
+pub(crate) async fn add_references(
     node_managers: NodeManagers,
     request: Request<AddReferencesRequest>,
 ) -> Response {
@@ -144,7 +147,7 @@ pub async fn add_references(
     }
 }
 
-pub async fn delete_nodes(
+pub(crate) async fn delete_nodes(
     node_managers: NodeManagers,
     request: Request<DeleteNodesRequest>,
 ) -> Response {
@@ -216,7 +219,7 @@ pub async fn delete_nodes(
     }
 }
 
-pub async fn delete_references(
+pub(crate) async fn delete_references(
     node_managers: NodeManagers,
     request: Request<DeleteReferencesRequest>,
 ) -> Response {

--- a/async-opcua-server/src/session/services/query.rs
+++ b/async-opcua-server/src/session/services/query.rs
@@ -12,7 +12,7 @@ use opcua_types::{
     ResponseHeader, StatusCode,
 };
 
-pub async fn query_first(
+pub(crate) async fn query_first(
     node_managers: NodeManagers,
     request: Request<QueryFirstRequest>,
 ) -> Response {
@@ -143,7 +143,7 @@ pub async fn query_first(
     }
 }
 
-pub async fn query_next(
+pub(crate) async fn query_next(
     node_managers: NodeManagers,
     request: Request<QueryNextRequest>,
 ) -> Response {

--- a/async-opcua-server/src/session/services/subscriptions.rs
+++ b/async-opcua-server/src/session/services/subscriptions.rs
@@ -10,7 +10,7 @@ use opcua_types::{
 use tracing::debug_span;
 use tracing_futures::Instrument;
 
-pub async fn delete_subscriptions(
+pub(crate) async fn delete_subscriptions(
     node_managers: NodeManagers,
     request: Request<DeleteSubscriptionsRequest>,
 ) -> Response {
@@ -44,7 +44,7 @@ pub async fn delete_subscriptions(
     }
 }
 
-pub async fn delete_subscriptions_inner(
+pub(crate) async fn delete_subscriptions_inner(
     node_managers: NodeManagers,
     to_delete: Vec<u32>,
     subscriptions: &SubscriptionCache,

--- a/async-opcua-server/src/session/services/view.rs
+++ b/async-opcua-server/src/session/services/view.rs
@@ -18,7 +18,10 @@ use opcua_types::{
     TranslateBrowsePathsToNodeIdsResponse, UnregisterNodesRequest, UnregisterNodesResponse,
 };
 
-pub async fn browse(node_managers: NodeManagers, request: Request<BrowseRequest>) -> Response {
+pub(crate) async fn browse(
+    node_managers: NodeManagers,
+    request: Request<BrowseRequest>,
+) -> Response {
     let mut context: RequestContext = request.context();
     let nodes_to_browse = take_service_items!(
         request,
@@ -163,7 +166,7 @@ pub async fn browse(node_managers: NodeManagers, request: Request<BrowseRequest>
     }
 }
 
-pub async fn browse_next(
+pub(crate) async fn browse_next(
     node_managers: NodeManagers,
     request: Request<BrowseNextRequest>,
 ) -> Response {
@@ -333,7 +336,7 @@ pub async fn browse_next(
     }
 }
 
-pub async fn translate_browse_paths(
+pub(crate) async fn translate_browse_paths(
     node_managers: NodeManagers,
     request: Request<TranslateBrowsePathsToNodeIdsRequest>,
 ) -> Response {
@@ -471,7 +474,7 @@ pub async fn translate_browse_paths(
     }
 }
 
-pub async fn register_nodes(
+pub(crate) async fn register_nodes(
     node_managers: NodeManagers,
     request: Request<RegisterNodesRequest>,
 ) -> Response {
@@ -527,7 +530,7 @@ pub async fn register_nodes(
     }
 }
 
-pub async fn unregister_nodes(
+pub(crate) async fn unregister_nodes(
     node_managers: NodeManagers,
     request: Request<UnregisterNodesRequest>,
 ) -> Response {

--- a/async-opcua-server/src/subscriptions/mod.rs
+++ b/async-opcua-server/src/subscriptions/mod.rs
@@ -778,11 +778,7 @@ struct PersistentSessionKey {
 }
 
 impl PersistentSessionKey {
-    pub fn new(
-        token: &UserToken,
-        security_mode: MessageSecurityMode,
-        application_uri: &str,
-    ) -> Self {
+    fn new(token: &UserToken, security_mode: MessageSecurityMode, application_uri: &str) -> Self {
         Self {
             token: token.clone(),
             security_mode,
@@ -790,7 +786,7 @@ impl PersistentSessionKey {
         }
     }
 
-    pub fn is_equivalent_for_transfer(&self, other: &PersistentSessionKey) -> bool {
+    fn is_equivalent_for_transfer(&self, other: &PersistentSessionKey) -> bool {
         if self.token.is_anonymous() {
             other.token.is_anonymous()
                 && matches!(

--- a/async-opcua-server/src/subscriptions/monitored_item.rs
+++ b/async-opcua-server/src/subscriptions/monitored_item.rs
@@ -13,7 +13,7 @@ use opcua_types::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Notification {
+pub(crate) enum Notification {
     MonitoredItemNotification(MonitoredItemNotification),
     Event(EventFieldList),
 }
@@ -615,7 +615,7 @@ pub(super) mod tests {
 
     use super::{FilterType, MonitoredItem};
 
-    pub fn new_monitored_item(
+    pub(crate) fn new_monitored_item(
         id: u32,
         item_to_monitor: ReadValueId,
         monitoring_mode: MonitoringMode,

--- a/async-opcua-server/src/subscriptions/subscription.rs
+++ b/async-opcua-server/src/subscriptions/subscription.rs
@@ -44,7 +44,7 @@ pub(crate) struct SubscriptionStateParams {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum UpdateStateAction {
+pub(crate) enum UpdateStateAction {
     None,
     // Return a keep alive
     ReturnKeepAlive,

--- a/async-opcua-server/src/transport/connect.rs
+++ b/async-opcua-server/src/transport/connect.rs
@@ -7,7 +7,7 @@ use crate::info::ServerInfo;
 
 use super::tcp::TcpTransport;
 
-pub trait Connector {
+pub(crate) trait Connector {
     fn connect(
         self,
         info: Arc<ServerInfo>,

--- a/async-opcua-server/src/transport/mod.rs
+++ b/async-opcua-server/src/transport/mod.rs
@@ -1,3 +1,3 @@
 mod connect;
-pub mod tcp;
-pub use connect::Connector;
+pub(crate) mod tcp;
+pub(crate) use connect::Connector;

--- a/async-opcua-server/src/transport/tcp.rs
+++ b/async-opcua-server/src/transport/tcp.rs
@@ -85,7 +85,7 @@ fn min_zero_infinite(server: u32, client: u32) -> u32 {
     }
 }
 
-pub struct TcpConnector {
+pub(crate) struct TcpConnector {
     read: FramedRead<ReadHalf<TcpStream>, TcpCodec>,
     write: WriteHalf<TcpStream>,
     deadline: Instant,
@@ -94,7 +94,7 @@ pub struct TcpConnector {
 }
 
 impl TcpConnector {
-    pub fn new(
+    pub(crate) fn new(
         stream: TcpStream,
         config: TransportConfig,
         decoding_options: DecodingOptions,
@@ -231,7 +231,7 @@ impl Connector for TcpConnector {
 }
 
 impl TcpTransport {
-    pub fn new(
+    pub(crate) fn new(
         read: FramedRead<ReadHalf<TcpStream>, TcpCodec>,
         write: WriteHalf<TcpStream>,
         send_buffer: SendBuffer,
@@ -249,19 +249,19 @@ impl TcpTransport {
 
     /// Set the transport state to closing, once the final message is sent
     /// the connection will be closed.
-    pub fn set_closing(&mut self) {
+    pub(crate) fn set_closing(&mut self) {
         self.state = TransportState::Closing;
     }
 
-    pub fn is_closing(&self) -> bool {
+    pub(crate) fn is_closing(&self) -> bool {
         matches!(self.state, TransportState::Closing)
     }
 
-    pub fn enqueue_error(&mut self, message: ErrorMessage) {
+    pub(crate) fn enqueue_error(&mut self, message: ErrorMessage) {
         self.send_buffer.write_error(message);
     }
 
-    pub fn enqueue_message_for_send(
+    pub(crate) fn enqueue_message_for_send(
         &mut self,
         channel: &mut SecureChannel,
         message: ResponseMessage,
@@ -290,7 +290,7 @@ impl TcpTransport {
         }
     }
 
-    pub async fn poll(&mut self, channel: &mut SecureChannel) -> TransportPollResult {
+    pub(crate) async fn poll(&mut self, channel: &mut SecureChannel) -> TransportPollResult {
         // Either we've got something in the send buffer, which we can send,
         // or we're waiting for more outgoing messages.
         // We won't wait for outgoing messages while sending, since that

--- a/async-opcua-types/Cargo.toml
+++ b/async-opcua-types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/async-opcua-types/"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [features]
 json = ["struson", "async-opcua-macros/json"]
 xml = ["async-opcua-xml", "async-opcua-macros/xml"]

--- a/async-opcua-types/src/argument.rs
+++ b/async-opcua-types/src/argument.rs
@@ -28,7 +28,7 @@ use crate::{
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 #[derive(Clone, Debug, PartialEq, Default, crate::UaNullable)]

--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -976,7 +976,7 @@ pub(crate) mod tests {
     }
 
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     const TYPE_NAMESPACE: &str = "my.custom.namespace.uri";

--- a/async-opcua-types/src/data_value.rs
+++ b/async-opcua-types/src/data_value.rs
@@ -33,7 +33,7 @@ bitflags! {
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 /// A data value is a value of a variable in the OPC UA server and contains information about its

--- a/async-opcua-types/src/diagnostic_info.rs
+++ b/async-opcua-types/src/diagnostic_info.rs
@@ -129,7 +129,7 @@ mod xml {
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 /// Diagnostic information.

--- a/async-opcua-types/src/generated/node_ids.rs
+++ b/async-opcua-types/src/generated/node_ids.rs
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[allow(non_camel_case_types, clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]

--- a/async-opcua-types/src/generated/types/action_method_data_type.rs
+++ b/async-opcua-types/src/generated/types/action_method_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.10.5

--- a/async-opcua-types/src/generated/types/action_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/action_target_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.10.3

--- a/async-opcua-types/src/generated/types/activate_session_request.rs
+++ b/async-opcua-types/src/generated/types/activate_session_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.3/#5.7.3.2

--- a/async-opcua-types/src/generated/types/activate_session_response.rs
+++ b/async-opcua-types/src/generated/types/activate_session_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.3/#5.7.3.2

--- a/async-opcua-types/src/generated/types/add_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_item.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.1

--- a/async-opcua-types/src/generated/types/add_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.2/#5.8.2.2

--- a/async-opcua-types/src/generated/types/add_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.2/#5.8.2.2

--- a/async-opcua-types/src/generated/types/add_nodes_result.rs
+++ b/async-opcua-types/src/generated/types/add_nodes_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.2/#5.8.2.2

--- a/async-opcua-types/src/generated/types/add_references_item.rs
+++ b/async-opcua-types/src/generated/types/add_references_item.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.2

--- a/async-opcua-types/src/generated/types/add_references_request.rs
+++ b/async-opcua-types/src/generated/types/add_references_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.3/#5.8.3.2

--- a/async-opcua-types/src/generated/types/add_references_response.rs
+++ b/async-opcua-types/src/generated/types/add_references_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.3/#5.8.3.2

--- a/async-opcua-types/src/generated/types/additional_parameters_type.rs
+++ b/async-opcua-types/src/generated/types/additional_parameters_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.1

--- a/async-opcua-types/src/generated/types/aggregate_configuration.rs
+++ b/async-opcua-types/src/generated/types/aggregate_configuration.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.4/#6.5.4.1

--- a/async-opcua-types/src/generated/types/aggregate_filter.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.4

--- a/async-opcua-types/src/generated/types/aggregate_filter_result.rs
+++ b/async-opcua-types/src/generated/types/aggregate_filter_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.4

--- a/async-opcua-types/src/generated/types/alias_name_data_type.rs
+++ b/async-opcua-types/src/generated/types/alias_name_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part17/7.2

--- a/async-opcua-types/src/generated/types/annotation.rs
+++ b/async-opcua-types/src/generated/types/annotation.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.6

--- a/async-opcua-types/src/generated/types/annotation_data_type.rs
+++ b/async-opcua-types/src/generated/types/annotation_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/6.6.1

--- a/async-opcua-types/src/generated/types/anonymous_identity_token.rs
+++ b/async-opcua-types/src/generated/types/anonymous_identity_token.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.15/#12.3.15.1

--- a/async-opcua-types/src/generated/types/application_description.rs
+++ b/async-opcua-types/src/generated/types/application_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/7.2.4/#7.2.4.6.5

--- a/async-opcua-types/src/generated/types/attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/attribute_operand.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.4/#7.7.4.4

--- a/async-opcua-types/src/generated/types/axis_information.rs
+++ b/async-opcua-types/src/generated/types/axis_information.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.6

--- a/async-opcua-types/src/generated/types/bit_field_definition.rs
+++ b/async-opcua-types/src/generated/types/bit_field_definition.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.45

--- a/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_connection_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.2/#6.4.2.2.3

--- a/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_reader_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.2/#6.4.2.6.6

--- a/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_data_set_writer_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.2/#6.4.2.5.7

--- a/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/broker_writer_group_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.2/#6.4.2.3.5

--- a/async-opcua-types/src/generated/types/browse_description.rs
+++ b/async-opcua-types/src/generated/types/browse_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.2/#5.9.2.2

--- a/async-opcua-types/src/generated/types/browse_next_request.rs
+++ b/async-opcua-types/src/generated/types/browse_next_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.3/#5.9.3.2

--- a/async-opcua-types/src/generated/types/browse_next_response.rs
+++ b/async-opcua-types/src/generated/types/browse_next_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.3/#5.9.3.2

--- a/async-opcua-types/src/generated/types/browse_path.rs
+++ b/async-opcua-types/src/generated/types/browse_path.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.4/#5.9.4.2

--- a/async-opcua-types/src/generated/types/browse_path_result.rs
+++ b/async-opcua-types/src/generated/types/browse_path_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.4/#5.9.4.2

--- a/async-opcua-types/src/generated/types/browse_path_target.rs
+++ b/async-opcua-types/src/generated/types/browse_path_target.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.4/#5.9.4.2

--- a/async-opcua-types/src/generated/types/browse_request.rs
+++ b/async-opcua-types/src/generated/types/browse_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.2/#5.9.2.2

--- a/async-opcua-types/src/generated/types/browse_response.rs
+++ b/async-opcua-types/src/generated/types/browse_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.2/#5.9.2.2

--- a/async-opcua-types/src/generated/types/browse_result.rs
+++ b/async-opcua-types/src/generated/types/browse_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.6

--- a/async-opcua-types/src/generated/types/build_info.rs
+++ b/async-opcua-types/src/generated/types/build_info.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.4

--- a/async-opcua-types/src/generated/types/call_method_request.rs
+++ b/async-opcua-types/src/generated/types/call_method_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.12.2/#5.12.2.2

--- a/async-opcua-types/src/generated/types/call_method_result.rs
+++ b/async-opcua-types/src/generated/types/call_method_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.12.2/#5.12.2.2

--- a/async-opcua-types/src/generated/types/call_request.rs
+++ b/async-opcua-types/src/generated/types/call_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.12.2/#5.12.2.2

--- a/async-opcua-types/src/generated/types/call_response.rs
+++ b/async-opcua-types/src/generated/types/call_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.12.2/#5.12.2.2

--- a/async-opcua-types/src/generated/types/cancel_request.rs
+++ b/async-opcua-types/src/generated/types/cancel_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.5/#5.7.5.2

--- a/async-opcua-types/src/generated/types/cancel_response.rs
+++ b/async-opcua-types/src/generated/types/cancel_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.5/#5.7.5.2

--- a/async-opcua-types/src/generated/types/channel_security_token.rs
+++ b/async-opcua-types/src/generated/types/channel_security_token.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/close_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/close_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/close_secure_channel_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/close_session_request.rs
+++ b/async-opcua-types/src/generated/types/close_session_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.4/#5.7.4.2

--- a/async-opcua-types/src/generated/types/close_session_response.rs
+++ b/async-opcua-types/src/generated/types/close_session_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.4/#5.7.4.2

--- a/async-opcua-types/src/generated/types/complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/complex_number_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.4

--- a/async-opcua-types/src/generated/types/configuration_version_data_type.rs
+++ b/async-opcua-types/src/generated/types/configuration_version_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.2.6

--- a/async-opcua-types/src/generated/types/content_filter.rs
+++ b/async-opcua-types/src/generated/types/content_filter.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.4

--- a/async-opcua-types/src/generated/types/content_filter_element.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.1

--- a/async-opcua-types/src/generated/types/content_filter_element_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_element_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.2

--- a/async-opcua-types/src/generated/types/content_filter_result.rs
+++ b/async-opcua-types/src/generated/types/content_filter_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.2

--- a/async-opcua-types/src/generated/types/create_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.2/#5.13.2.2

--- a/async-opcua-types/src/generated/types/create_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/create_monitored_items_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.2/#5.13.2.2

--- a/async-opcua-types/src/generated/types/create_session_request.rs
+++ b/async-opcua-types/src/generated/types/create_session_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.2/#5.7.2.2

--- a/async-opcua-types/src/generated/types/create_session_response.rs
+++ b/async-opcua-types/src/generated/types/create_session_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.7.2/#5.7.2.2

--- a/async-opcua-types/src/generated/types/create_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.2/#5.14.2.2

--- a/async-opcua-types/src/generated/types/create_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/create_subscription_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.2/#5.14.2.2

--- a/async-opcua-types/src/generated/types/currency_unit_type.rs
+++ b/async-opcua-types/src/generated/types/currency_unit_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.2

--- a/async-opcua-types/src/generated/types/data_change_filter.rs
+++ b/async-opcua-types/src/generated/types/data_change_filter.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.2

--- a/async-opcua-types/src/generated/types/data_change_notification.rs
+++ b/async-opcua-types/src/generated/types/data_change_notification.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.2

--- a/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_meta_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.2.3

--- a/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_reader_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.9/#6.2.9.13.1

--- a/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
+++ b/async-opcua-types/src/generated/types/data_set_writer_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.4/#6.2.4.5.1

--- a/async-opcua-types/src/generated/types/data_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/data_type_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.8

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_2_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.2.7

--- a/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_connection_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.2.2

--- a/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_data_set_reader_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.6.5

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_2_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.3.9

--- a/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
+++ b/async-opcua-types/src/generated/types/datagram_writer_group_transport_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.3.3

--- a/async-opcua-types/src/generated/types/decimal_data_type.rs
+++ b/async-opcua-types/src/generated/types/decimal_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/delete_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/delete_at_time_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.6/#6.9.6.1

--- a/async-opcua-types/src/generated/types/delete_event_details.rs
+++ b/async-opcua-types/src/generated/types/delete_event_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.7/#6.9.7.1

--- a/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.6/#5.13.6.2

--- a/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/delete_monitored_items_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.6/#5.13.6.2

--- a/async-opcua-types/src/generated/types/delete_nodes_item.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_item.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.6

--- a/async-opcua-types/src/generated/types/delete_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.4/#5.8.4.2

--- a/async-opcua-types/src/generated/types/delete_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/delete_nodes_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.4/#5.8.4.2

--- a/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/delete_raw_modified_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.5/#6.9.5.1

--- a/async-opcua-types/src/generated/types/delete_references_item.rs
+++ b/async-opcua-types/src/generated/types/delete_references_item.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.7

--- a/async-opcua-types/src/generated/types/delete_references_request.rs
+++ b/async-opcua-types/src/generated/types/delete_references_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.5/#5.8.5.1

--- a/async-opcua-types/src/generated/types/delete_references_response.rs
+++ b/async-opcua-types/src/generated/types/delete_references_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.8.5/#5.8.5.1

--- a/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.8/#5.14.8.2

--- a/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/delete_subscriptions_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.8/#5.14.8.2

--- a/async-opcua-types/src/generated/types/discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/discovery_configuration.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.13.1

--- a/async-opcua-types/src/generated/types/double_complex_number_type.rs
+++ b/async-opcua-types/src/generated/types/double_complex_number_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.5

--- a/async-opcua-types/src/generated/types/dtls_pub_sub_connection_data_type.rs
+++ b/async-opcua-types/src/generated/types/dtls_pub_sub_connection_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.7.6

--- a/async-opcua-types/src/generated/types/element_operand.rs
+++ b/async-opcua-types/src/generated/types/element_operand.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.4/#7.7.4.2

--- a/async-opcua-types/src/generated/types/endpoint_configuration.rs
+++ b/async-opcua-types/src/generated/types/endpoint_configuration.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/endpoint_description.rs
+++ b/async-opcua-types/src/generated/types/endpoint_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.14

--- a/async-opcua-types/src/generated/types/endpoint_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part18/4.4.2

--- a/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/endpoint_url_list_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.20

--- a/async-opcua-types/src/generated/types/enum_definition.rs
+++ b/async-opcua-types/src/generated/types/enum_definition.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.4

--- a/async-opcua-types/src/generated/types/enum_description.rs
+++ b/async-opcua-types/src/generated/types/enum_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.34

--- a/async-opcua-types/src/generated/types/enum_field.rs
+++ b/async-opcua-types/src/generated/types/enum_field.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.7

--- a/async-opcua-types/src/generated/types/enum_value_type.rs
+++ b/async-opcua-types/src/generated/types/enum_value_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.6

--- a/async-opcua-types/src/generated/types/enums.rs
+++ b/async-opcua-types/src/generated/types/enums.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] #[doc =

--- a/async-opcua-types/src/generated/types/ephemeral_key_type.rs
+++ b/async-opcua-types/src/generated/types/ephemeral_key_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.15

--- a/async-opcua-types/src/generated/types/eu_information.rs
+++ b/async-opcua-types/src/generated/types/eu_information.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.3/#5.6.3.3

--- a/async-opcua-types/src/generated/types/event_field_list.rs
+++ b/async-opcua-types/src/generated/types/event_field_list.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.3

--- a/async-opcua-types/src/generated/types/event_filter.rs
+++ b/async-opcua-types/src/generated/types/event_filter.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.3

--- a/async-opcua-types/src/generated/types/event_filter_result.rs
+++ b/async-opcua-types/src/generated/types/event_filter_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.3

--- a/async-opcua-types/src/generated/types/event_notification_list.rs
+++ b/async-opcua-types/src/generated/types/event_notification_list.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.3

--- a/async-opcua-types/src/generated/types/field_meta_data.rs
+++ b/async-opcua-types/src/generated/types/field_meta_data.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.2.4

--- a/async-opcua-types/src/generated/types/field_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/field_target_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.10/#6.2.10.2.3

--- a/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.3/#5.5.3.2

--- a/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_on_network_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.3/#5.5.3.2

--- a/async-opcua-types/src/generated/types/find_servers_request.rs
+++ b/async-opcua-types/src/generated/types/find_servers_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.2/#5.5.2.2

--- a/async-opcua-types/src/generated/types/find_servers_response.rs
+++ b/async-opcua-types/src/generated/types/find_servers_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.2/#5.5.2.2

--- a/async-opcua-types/src/generated/types/generic_attribute_value.rs
+++ b/async-opcua-types/src/generated/types/generic_attribute_value.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.10

--- a/async-opcua-types/src/generated/types/generic_attributes.rs
+++ b/async-opcua-types/src/generated/types/generic_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.10

--- a/async-opcua-types/src/generated/types/get_endpoints_request.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.4/#5.5.4.2

--- a/async-opcua-types/src/generated/types/get_endpoints_response.rs
+++ b/async-opcua-types/src/generated/types/get_endpoints_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.4/#5.5.4.2

--- a/async-opcua-types/src/generated/types/history_data.rs
+++ b/async-opcua-types/src/generated/types/history_data.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.2

--- a/async-opcua-types/src/generated/types/history_event.rs
+++ b/async-opcua-types/src/generated/types/history_event.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.4

--- a/async-opcua-types/src/generated/types/history_event_field_list.rs
+++ b/async-opcua-types/src/generated/types/history_event_field_list.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.4

--- a/async-opcua-types/src/generated/types/history_modified_data.rs
+++ b/async-opcua-types/src/generated/types/history_modified_data.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.3

--- a/async-opcua-types/src/generated/types/history_modified_event.rs
+++ b/async-opcua-types/src/generated/types/history_modified_event.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.5

--- a/async-opcua-types/src/generated/types/history_read_request.rs
+++ b/async-opcua-types/src/generated/types/history_read_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.3/#5.11.3.2

--- a/async-opcua-types/src/generated/types/history_read_response.rs
+++ b/async-opcua-types/src/generated/types/history_read_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.3/#5.11.3.2

--- a/async-opcua-types/src/generated/types/history_read_result.rs
+++ b/async-opcua-types/src/generated/types/history_read_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.3/#5.11.3.2

--- a/async-opcua-types/src/generated/types/history_read_value_id.rs
+++ b/async-opcua-types/src/generated/types/history_read_value_id.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.3/#5.11.3.2

--- a/async-opcua-types/src/generated/types/history_update_request.rs
+++ b/async-opcua-types/src/generated/types/history_update_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.5/#5.11.5.2

--- a/async-opcua-types/src/generated/types/history_update_response.rs
+++ b/async-opcua-types/src/generated/types/history_update_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.5/#5.11.5.2

--- a/async-opcua-types/src/generated/types/history_update_result.rs
+++ b/async-opcua-types/src/generated/types/history_update_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.5/#5.11.5.2

--- a/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
+++ b/async-opcua-types/src/generated/types/identity_mapping_rule_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part18/4.4.3

--- a/async-opcua-types/src/generated/types/issued_identity_token.rs
+++ b/async-opcua-types/src/generated/types/issued_identity_token.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.15/#12.3.15.2

--- a/async-opcua-types/src/generated/types/json_action_meta_data_message.rs
+++ b/async-opcua-types/src/generated/types/json_action_meta_data_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_action_network_message.rs
+++ b/async-opcua-types/src/generated/types/json_action_network_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_action_request_message.rs
+++ b/async-opcua-types/src/generated/types/json_action_request_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_action_responder_message.rs
+++ b/async-opcua-types/src/generated/types/json_action_responder_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_action_response_message.rs
+++ b/async-opcua-types/src/generated/types/json_action_response_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_application_description_message.rs
+++ b/async-opcua-types/src/generated/types/json_application_description_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_data_set_message.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_data_set_meta_data_message.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_meta_data_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_reader_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.2/#6.3.2.4.3

--- a/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_data_set_writer_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.2/#6.3.2.3.2

--- a/async-opcua-types/src/generated/types/json_network_message.rs
+++ b/async-opcua-types/src/generated/types/json_network_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_pub_sub_connection_message.rs
+++ b/async-opcua-types/src/generated/types/json_pub_sub_connection_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_server_endpoints_message.rs
+++ b/async-opcua-types/src/generated/types/json_server_endpoints_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_status_message.rs
+++ b/async-opcua-types/src/generated/types/json_status_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/json_writer_group_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.2/#6.3.2.1.2

--- a/async-opcua-types/src/generated/types/key_value_pair.rs
+++ b/async-opcua-types/src/generated/types/key_value_pair.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.21

--- a/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
+++ b/async-opcua-types/src/generated/types/linear_conversion_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/6.6.2

--- a/async-opcua-types/src/generated/types/literal_operand.rs
+++ b/async-opcua-types/src/generated/types/literal_operand.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.4/#7.7.4.3

--- a/async-opcua-types/src/generated/types/lldp_management_address_tx_port_type.rs
+++ b/async-opcua-types/src/generated/types/lldp_management_address_tx_port_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part22/5.3.2/#5.3.2.2

--- a/async-opcua-types/src/generated/types/lldp_management_address_type.rs
+++ b/async-opcua-types/src/generated/types/lldp_management_address_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part22/5.3.2/#5.3.2.3

--- a/async-opcua-types/src/generated/types/lldp_tlv_type.rs
+++ b/async-opcua-types/src/generated/types/lldp_tlv_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part22/5.3.2/#5.3.2.4

--- a/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
+++ b/async-opcua-types/src/generated/types/mdns_discovery_configuration.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.13.2

--- a/async-opcua-types/src/generated/types/method_attributes.rs
+++ b/async-opcua-types/src/generated/types/method_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.4

--- a/async-opcua-types/src/generated/types/mod.rs
+++ b/async-opcua-types/src/generated/types/mod.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 pub mod enums;
 pub use enums::*;

--- a/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/model_change_structure_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.16

--- a/async-opcua-types/src/generated/types/modification_info.rs
+++ b/async-opcua-types/src/generated/types/modification_info.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.6.5

--- a/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.3/#5.13.3.2

--- a/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
+++ b/async-opcua-types/src/generated/types/modify_monitored_items_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.3/#5.13.3.2

--- a/async-opcua-types/src/generated/types/modify_subscription_request.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.3/#5.14.3.2

--- a/async-opcua-types/src/generated/types/modify_subscription_response.rs
+++ b/async-opcua-types/src/generated/types/modify_subscription_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.3/#5.14.3.2

--- a/async-opcua-types/src/generated/types/monitored_item_create_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.2/#5.13.2.2

--- a/async-opcua-types/src/generated/types/monitored_item_create_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_create_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.2/#5.13.2.2

--- a/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.3/#5.13.3.2

--- a/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_modify_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.3/#5.13.3.2

--- a/async-opcua-types/src/generated/types/monitored_item_notification.rs
+++ b/async-opcua-types/src/generated/types/monitored_item_notification.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.2

--- a/async-opcua-types/src/generated/types/monitoring_filter.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.22.1

--- a/async-opcua-types/src/generated/types/monitoring_filter_result.rs
+++ b/async-opcua-types/src/generated/types/monitoring_filter_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/monitoring_parameters.rs
+++ b/async-opcua-types/src/generated/types/monitoring_parameters.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.21

--- a/async-opcua-types/src/generated/types/network_address_url_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_address_url_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.7/#6.2.7.5.4

--- a/async-opcua-types/src/generated/types/network_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/network_group_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.19

--- a/async-opcua-types/src/generated/types/node_attributes.rs
+++ b/async-opcua-types/src/generated/types/node_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.1

--- a/async-opcua-types/src/generated/types/node_reference.rs
+++ b/async-opcua-types/src/generated/types/node_reference.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/node_type_description.rs
+++ b/async-opcua-types/src/generated/types/node_type_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.3/#5.10.3.1

--- a/async-opcua-types/src/generated/types/notification_data.rs
+++ b/async-opcua-types/src/generated/types/notification_data.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.1

--- a/async-opcua-types/src/generated/types/notification_message.rs
+++ b/async-opcua-types/src/generated/types/notification_message.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.26

--- a/async-opcua-types/src/generated/types/object_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.2

--- a/async-opcua-types/src/generated/types/object_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/object_type_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.5

--- a/async-opcua-types/src/generated/types/open_secure_channel_request.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/open_secure_channel_response.rs
+++ b/async-opcua-types/src/generated/types/open_secure_channel_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/parsing_result.rs
+++ b/async-opcua-types/src/generated/types/parsing_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.3/#5.10.3.1

--- a/async-opcua-types/src/generated/types/portable_node_id.rs
+++ b/async-opcua-types/src/generated/types/portable_node_id.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.38

--- a/async-opcua-types/src/generated/types/portable_qualified_name.rs
+++ b/async-opcua-types/src/generated/types/portable_qualified_name.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.37

--- a/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
+++ b/async-opcua-types/src/generated/types/priority_mapping_entry_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part22/5.3.2/#5.3.2.1

--- a/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_2_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part10/5.2.8

--- a/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
+++ b/async-opcua-types/src/generated/types/program_diagnostic_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_2_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.12/#6.2.12.4

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.12/#6.2.12.1

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_ref_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/9.1.3/#9.1.3.7.3

--- a/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_configuration_value_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/9.1.3/#9.1.3.7.4

--- a/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_connection_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.7/#6.2.7.5.1

--- a/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
+++ b/async-opcua-types/src/generated/types/pub_sub_key_push_target_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.12/#6.2.12.3

--- a/async-opcua-types/src/generated/types/publish_request.rs
+++ b/async-opcua-types/src/generated/types/publish_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.5/#5.14.5.2

--- a/async-opcua-types/src/generated/types/publish_response.rs
+++ b/async-opcua-types/src/generated/types/publish_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.5/#5.14.5.2

--- a/async-opcua-types/src/generated/types/published_action_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_action_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.10.4

--- a/async-opcua-types/src/generated/types/published_action_method_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_action_method_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.10.6

--- a/async-opcua-types/src/generated/types/published_data_items_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_items_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.7.2

--- a/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_custom_source_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.9.2

--- a/async-opcua-types/src/generated/types/published_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_data_set_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.5

--- a/async-opcua-types/src/generated/types/published_events_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_events_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.8.4

--- a/async-opcua-types/src/generated/types/published_variable_data_type.rs
+++ b/async-opcua-types/src/generated/types/published_variable_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.3/#6.2.3.7.1

--- a/async-opcua-types/src/generated/types/quantity_dimension.rs
+++ b/async-opcua-types/src/generated/types/quantity_dimension.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/6.6.4

--- a/async-opcua-types/src/generated/types/query_data_description.rs
+++ b/async-opcua-types/src/generated/types/query_data_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.3/#5.10.3.1

--- a/async-opcua-types/src/generated/types/query_data_set.rs
+++ b/async-opcua-types/src/generated/types/query_data_set.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.28

--- a/async-opcua-types/src/generated/types/query_first_request.rs
+++ b/async-opcua-types/src/generated/types/query_first_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.3/#5.10.3.1

--- a/async-opcua-types/src/generated/types/query_first_response.rs
+++ b/async-opcua-types/src/generated/types/query_first_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.3/#5.10.3.1

--- a/async-opcua-types/src/generated/types/query_next_request.rs
+++ b/async-opcua-types/src/generated/types/query_next_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.4/#5.10.4.2

--- a/async-opcua-types/src/generated/types/query_next_response.rs
+++ b/async-opcua-types/src/generated/types/query_next_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.10.4/#5.10.4.2

--- a/async-opcua-types/src/generated/types/range.rs
+++ b/async-opcua-types/src/generated/types/range.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.2

--- a/async-opcua-types/src/generated/types/rational_number.rs
+++ b/async-opcua-types/src/generated/types/rational_number.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.22

--- a/async-opcua-types/src/generated/types/read_annotation_data_details.rs
+++ b/async-opcua-types/src/generated/types/read_annotation_data_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.6/#6.5.6.1

--- a/async-opcua-types/src/generated/types/read_at_time_details.rs
+++ b/async-opcua-types/src/generated/types/read_at_time_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.5/#6.5.5.1

--- a/async-opcua-types/src/generated/types/read_event_details.rs
+++ b/async-opcua-types/src/generated/types/read_event_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.2/#6.5.2.1

--- a/async-opcua-types/src/generated/types/read_event_details_2.rs
+++ b/async-opcua-types/src/generated/types/read_event_details_2.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.2/#6.5.2.3

--- a/async-opcua-types/src/generated/types/read_event_details_sorted.rs
+++ b/async-opcua-types/src/generated/types/read_event_details_sorted.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.2/#6.5.2.5

--- a/async-opcua-types/src/generated/types/read_processed_details.rs
+++ b/async-opcua-types/src/generated/types/read_processed_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.4/#6.5.4.1

--- a/async-opcua-types/src/generated/types/read_raw_modified_details.rs
+++ b/async-opcua-types/src/generated/types/read_raw_modified_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.3/#6.5.3.1

--- a/async-opcua-types/src/generated/types/read_request.rs
+++ b/async-opcua-types/src/generated/types/read_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.2/#5.11.2.2

--- a/async-opcua-types/src/generated/types/read_response.rs
+++ b/async-opcua-types/src/generated/types/read_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.2/#5.11.2.2

--- a/async-opcua-types/src/generated/types/read_value_id.rs
+++ b/async-opcua-types/src/generated/types/read_value_id.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.29

--- a/async-opcua-types/src/generated/types/reader_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/reader_group_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.8/#6.2.8.2.1

--- a/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/receive_qos_priority_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.1.6.2

--- a/async-opcua-types/src/generated/types/redundant_server_data_type.rs
+++ b/async-opcua-types/src/generated/types/redundant_server_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.7

--- a/async-opcua-types/src/generated/types/reference_description.rs
+++ b/async-opcua-types/src/generated/types/reference_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.30

--- a/async-opcua-types/src/generated/types/reference_description_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_description_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
+++ b/async-opcua-types/src/generated/types/reference_list_entry_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/reference_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/reference_type_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.7

--- a/async-opcua-types/src/generated/types/register_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.5/#5.9.5.2

--- a/async-opcua-types/src/generated/types/register_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/register_nodes_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.5/#5.9.5.2

--- a/async-opcua-types/src/generated/types/register_server_2_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.6/#5.5.6.2

--- a/async-opcua-types/src/generated/types/register_server_2_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_2_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.6/#5.5.6.2

--- a/async-opcua-types/src/generated/types/register_server_request.rs
+++ b/async-opcua-types/src/generated/types/register_server_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.5/#5.5.5.2

--- a/async-opcua-types/src/generated/types/register_server_response.rs
+++ b/async-opcua-types/src/generated/types/register_server_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.5/#5.5.5.2

--- a/async-opcua-types/src/generated/types/registered_server.rs
+++ b/async-opcua-types/src/generated/types/registered_server.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.32

--- a/async-opcua-types/src/generated/types/relative_path.rs
+++ b/async-opcua-types/src/generated/types/relative_path.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.31

--- a/async-opcua-types/src/generated/types/relative_path_element.rs
+++ b/async-opcua-types/src/generated/types/relative_path_element.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.31

--- a/async-opcua-types/src/generated/types/republish_request.rs
+++ b/async-opcua-types/src/generated/types/republish_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.6/#5.14.6.2

--- a/async-opcua-types/src/generated/types/republish_response.rs
+++ b/async-opcua-types/src/generated/types/republish_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.6/#5.14.6.2

--- a/async-opcua-types/src/generated/types/role_permission_type.rs
+++ b/async-opcua-types/src/generated/types/role_permission_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.9

--- a/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/sampling_interval_diagnostics_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.8

--- a/async-opcua-types/src/generated/types/security_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/security_group_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.12/#6.2.12.2

--- a/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
+++ b/async-opcua-types/src/generated/types/semantic_change_structure_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.17

--- a/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_diagnostics_summary_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.9

--- a/async-opcua-types/src/generated/types/server_on_network.rs
+++ b/async-opcua-types/src/generated/types/server_on_network.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.5.3/#5.5.3.2

--- a/async-opcua-types/src/generated/types/server_status_data_type.rs
+++ b/async-opcua-types/src/generated/types/server_status_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.10

--- a/async-opcua-types/src/generated/types/service_counter_data_type.rs
+++ b/async-opcua-types/src/generated/types/service_counter_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.13

--- a/async-opcua-types/src/generated/types/service_fault.rs
+++ b/async-opcua-types/src/generated/types/service_fault.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.35

--- a/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_diagnostics_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.11

--- a/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/session_security_diagnostics_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.12

--- a/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_request_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
+++ b/async-opcua-types/src/generated/types/sessionless_invoke_response_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.4/#5.13.4.2

--- a/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_monitoring_mode_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.4/#5.13.4.2

--- a/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.4/#5.14.4.2

--- a/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
+++ b/async-opcua-types/src/generated/types/set_publishing_mode_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.4/#5.14.4.2

--- a/async-opcua-types/src/generated/types/set_triggering_request.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.5/#5.13.5.2

--- a/async-opcua-types/src/generated/types/set_triggering_response.rs
+++ b/async-opcua-types/src/generated/types/set_triggering_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.13.5/#5.13.5.2

--- a/async-opcua-types/src/generated/types/signature_data.rs
+++ b/async-opcua-types/src/generated/types/signature_data.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.37

--- a/async-opcua-types/src/generated/types/signed_software_certificate.rs
+++ b/async-opcua-types/src/generated/types/signed_software_certificate.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.13

--- a/async-opcua-types/src/generated/types/simple_attribute_operand.rs
+++ b/async-opcua-types/src/generated/types/simple_attribute_operand.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.4/#7.7.4.5

--- a/async-opcua-types/src/generated/types/simple_type_description.rs
+++ b/async-opcua-types/src/generated/types/simple_type_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.35

--- a/async-opcua-types/src/generated/types/sort_rule_element.rs
+++ b/async-opcua-types/src/generated/types/sort_rule_element.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.5.7

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.10/#6.2.10.5

--- a/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
+++ b/async-opcua-types/src/generated/types/standalone_subscribed_data_set_ref_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.10/#6.2.10.4

--- a/async-opcua-types/src/generated/types/status_change_notification.rs
+++ b/async-opcua-types/src/generated/types/status_change_notification.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.25.4

--- a/async-opcua-types/src/generated/types/status_result.rs
+++ b/async-opcua-types/src/generated/types/status_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.14

--- a/async-opcua-types/src/generated/types/structure_definition.rs
+++ b/async-opcua-types/src/generated/types/structure_definition.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.5

--- a/async-opcua-types/src/generated/types/structure_description.rs
+++ b/async-opcua-types/src/generated/types/structure_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.33

--- a/async-opcua-types/src/generated/types/structure_field.rs
+++ b/async-opcua-types/src/generated/types/structure_field.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.10

--- a/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscribed_data_set_mirror_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.10/#6.2.10.3.4

--- a/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
+++ b/async-opcua-types/src/generated/types/subscription_acknowledgement.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.5/#5.14.5.2

--- a/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
+++ b/async-opcua-types/src/generated/types/subscription_diagnostics_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.15

--- a/async-opcua-types/src/generated/types/target_variables_data_type.rs
+++ b/async-opcua-types/src/generated/types/target_variables_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.10/#6.2.10.2.2

--- a/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
+++ b/async-opcua-types/src/generated/types/three_d_cartesian_coordinates.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.26

--- a/async-opcua-types/src/generated/types/three_d_frame.rs
+++ b/async-opcua-types/src/generated/types/three_d_frame.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.30

--- a/async-opcua-types/src/generated/types/three_d_orientation.rs
+++ b/async-opcua-types/src/generated/types/three_d_orientation.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.28

--- a/async-opcua-types/src/generated/types/three_d_vector.rs
+++ b/async-opcua-types/src/generated/types/three_d_vector.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.24

--- a/async-opcua-types/src/generated/types/time_zone_data_type.rs
+++ b/async-opcua-types/src/generated/types/time_zone_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.2.12/#12.2.12.11

--- a/async-opcua-types/src/generated/types/transaction_error_type.rs
+++ b/async-opcua-types/src/generated/types/transaction_error_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part12/7.10.16

--- a/async-opcua-types/src/generated/types/transfer_result.rs
+++ b/async-opcua-types/src/generated/types/transfer_result.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.7/#5.14.7.2

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.7/#5.14.7.2

--- a/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
+++ b/async-opcua-types/src/generated/types/transfer_subscriptions_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.14.7/#5.14.7.2

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.4/#5.9.4.2

--- a/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
+++ b/async-opcua-types/src/generated/types/translate_browse_paths_to_node_ids_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.4/#5.9.4.2

--- a/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
+++ b/async-opcua-types/src/generated/types/transmit_qos_priority_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.4.1/#6.4.1.1.4.2

--- a/async-opcua-types/src/generated/types/trust_list_data_type.rs
+++ b/async-opcua-types/src/generated/types/trust_list_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part12/7.8.2/#7.8.2.6

--- a/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
+++ b/async-opcua-types/src/generated/types/ua_binary_file_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.36

--- a/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_reader_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.1/#6.3.1.4.10

--- a/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_data_set_writer_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.1/#6.3.1.3.6

--- a/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
+++ b/async-opcua-types/src/generated/types/uadp_writer_group_message_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.3.1/#6.3.1.1.7

--- a/async-opcua-types/src/generated/types/unregister_nodes_request.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.6/#5.9.6.2

--- a/async-opcua-types/src/generated/types/unregister_nodes_response.rs
+++ b/async-opcua-types/src/generated/types/unregister_nodes_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.9.6/#5.9.6.2

--- a/async-opcua-types/src/generated/types/unsigned_rational_number.rs
+++ b/async-opcua-types/src/generated/types/unsigned_rational_number.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.40

--- a/async-opcua-types/src/generated/types/update_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_data_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.2/#6.9.2.1

--- a/async-opcua-types/src/generated/types/update_event_details.rs
+++ b/async-opcua-types/src/generated/types/update_event_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.4/#6.9.4.1

--- a/async-opcua-types/src/generated/types/update_structure_data_details.rs
+++ b/async-opcua-types/src/generated/types/update_structure_data_details.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part11/6.9.3/#6.9.3.1

--- a/async-opcua-types/src/generated/types/user_management_data_type.rs
+++ b/async-opcua-types/src/generated/types/user_management_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part18/5.2.4

--- a/async-opcua-types/src/generated/types/user_name_identity_token.rs
+++ b/async-opcua-types/src/generated/types/user_name_identity_token.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.15/#12.3.15.3

--- a/async-opcua-types/src/generated/types/user_token_policy.rs
+++ b/async-opcua-types/src/generated/types/user_token_policy.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.42

--- a/async-opcua-types/src/generated/types/variable_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.3

--- a/async-opcua-types/src/generated/types/variable_type_attributes.rs
+++ b/async-opcua-types/src/generated/types/variable_type_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.6

--- a/async-opcua-types/src/generated/types/view_attributes.rs
+++ b/async-opcua-types/src/generated/types/view_attributes.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.24.9

--- a/async-opcua-types/src/generated/types/view_description.rs
+++ b/async-opcua-types/src/generated/types/view_description.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/7.45

--- a/async-opcua-types/src/generated/types/write_request.rs
+++ b/async-opcua-types/src/generated/types/write_request.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.4/#5.11.4.2

--- a/async-opcua-types/src/generated/types/write_response.rs
+++ b/async-opcua-types/src/generated/types/write_response.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.4/#5.11.4.2

--- a/async-opcua-types/src/generated/types/write_value.rs
+++ b/async-opcua-types/src/generated/types/write_value.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part4/5.11.4/#5.11.4.2

--- a/async-opcua-types/src/generated/types/writer_group_data_type.rs
+++ b/async-opcua-types/src/generated/types/writer_group_data_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part14/6.2.6/#6.2.6.7.1

--- a/async-opcua-types/src/generated/types/x_509_identity_token.rs
+++ b/async-opcua-types/src/generated/types/x_509_identity_token.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part5/12.3.15/#12.3.15.4

--- a/async-opcua-types/src/generated/types/xv_type.rs
+++ b/async-opcua-types/src/generated/types/xv_type.rs
@@ -7,7 +7,7 @@
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 #[opcua::types::ua_encodable]
 ///https://reference.opcfoundation.org/v105/Core/docs/Part8/5.6.8

--- a/async-opcua-types/src/localized_text.rs
+++ b/async-opcua-types/src/localized_text.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 /// A human readable text with an optional locale identifier.
 #[derive(PartialEq, Default, Debug, Clone, crate::UaNullable)]

--- a/async-opcua-types/src/qualified_name.rs
+++ b/async-opcua-types/src/qualified_name.rs
@@ -20,7 +20,7 @@ use crate::{
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 /// An identifier for a error or condition that is associated with a value or an operation.

--- a/async-opcua-types/src/request_header.rs
+++ b/async-opcua-types/src/request_header.rs
@@ -22,7 +22,7 @@ use crate::{
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 /// The `RequestHeader` contains information common to every request from a client to the server.

--- a/async-opcua-types/src/response_header.rs
+++ b/async-opcua-types/src/response_header.rs
@@ -23,7 +23,7 @@ use crate::{
 
 #[allow(unused)]
 mod opcua {
-    pub use crate as types;
+    pub(super) use crate as types;
 }
 
 /// The `ResponseHeader` contains information common to every response from server to client.

--- a/async-opcua-types/src/tests/encoding.rs
+++ b/async-opcua-types/src/tests/encoding.rs
@@ -557,11 +557,11 @@ fn deep_encoding() {
 #[test]
 fn test_custom_struct_with_optional() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, BinaryDecodable, BinaryEncodable)]
-    pub struct MyStructWithOptionalFields {
+    struct MyStructWithOptionalFields {
         foo: i32,
         #[opcua(optional)]
         my_opt: Option<LocalizedText>,
@@ -604,11 +604,11 @@ fn test_custom_struct_with_optional() {
 #[test]
 fn test_custom_union() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, BinaryDecodable, BinaryEncodable)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         Var2(EUInformation),
         Var3(f64),
@@ -639,11 +639,11 @@ fn test_custom_union() {
 #[test]
 fn test_custom_union_nullable() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, BinaryDecodable, BinaryEncodable)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         Null,
     }

--- a/async-opcua-types/src/tests/json.rs
+++ b/async-opcua-types/src/tests/json.rs
@@ -764,11 +764,11 @@ fn extension_object_round_trip() {
 #[test]
 fn test_custom_struct_with_optional() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
-    pub struct MyStructWithOptionalFields {
+    struct MyStructWithOptionalFields {
         foo: i32,
         #[opcua(optional)]
         my_opt: Option<LocalizedText>,
@@ -835,11 +835,11 @@ fn test_custom_struct_with_optional() {
 #[test]
 fn test_custom_union() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         #[opcua(rename = "EUInfo")]
         Var2(EUInformation),
@@ -900,11 +900,11 @@ fn test_custom_union() {
 #[test]
 fn test_custom_union_nullable() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, JsonDecodable, JsonEncodable, UaNullable)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         Null,
     }

--- a/async-opcua-types/src/tests/mod.rs
+++ b/async-opcua-types/src/tests/mod.rs
@@ -15,14 +15,14 @@ use crate::{
     argument::Argument, status_code::StatusCode, BinaryDecodable, BinaryEncodable, ContextOwned,
 };
 
-pub fn serialize_test_and_return<T>(value: T) -> T
+fn serialize_test_and_return<T>(value: T) -> T
 where
     T: BinaryEncodable + BinaryDecodable + Debug + PartialEq + Clone,
 {
     serialize_test_and_return_expected(value.clone(), value)
 }
 
-pub fn serialize_as_stream<T>(value: T) -> Cursor<Vec<u8>>
+fn serialize_as_stream<T>(value: T) -> Cursor<Vec<u8>>
 where
     T: BinaryEncodable + Debug,
 {
@@ -46,7 +46,7 @@ where
     Cursor::new(actual)
 }
 
-pub fn serialize_test_and_return_expected<T>(value: T, expected_value: T) -> T
+fn serialize_test_and_return_expected<T>(value: T, expected_value: T) -> T
 where
     T: BinaryEncodable + BinaryDecodable + Debug + PartialEq,
 {
@@ -60,21 +60,21 @@ where
     new_value
 }
 
-pub fn serialize_test<T>(value: T)
+fn serialize_test<T>(value: T)
 where
     T: BinaryEncodable + BinaryDecodable + Debug + PartialEq + Clone,
 {
     let _ = serialize_test_and_return(value);
 }
 
-pub fn serialize_test_expected<T>(value: T, expected_value: T)
+fn serialize_test_expected<T>(value: T, expected_value: T)
 where
     T: BinaryEncodable + BinaryDecodable + Debug + PartialEq,
 {
     let _ = serialize_test_and_return_expected(value, expected_value);
 }
 
-pub fn serialize_and_compare<T>(value: T, expected: &[u8])
+fn serialize_and_compare<T>(value: T, expected: &[u8])
 where
     T: BinaryEncodable + Debug + PartialEq,
 {

--- a/async-opcua-types/src/tests/xml.rs
+++ b/async-opcua-types/src/tests/xml.rs
@@ -422,11 +422,11 @@ fn from_xml_variant() {
 #[test]
 fn test_custom_union() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, XmlDecodable, XmlEncodable, UaNullable, XmlType)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         #[opcua(rename = "EUInfo")]
         Var2(EUInformation),
@@ -465,11 +465,11 @@ fn test_custom_union() {
 #[test]
 fn test_custom_union_nullable() {
     mod opcua {
-        pub use crate as types;
+        pub(super) use crate as types;
     }
 
     #[derive(Debug, PartialEq, Clone, XmlDecodable, XmlEncodable, UaNullable, XmlType)]
-    pub enum MyUnion {
+    enum MyUnion {
         Var1(i32),
         Null,
     }

--- a/async-opcua-types/src/variant/type_id.rs
+++ b/async-opcua-types/src/variant/type_id.rs
@@ -341,35 +341,36 @@ pub(crate) struct EncodingMask;
 
 impl EncodingMask {
     // These are values, not bits
-    pub const BOOLEAN: u8 = DataTypeId::Boolean as u8;
-    pub const SBYTE: u8 = DataTypeId::SByte as u8;
-    pub const BYTE: u8 = DataTypeId::Byte as u8;
-    pub const INT16: u8 = DataTypeId::Int16 as u8;
-    pub const UINT16: u8 = DataTypeId::UInt16 as u8;
-    pub const INT32: u8 = DataTypeId::Int32 as u8;
-    pub const UINT32: u8 = DataTypeId::UInt32 as u8;
-    pub const INT64: u8 = DataTypeId::Int64 as u8;
-    pub const UINT64: u8 = DataTypeId::UInt64 as u8;
-    pub const FLOAT: u8 = DataTypeId::Float as u8;
-    pub const DOUBLE: u8 = DataTypeId::Double as u8;
-    pub const STRING: u8 = DataTypeId::String as u8;
-    pub const DATE_TIME: u8 = DataTypeId::DateTime as u8;
-    pub const GUID: u8 = DataTypeId::Guid as u8;
-    pub const BYTE_STRING: u8 = DataTypeId::ByteString as u8;
-    pub const XML_ELEMENT: u8 = DataTypeId::XmlElement as u8;
-    pub const NODE_ID: u8 = DataTypeId::NodeId as u8;
-    pub const EXPANDED_NODE_ID: u8 = DataTypeId::ExpandedNodeId as u8;
-    pub const STATUS_CODE: u8 = DataTypeId::StatusCode as u8;
-    pub const QUALIFIED_NAME: u8 = DataTypeId::QualifiedName as u8;
-    pub const LOCALIZED_TEXT: u8 = DataTypeId::LocalizedText as u8;
-    pub const EXTENSION_OBJECT: u8 = 22; // DataTypeId::ExtensionObject as u8;
-    pub const DATA_VALUE: u8 = DataTypeId::DataValue as u8;
-    pub const VARIANT: u8 = 24;
-    pub const DIAGNOSTIC_INFO: u8 = DataTypeId::DiagnosticInfo as u8;
+    pub(crate) const BOOLEAN: u8 = DataTypeId::Boolean as u8;
+    pub(crate) const SBYTE: u8 = DataTypeId::SByte as u8;
+    pub(crate) const BYTE: u8 = DataTypeId::Byte as u8;
+    pub(crate) const INT16: u8 = DataTypeId::Int16 as u8;
+    pub(crate) const UINT16: u8 = DataTypeId::UInt16 as u8;
+    pub(crate) const INT32: u8 = DataTypeId::Int32 as u8;
+    pub(crate) const UINT32: u8 = DataTypeId::UInt32 as u8;
+    pub(crate) const INT64: u8 = DataTypeId::Int64 as u8;
+    pub(crate) const UINT64: u8 = DataTypeId::UInt64 as u8;
+    pub(crate) const FLOAT: u8 = DataTypeId::Float as u8;
+    pub(crate) const DOUBLE: u8 = DataTypeId::Double as u8;
+    pub(crate) const STRING: u8 = DataTypeId::String as u8;
+    pub(crate) const DATE_TIME: u8 = DataTypeId::DateTime as u8;
+    pub(crate) const GUID: u8 = DataTypeId::Guid as u8;
+    pub(crate) const BYTE_STRING: u8 = DataTypeId::ByteString as u8;
+    pub(crate) const XML_ELEMENT: u8 = DataTypeId::XmlElement as u8;
+    pub(crate) const NODE_ID: u8 = DataTypeId::NodeId as u8;
+    pub(crate) const EXPANDED_NODE_ID: u8 = DataTypeId::ExpandedNodeId as u8;
+    pub(crate) const STATUS_CODE: u8 = DataTypeId::StatusCode as u8;
+    pub(crate) const QUALIFIED_NAME: u8 = DataTypeId::QualifiedName as u8;
+    pub(crate) const LOCALIZED_TEXT: u8 = DataTypeId::LocalizedText as u8;
+    pub(crate) const EXTENSION_OBJECT: u8 = 22; // DataTypeId::ExtensionObject as u8;
+    pub(crate) const DATA_VALUE: u8 = DataTypeId::DataValue as u8;
+    pub(crate) const VARIANT: u8 = 24;
+    pub(crate) const DIAGNOSTIC_INFO: u8 = DataTypeId::DiagnosticInfo as u8;
     /// Bit indicates an array with dimensions
-    pub const ARRAY_DIMENSIONS_BIT: u8 = 1 << 6;
+    pub(crate) const ARRAY_DIMENSIONS_BIT: u8 = 1 << 6;
     /// Bit indicates an array with values
-    pub const ARRAY_VALUES_BIT: u8 = 1 << 7;
+    pub(crate) const ARRAY_VALUES_BIT: u8 = 1 << 7;
 
-    pub const ARRAY_MASK: u8 = EncodingMask::ARRAY_DIMENSIONS_BIT | EncodingMask::ARRAY_VALUES_BIT;
+    pub(crate) const ARRAY_MASK: u8 =
+        EncodingMask::ARRAY_DIMENSIONS_BIT | EncodingMask::ARRAY_VALUES_BIT;
 }

--- a/async-opcua-xml/Cargo.toml
+++ b/async-opcua-xml/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["opcua", "opc", "ua"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-xml/"
 
+[lints]
+workspace = true
+
 [lib]
 name = "opcua_xml"
 

--- a/async-opcua-xml/src/ext.rs
+++ b/async-opcua-xml/src/ext.rs
@@ -2,7 +2,7 @@ use roxmltree::Node;
 
 use crate::{error::XmlError, FromValue, XmlLoad};
 
-pub trait NodeExt<'a, 'input: 'a> {
+pub(crate) trait NodeExt<'a, 'input: 'a> {
     fn first_child_with_name(&self, name: &str) -> Result<Node<'a, 'input>, XmlError>;
 
     fn with_name(&self, name: &str) -> impl Iterator<Item = Node<'a, 'input>>;
@@ -33,7 +33,7 @@ impl<'a, 'input: 'a> NodeExt<'a, 'input> for Node<'a, 'input> {
     }
 }
 
-pub fn children_with_name<'input, T: XmlLoad<'input>>(
+pub(crate) fn children_with_name<'input, T: XmlLoad<'input>>(
     node: &Node<'_, 'input>,
     name: &str,
 ) -> Result<Vec<T>, XmlError> {
@@ -41,14 +41,14 @@ pub fn children_with_name<'input, T: XmlLoad<'input>>(
 }
 
 #[allow(unused)]
-pub fn first_child_with_name<'input, T: XmlLoad<'input>>(
+pub(crate) fn first_child_with_name<'input, T: XmlLoad<'input>>(
     node: &Node<'_, 'input>,
     name: &str,
 ) -> Result<T, XmlError> {
     T::load(&node.first_child_with_name(name)?)
 }
 
-pub fn first_child_with_name_opt<'input, T: XmlLoad<'input>>(
+pub(crate) fn first_child_with_name_opt<'input, T: XmlLoad<'input>>(
     node: &Node<'_, 'input>,
     name: &str,
 ) -> Result<Option<T>, XmlError> {
@@ -58,30 +58,35 @@ pub fn first_child_with_name_opt<'input, T: XmlLoad<'input>>(
     T::load(&child).map(|v| Some(v))
 }
 
-pub fn uint_attr(node: &Node<'_, '_>, name: &str) -> Result<Option<u64>, XmlError> {
+pub(crate) fn uint_attr(node: &Node<'_, '_>, name: &str) -> Result<Option<u64>, XmlError> {
     node.attribute(name)
         .map(|a| a.parse())
         .transpose()
         .map_err(|e| XmlError::parse_int(node, name, e))
 }
 
-pub fn int_attr(node: &Node<'_, '_>, name: &str) -> Result<Option<i64>, XmlError> {
+pub(crate) fn int_attr(node: &Node<'_, '_>, name: &str) -> Result<Option<i64>, XmlError> {
     node.attribute(name)
         .map(|a| a.parse())
         .transpose()
         .map_err(|e| XmlError::parse_int(node, name, e))
 }
 
-pub fn value_from_contents<T: FromValue>(node: &Node<'_, '_>) -> Result<T, XmlError> {
+pub(crate) fn value_from_contents<T: FromValue>(node: &Node<'_, '_>) -> Result<T, XmlError> {
     T::from_value(node, "content", node.try_contents()?)
 }
 
-pub fn value_from_attr<T: FromValue>(node: &Node<'_, '_>, attr: &str) -> Result<T, XmlError> {
+pub(crate) fn value_from_attr<T: FromValue>(
+    node: &Node<'_, '_>,
+    attr: &str,
+) -> Result<T, XmlError> {
     T::from_value(node, attr, node.try_attribute(attr)?)
 }
 
 #[allow(unused)]
-pub fn value_from_contents_opt<T: FromValue>(node: &Node<'_, '_>) -> Result<Option<T>, XmlError> {
+pub(crate) fn value_from_contents_opt<T: FromValue>(
+    node: &Node<'_, '_>,
+) -> Result<Option<T>, XmlError> {
     let Some(c) = node.text() else {
         return Ok(None);
     };
@@ -89,7 +94,7 @@ pub fn value_from_contents_opt<T: FromValue>(node: &Node<'_, '_>) -> Result<Opti
     T::from_value(node, "content", c).map(Some)
 }
 
-pub fn value_from_attr_opt<T: FromValue>(
+pub(crate) fn value_from_attr_opt<T: FromValue>(
     node: &Node<'_, '_>,
     attr: &str,
 ) -> Result<Option<T>, XmlError> {
@@ -100,7 +105,7 @@ pub fn value_from_attr_opt<T: FromValue>(
     T::from_value(node, attr, c).map(Some)
 }
 
-pub fn children_of_type<'input, T>(node: &Node<'_, 'input>) -> Result<Vec<T>, XmlError>
+pub(crate) fn children_of_type<'input, T>(node: &Node<'_, 'input>) -> Result<Vec<T>, XmlError>
 where
     Option<T>: XmlLoad<'input>,
 {
@@ -110,7 +115,7 @@ where
 }
 
 #[allow(unused)]
-pub fn first_child_of_type<'input, T>(node: &Node<'_, 'input>) -> Result<Option<T>, XmlError>
+pub(crate) fn first_child_of_type<'input, T>(node: &Node<'_, 'input>) -> Result<Option<T>, XmlError>
 where
     Option<T>: XmlLoad<'input>,
 {
@@ -121,7 +126,10 @@ where
 }
 
 #[allow(unused)]
-pub fn first_child_of_type_req<'input, T>(node: &Node<'_, 'input>, ctx: &str) -> Result<T, XmlError>
+pub(crate) fn first_child_of_type_req<'input, T>(
+    node: &Node<'_, 'input>,
+    ctx: &str,
+) -> Result<T, XmlError>
 where
     Option<T>: XmlLoad<'input>,
 {

--- a/async-opcua/src/lib.rs
+++ b/async-opcua/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![warn(unreachable_pub)]
 
 //! This is an [OPC UA](https://opcfoundation.org/about/opc-technologies/opc-ua/)
 //! server / client API implementation for Rust.

--- a/code_gen_config.yml
+++ b/code_gen_config.yml
@@ -15,7 +15,7 @@ targets:
         add_to_type_loader: true
     extra_header: |
       #[allow(unused)]
-      mod opcua { pub use crate as types; }
+      mod opcua { pub(super) use crate as types; }
     default_excluded:
       - AnonymousIdentityToken
       - HistoryUpdateType
@@ -37,13 +37,13 @@ targets:
       output_dir: async-opcua-core-namespace/src/events
       extra_header: |
         #[allow(unused)]
-        mod opcua { pub use opcua_types as types; pub use opcua_nodes as nodes; pub use opcua_nodes::{Event, EventField}; }
+        mod opcua { pub(super) use opcua_types as types; pub(super) use opcua_nodes as nodes; pub(super) use opcua_nodes::{Event, EventField}; }
         #[allow(unused)]
         use opcua_types as types;
   - type: ids
     file_path: schemas/1.05/NodeIds.csv
     extra_header: |
-      mod opcua { pub use crate as types; }
+      mod opcua { pub(super) use crate as types; }
     output_file: async-opcua-types/src/generated/node_ids.rs
 
 sources:


### PR DESCRIPTION
This lint is handy, as it notifies us of items marked `pub` that are not actually public in the crate itself. This is useful, since a common source of issues is that we forget to expose some component that we want to expose.

I also made a tiny, related refactor of the security policies in the crypto library, essentially just moving the constants for each policy onto a type, as a trait, instead of as a module each. We may be able to use a `dyn SecurityPolicy` or something here in the future, to avoid needing the enum, which would be quite nice.