### PR TITLE
Add support for IssuedToken authentication

### DIFF
--- a/async-opcua-client/src/identity_token.rs
+++ b/async-opcua-client/src/identity_token.rs
@@ -1,0 +1,121 @@
+use std::{path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use opcua_crypto::{CertificateStore, PrivateKey, X509};
+use opcua_types::{ByteString, Error, StatusCode};
+
+#[async_trait]
+/// Source for an issued token. Since each re-authentication when using
+/// issued tokens may require a new token.
+pub trait IssuedTokenSource: Send + Sync {
+    /// Get a valid issued token. This may be a cached token,
+    /// or a new one if the cache is empty or expired.
+    async fn get_issued_token(&self) -> Result<ByteString, Error>;
+}
+
+#[async_trait]
+impl IssuedTokenSource for ByteString {
+    async fn get_issued_token(&self) -> Result<ByteString, Error> {
+        Ok(self.clone())
+    }
+}
+
+/// Wrapper for an issued token source.
+#[derive(Clone)]
+pub struct IssuedTokenWrapper(pub(crate) Arc<dyn IssuedTokenSource>);
+
+impl IssuedTokenWrapper {
+    /// Create a new issued token wrapper from a reference to an issued token source.
+    pub fn new(token_source: Arc<dyn IssuedTokenSource>) -> Self {
+        Self(token_source)
+    }
+
+    /// Create a new issued token wrapper.
+    pub fn new_source(token_source: impl IssuedTokenSource + 'static) -> Self {
+        Self(Arc::new(token_source))
+    }
+}
+
+impl std::fmt::Debug for IssuedTokenWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IssuedTokenSource").finish()
+    }
+}
+
+#[derive(Clone)]
+/// A wrapper around a password as string. This intentionally implements
+/// debug in a way that does not expose the password.
+pub struct Password(pub String);
+
+impl Password {
+    /// Create a new password from a string.
+    pub fn new(password: impl Into<String>) -> Self {
+        Password(password.into())
+    }
+}
+
+impl<T> From<T> for Password
+where
+    T: Into<String>,
+{
+    fn from(value: T) -> Self {
+        Password(value.into())
+    }
+}
+
+impl std::fmt::Debug for Password {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Password").field(&"*****").finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Client-side identity token representation.
+pub enum IdentityToken {
+    /// Anonymous identity token
+    Anonymous,
+    /// User name and a password
+    UserName(String, Password),
+    /// X5090 cert and private key.
+    X509(Box<X509>, Box<PrivateKey>),
+    /// Issued token
+    IssuedToken(IssuedTokenWrapper),
+}
+
+impl IdentityToken {
+    /// Create a new anonymous identity token.
+    pub fn new_anonymous() -> Self {
+        IdentityToken::Anonymous
+    }
+    /// Create a new user name identity token.
+    pub fn new_user_name(user_name: impl Into<String>, password: impl Into<Password>) -> Self {
+        IdentityToken::UserName(user_name.into(), password.into())
+    }
+
+    /// Create a new x509 identity token.
+    pub fn new_x509(cert: X509, private_key: PrivateKey) -> Self {
+        IdentityToken::X509(Box::new(cert), Box::new(private_key))
+    }
+
+    /// Create a new x509 identity token from a path to a certificate and private key.
+    pub fn new_x509_path(
+        cert_path: impl AsRef<Path>,
+        key_path: impl AsRef<Path>,
+    ) -> Result<Self, Error> {
+        let cert = CertificateStore::read_cert(cert_path.as_ref())
+            .map_err(|e| Error::new(StatusCode::Bad, e))?;
+        let private_key = CertificateStore::read_pkey(key_path.as_ref())
+            .map_err(|e| Error::new(StatusCode::Bad, e))?;
+        Ok(IdentityToken::X509(Box::new(cert), Box::new(private_key)))
+    }
+
+    /// Create a new issued token based identity token.
+    pub fn new_issued_token(token_source: impl IssuedTokenSource + 'static) -> Self {
+        IdentityToken::IssuedToken(IssuedTokenWrapper::new_source(token_source))
+    }
+
+    /// Create a new issued token based identity token from a shared reference.
+    pub fn new_issued_token_arc(token_source: Arc<dyn IssuedTokenSource>) -> Self {
+        IdentityToken::IssuedToken(IssuedTokenWrapper::new(token_source))
+    }
+}

--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -115,11 +115,10 @@ pub mod browser;
 mod builder;
 mod config;
 pub mod custom_types;
+mod identity_token;
 mod retry;
 mod session;
 pub mod transport;
-
-use std::path::PathBuf;
 
 pub use builder::ClientBuilder;
 pub use config::{ClientConfig, ClientEndpoint, ClientUserToken, ANONYMOUS_USER_TOKEN_ID};
@@ -148,13 +147,4 @@ pub mod services {
     };
 }
 
