### PR TITLE
Improve legacy secrets

### DIFF
--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -512,7 +512,10 @@ impl SecureChannel {
                     (self.security_policy.plain_block_size(), signature_size)
                 } else {
                     // Padding requires we look at the remote certificate and security policy
-                    let padding = self.security_policy.asymmetric_encryption_padding();
+                    let padding = self
+                        .security_policy
+                        .asymmetric_encryption_padding()
+                        .expect("Invalid algorithm");
                     let x509 = self.remote_cert().unwrap();
                     let pk = x509.public_key().unwrap();
                     (
@@ -884,7 +887,9 @@ impl SecureChannel {
         // Encryption will change the size of the chunk. Since we sign before encrypting, we need to
         // compute that size and change the message header to be that new size
         let cipher_text_size = {
-            let padding = security_policy.asymmetric_encryption_padding();
+            let padding = security_policy
+                .asymmetric_encryption_padding()
+                .expect("Invalid algorithm");
             let plain_text_size = encrypted_range.end - encrypted_range.start;
             let cipher_text_size =
                 encryption_key.calculate_cipher_text_size(plain_text_size, padding);

--- a/async-opcua-crypto/src/tests/crypto.rs
+++ b/async-opcua-crypto/src/tests/crypto.rs
@@ -13,7 +13,7 @@ use crate::{
         make_certificate_store, make_test_cert_1024, make_test_cert_2048, APPLICATION_HOSTNAME,
         APPLICATION_URI,
     },
-    user_identity::{legacy_password_decrypt, legacy_password_encrypt},
+    user_identity::{legacy_secret_decrypt, legacy_secret_encrypt},
     x509::{X509Data, X509},
     SecurityPolicy, SHA1_SIZE, SHA256_SIZE,
 };
@@ -599,8 +599,9 @@ fn encrypt_decrypt_password() {
     let (cert, pkey) = make_test_cert_1024();
 
     let padding = RsaPadding::OaepSha1;
-    let secret = legacy_password_encrypt(&password, nonce.as_ref(), &cert, padding).unwrap();
-    let password2 = legacy_password_decrypt(&secret, nonce.as_ref(), &pkey, padding).unwrap();
+    let secret =
+        legacy_secret_encrypt(password.as_bytes(), nonce.as_ref(), &cert, padding).unwrap();
+    let password2 = legacy_secret_decrypt(&secret, nonce.as_ref(), &pkey, padding).unwrap();
 
     assert_eq!(password, password2);
 }

--- a/async-opcua-server/src/info.rs
+++ b/async-opcua-server/src/info.rs
@@ -443,11 +443,7 @@ impl ServerInfo {
             );
             let token_password = if !token.encryption_algorithm.is_null() {
                 if let Some(ref server_key) = server_key {
-                    user_identity::decrypt_user_identity_token_password(
-                        token,
-                        server_nonce.as_ref(),
-                        server_key,
-                    )?
+                    user_identity::legacy_decrypt_secret(token, server_nonce.as_ref(), server_key)?
                 } else {
                     error!("Identity token password is encrypted but no server private key was supplied");
                     return Err(Error::new(

--- a/async-opcua-types/src/impls.rs
+++ b/async-opcua-types/src/impls.rs
@@ -125,48 +125,6 @@ impl UserNameIdentityToken {
         }
         String::from_utf8(self.password.as_ref().to_vec()).map_err(Error::decoding)
     }
-
-    /// Authenticates the token against the supplied username and password.
-    pub fn authenticate(&self, username: &str, password: &[u8]) -> Result<(), StatusCode> {
-        // No comparison will be made unless user and pass are explicitly set to something in the token
-        // Even if someone has a blank password, client should pass an empty string, not null.
-        let valid = if self.is_valid() {
-            // Plaintext encryption
-            if self.encryption_algorithm.is_null() {
-                // Password shall be a UTF-8 encoded string
-                let id_user = self.user_name.as_ref();
-                let id_pass = self.password.value.as_ref().unwrap();
-                if username == id_user {
-                    if password == id_pass.as_slice() {
-                        true
-                    } else {
-                        error!("Authentication error: User name {} supplied by client is recognised but password is not", username);
-                        false
-                    }
-                } else {
-                    error!("Authentication error: User name supplied by client is unrecognised");
-                    false
-                }
-            } else {
-                // TODO See 7.36.3. UserTokenPolicy and SecurityPolicy should be used to provide
-                //  a means to encrypt a password and not send it plain text. Sending a plaintext
-                //  password over unsecured network is a bad thing!!!
-                error!(
-                    "Authentication error: Unsupported encryption algorithm {}",
-                    self.encryption_algorithm.as_ref()
-                );
-                false
-            }
-        } else {
-            error!("Authentication error: User / pass credentials not supplied in token");
-            false
-        };
-        if valid {
-            Ok(())
-        } else {
-            Err(StatusCode::BadIdentityTokenRejected)
-        }
-    }
 }
 
 impl<'a> From<&'a NodeId> for ReadValueId {


### PR DESCRIPTION
Some misc code improvement around legacy secrets. I want to add support for issuedtoken secrets on the server and client, which needs to reuse the machinery that already exists for username authentication.

We also didn't quite follow the standard here, but we should now do so more explicitly.