-#[derive(Debug, Clone)]
-/// Client-side identity token representation.
-pub enum IdentityToken {
-    /// Anonymous identity token
-    Anonymous,
-    /// User name and a password
-    UserName(String, String),
-    /// X5090 cert - a path to the cert.der, and private.pem
-    X509(PathBuf, PathBuf),
-}
+pub use identity_token::{IdentityToken, IssuedTokenSource, IssuedTokenWrapper, Password};

--- a/async-opcua-client/src/session/connection.rs
+++ b/async-opcua-client/src/session/connection.rs
@@ -106,6 +106,10 @@ impl<T, R> SessionBuilder<'_, T, R> {
                 .user_identity_tokens
                 .as_ref()
                 .is_some_and(|e| e.iter().any(|p| p.token_type == UserTokenType::Certificate)),
+            IdentityToken::IssuedToken(_) => endpoint
+                .user_identity_tokens
+                .as_ref()
+                .is_some_and(|e| e.iter().any(|p| p.token_type == UserTokenType::IssuedToken)),
         }
     }
 }
@@ -158,13 +162,10 @@ impl<'a> SessionBuilder<'a, (), Vec<EndpointDescription>> {
                 default_endpoint_id
             ));
         };
-        let Some(user_identity_token) = self.config.client_identity_token(&endpoint.user_token_id)
-        else {
-            return Err(format!(
-                "User token id {} not found",
-                endpoint.user_token_id
-            ));
-        };
+        let user_identity_token = self
+            .config
+            .client_identity_token(&endpoint.user_token_id)
+            .map_err(|e| e.to_string())?;
         let endpoint = self
             .config
             .endpoint_description_for_client_endpoint(&endpoint, &self.endpoints)?;
@@ -189,13 +190,10 @@ impl<'a> SessionBuilder<'a, (), Vec<EndpointDescription>> {
             .endpoints
             .get(&endpoint_id)
             .ok_or_else(|| format!("Cannot find endpoint with id {endpoint_id}"))?;
-        let Some(user_identity_token) = self.config.client_identity_token(&endpoint.user_token_id)
-        else {
-            return Err(format!(
-                "User token id {} not found",
-                endpoint.user_token_id
-            ));
-        };
+        let user_identity_token = self
+            .config
+            .client_identity_token(&endpoint.user_token_id)
+            .map_err(|e| e.to_string())?;
 
         let endpoint = self
             .config

--- a/async-opcua-client/src/session/request_builder.rs
+++ b/async-opcua-client/src/session/request_builder.rs
@@ -15,7 +15,7 @@ pub trait UARequest {
     fn send<'a>(
         self,
         channel: &'a AsyncSecureChannel,
-    ) -> impl Future<Output = Result<Self::Out, StatusCode>> + Send + Sync + 'a
+    ) -> impl Future<Output = Result<Self::Out, StatusCode>> + Send + 'a
     where
         Self: 'a;
 }

--- a/async-opcua-crypto/src/tests/authentication.rs
+++ b/async-opcua-crypto/src/tests/authentication.rs
@@ -56,7 +56,10 @@ fn user_name_identity_token_encrypted() {
     assert!(token.encryption_algorithm.is_null());
     assert_eq!(token.secret.as_ref(), password.as_bytes());
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #2 This should be plaintext since channel security policy is none, token policy is none
     user_token_policy.security_policy_uri = UAString::from(SecurityPolicy::None.to_uri());
@@ -72,7 +75,10 @@ fn user_name_identity_token_encrypted() {
     assert!(token.encryption_algorithm.is_null());
     assert_eq!(token.secret.as_ref(), password.as_bytes());
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #3 This should be Rsa15 since channel security policy is none, token policy is Rsa15
     user_token_policy.security_policy_uri = UAString::from(SecurityPolicy::Basic128Rsa15.to_uri());
@@ -90,7 +96,10 @@ fn user_name_identity_token_encrypted() {
         crypto::algorithms::ENC_RSA_15
     );
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #4 This should be Rsa-15 since channel security policy is Rsa15, token policy is empty
     user_token_policy.security_policy_uri = UAString::null();
@@ -108,7 +117,10 @@ fn user_name_identity_token_encrypted() {
         crypto::algorithms::ENC_RSA_15
     );
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #5 This should be Rsa-OAEP since channel security policy is Rsa-15, token policy is Rsa-OAEP
     user_token_policy.security_policy_uri = UAString::from(SecurityPolicy::Basic256Sha256.to_uri());
@@ -126,7 +138,10 @@ fn user_name_identity_token_encrypted() {
         crypto::algorithms::ENC_RSA_OAEP
     );
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #6 This should be Rsa-OAEP since channel security policy is Rsa-OAEP,  token policy is Rsa-OAEP
     user_token_policy.security_policy_uri =
@@ -145,7 +160,10 @@ fn user_name_identity_token_encrypted() {
         crypto::algorithms::ENC_RSA_OAEP_SHA256
     );
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 
     // #7 This should be None since channel security policy is Rsa-15, token policy is None
     user_token_policy.security_policy_uri = UAString::from(SecurityPolicy::None.to_uri());
@@ -160,5 +178,8 @@ fn user_name_identity_token_encrypted() {
     .unwrap();
     assert!(token.encryption_algorithm.is_empty());
     let password1 = legacy_decrypt_secret(&token, nonce.as_ref(), &pkey).unwrap();
-    assert_eq!(password, password1);
+    assert_eq!(
+        password,
+        String::from_utf8(password1.value.unwrap()).unwrap()
+    );
 }

--- a/async-opcua-crypto/src/tests/crypto.rs
+++ b/async-opcua-crypto/src/tests/crypto.rs
@@ -603,5 +603,8 @@ fn encrypt_decrypt_password() {
         legacy_secret_encrypt(password.as_bytes(), nonce.as_ref(), &cert, padding).unwrap();
     let password2 = legacy_secret_decrypt(&secret, nonce.as_ref(), &pkey, padding).unwrap();
 
-    assert_eq!(password, password2);
+    assert_eq!(
+        password,
+        String::from_utf8(password2.value.unwrap()).unwrap()
+    );
 }

--- a/async-opcua-crypto/src/user_identity.rs
+++ b/async-opcua-crypto/src/user_identity.rs
@@ -64,9 +64,9 @@ pub fn legacy_decrypt_secret(
     secret: &impl LegacySecret,
     server_nonce: &[u8],
     server_key: &PrivateKey,
-) -> Result<String, Error> {
+) -> Result<ByteString, Error> {
     if secret.encryption_algorithm().is_empty() {
-        String::from_utf8(secret.raw_secret().as_ref().to_vec()).map_err(Error::decoding)
+        Ok(secret.raw_secret().clone())
     } else {
         // Determine the padding from the algorithm.
         let encryption_algorithm = secret.encryption_algorithm().as_ref();
@@ -250,7 +250,7 @@ pub(crate) fn legacy_secret_decrypt(
     server_nonce: &[u8],
     server_key: &PrivateKey,
     padding: RsaPadding,
-) -> Result<String, Error> {
+) -> Result<ByteString, Error> {
     if secret.is_null() {
         Err(Error::decoding("Missing server secret"))
     } else {
@@ -299,8 +299,7 @@ pub(crate) fn legacy_secret_decrypt(
                 Err(Error::decoding("Invalid nonce"))
             } else {
                 let password = &dst[4..nonce_begin];
-                let password = String::from_utf8(password.to_vec()).map_err(Error::decoding)?;
-                Ok(password)
+                Ok(ByteString::from(password))
             }
         }
     }

--- a/async-opcua-server/src/identity_token.rs
+++ b/async-opcua-server/src/identity_token.rs
@@ -3,14 +3,19 @@
 // Copyright (C) 2017-2024 Adam Lock
 
 use opcua_types::{
-    match_extension_object_owned, AnonymousIdentityToken, ExtensionObject, UAString,
-    UserNameIdentityToken, X509IdentityToken,
+    match_extension_object_owned, AnonymousIdentityToken, ExtensionObject, IssuedIdentityToken,
+    UAString, UserNameIdentityToken, X509IdentityToken,
 };
 
 pub(crate) const POLICY_ID_ANONYMOUS: &str = "anonymous";
 pub(crate) const POLICY_ID_USER_PASS_NONE: &str = "userpass_none";
 pub(crate) const POLICY_ID_USER_PASS_RSA_15: &str = "userpass_rsa_15";
 pub(crate) const POLICY_ID_USER_PASS_RSA_OAEP: &str = "userpass_rsa_oaep";
+pub(crate) const POLICY_ID_USER_PASS_RSA_OAEP_SHA256: &str = "userpass_rsa_oaep_sha256";
+pub(crate) const POLICY_ID_ISSUED_TOKEN_NONE: &str = "userpass_none";
+pub(crate) const POLICY_ID_ISSUED_TOKEN_RSA_15: &str = "userpass_rsa_15";
+pub(crate) const POLICY_ID_ISSUED_TOKEN_RSA_OAEP: &str = "userpass_rsa_oaep";
+pub(crate) const POLICY_ID_ISSUED_TOKEN_RSA_OAEP_SHA256: &str = "userpass_rsa_oaep_sha256";
 pub(crate) const POLICY_ID_X509: &str = "x509";
 
 /// Identity token representation on the server, decoded from the client.
@@ -23,6 +28,8 @@ pub enum IdentityToken {
     UserName(UserNameIdentityToken),
     /// Identity token for X.509 certificate.
     X509(X509IdentityToken),
+    /// Identity token for an issued identity token, i.e. OAuth.
+    IssuedToken(IssuedIdentityToken),
     /// Invalid identity token with some unknown structure.
     Invalid(ExtensionObject),
 }
@@ -41,6 +48,7 @@ impl IdentityToken {
                 v: AnonymousIdentityToken => Self::Anonymous(v),
                 v: UserNameIdentityToken => Self::UserName(v),
                 v: X509IdentityToken => Self::X509(v),
+                v: IssuedIdentityToken => Self::IssuedToken(v),
                 _ => Self::Invalid(o)
             )
         }

--- a/async-opcua-types/src/impls.rs
+++ b/async-opcua-types/src/impls.rs
@@ -121,9 +121,13 @@ impl UserNameIdentityToken {
     pub fn plaintext_password(&self) -> Result<String, Error> {
         if !self.encryption_algorithm.is_empty() {
             // Should not be calling this function at all encryption is applied
-            panic!();
+            return Err(Error::new(
+                StatusCode::BadSecurityChecksFailed,
+                "Password is encrypted",
+            ));
         }
-        String::from_utf8(self.password.as_ref().to_vec()).map_err(Error::decoding)
+        String::from_utf8(self.password.as_ref().to_vec())
+            .map_err(|e| Error::new(StatusCode::BadSecurityChecksFailed, e))
     }
 }
 

--- a/async-opcua-types/src/lib.rs
+++ b/async-opcua-types/src/lib.rs
@@ -56,6 +56,12 @@ pub mod constants {
     pub const SECURITY_POLICY_NONE: &str = "None";
 }
 
+/// Contains constants for known issued token types as defined in the OPC-UA standard.
+pub mod issued_token_types {
+    /// JSON Web Tokens (JWT).
+    pub const JSON_WEB_TOKEN: &str = "http://opcfoundation.org/UA/UserToken#JWT";
+}
+
 use bitflags::bitflags;
 
 // Attributes mask bits

--- a/async-opcua/tests/integration/core_tests.rs
+++ b/async-opcua/tests/integration/core_tests.rs
@@ -224,7 +224,7 @@ async fn connect_basic128rsa15_with_x509_token() {
     conn_test(
         SecurityPolicy::Basic128Rsa15,
         MessageSecurityMode::SignAndEncrypt,
-        client_x509_token(),
+        client_x509_token().unwrap(),
     )
     .await;
 }
@@ -236,7 +236,7 @@ async fn connect_basic128rsa_15_with_invalid_token() {
         .connect(
             SecurityPolicy::Basic128Rsa15,
             MessageSecurityMode::SignAndEncrypt,
-            IdentityToken::UserName(CLIENT_USERPASS_ID.to_owned(), "invalid".to_owned()),
+            IdentityToken::UserName(CLIENT_USERPASS_ID.to_owned(), "invalid".into()),
         )
         .await
         .unwrap();
@@ -307,7 +307,7 @@ async fn multi_client_test() {
             MessageSecurityMode::SignAndEncrypt,
             IdentityToken::UserName(
                 CLIENT_USERPASS_ID.to_owned(),
-                format!("{CLIENT_USERPASS_ID}_password"),
+                format!("{CLIENT_USERPASS_ID}_password").into(),
             ),
         )
         .await
@@ -319,7 +319,7 @@ async fn multi_client_test() {
             MessageSecurityMode::SignAndEncrypt,
             IdentityToken::UserName(
                 CLIENT_USERPASS_ID.to_owned(),
-                format!("{CLIENT_USERPASS_ID}_password"),
+                format!("{CLIENT_USERPASS_ID}_password").into(),
             ),
         )
         .await

--- a/async-opcua/tests/utils/tester.rs
+++ b/async-opcua/tests/utils/tester.rs
@@ -400,6 +400,25 @@ impl Tester {
             .await
     }
 
+    pub async fn connect_path(
+        &mut self,
+        security_policy: SecurityPolicy,
+        security_mode: MessageSecurityMode,
+        user_identity: IdentityToken,
+        path: &str,
+    ) -> Result<(Arc<Session>, SessionEventLoop), StatusCode> {
+        self.client
+            .connect_to_matching_endpoint(
+                (
+                    &format!("{}{}", self.endpoint(), path) as &str,
+                    security_policy.to_str(),
+                    security_mode,
+                ),
+                user_identity,
+            )
+            .await
+    }
+
     #[allow(unused)]
     pub async fn connect_and_wait(
         &mut self,

--- a/async-opcua/tests/utils/tester.rs
+++ b/async-opcua/tests/utils/tester.rs
@@ -70,16 +70,13 @@ pub async fn setup() -> (Tester, Arc<TestNodeManager>, Arc<Session>) {
 pub fn client_user_token() -> IdentityToken {
     IdentityToken::UserName(
         CLIENT_USERPASS_ID.to_owned(),
-        format!("{CLIENT_USERPASS_ID}_password"),
+        format!("{CLIENT_USERPASS_ID}_password").into(),
     )
 }
 
 #[allow(unused)]
-pub fn client_x509_token() -> IdentityToken {
-    IdentityToken::X509(
-        PathBuf::from(USER_X509_CERTIFICATE_PATH),
-        PathBuf::from(USER_X509_PRIVATE_KEY_PATH),
-    )
+pub fn client_x509_token() -> Result<IdentityToken, opcua::types::Error> {
+    IdentityToken::new_x509_path(USER_X509_CERTIFICATE_PATH, USER_X509_PRIVATE_KEY_PATH)
 }
 
 pub fn default_server() -> ServerBuilder {

--- a/dotnet-tests/external-tests/src/tests/client/connect.rs
+++ b/dotnet-tests/external-tests/src/tests/client/connect.rs
@@ -38,7 +38,7 @@ async fn test_connect(
         test_connect_inner,
         policy,
         mode,
-        IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+        IdentityToken::UserName("test".to_owned(), "pass".into()),
         ctx,
     )
     .await;

--- a/dotnet-tests/external-tests/src/tests/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/mod.rs
@@ -31,7 +31,7 @@ macro_rules! run_encrypted_test {
                     $test,
                     SecurityPolicy::Aes256Sha256RsaPss,
                     MessageSecurityMode::SignAndEncrypt,
-                    IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+                    IdentityToken::UserName("test".to_owned(), "pass".into()),
                     &mut $ctx,
                 ),
             )


### PR DESCRIPTION
This also refactors the IdentityToken type on the client a little bit. If you're just using username/password or anonymous you shouldn't notice any changes, but X509 certificates are changed a little.

IssuedToken auth is a little different from other variants, in that it may require a new value on reconnect.