### PR TITLE
Infer namespace URIs from the schema instead of config

### DIFF
--- a/async-opcua-codegen/src/lib.rs
+++ b/async-opcua-codegen/src/lib.rs
@@ -163,10 +163,10 @@ pub fn run_codegen(config: &CodeGenConfig, root_path: &str) -> Result<(), CodeGe
                 let node_set = cache.get_nodeset(&n.file)?;
                 info!("Found {} nodes in node set", node_set.xml.nodes.len());
 
-                let chunks = generate_target(n, &node_set.xml, &config.preferred_locale, &cache)
+                let chunks = generate_target(n, node_set, &config.preferred_locale, &cache)
                     .map_err(|e| e.in_file(&node_set.path))?;
-                let module_file =
-                    make_root_module(&chunks, n).map_err(|e| e.in_file(&node_set.path))?;
+                let module_file = make_root_module(&chunks, n, node_set)
+                    .map_err(|e| e.in_file(&node_set.path))?;
 
                 info!("Writing {} files to {}", chunks.len() + 1, n.output_dir);
 

--- a/async-opcua-codegen/src/nodeset/gen.rs
+++ b/async-opcua-codegen/src/nodeset/gen.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use opcua_xml::schema::ua_node_set::{
-    AliasTable, ArrayDimensions, DataTypeDefinition, LocalizedText, NodeId, Reference, UADataType,
-    UAMethod, UANode, UANodeBase, UAObject, UAObjectType, UAReferenceType, UAVariable,
-    UAVariableType, UAView,
+    ArrayDimensions, DataTypeDefinition, LocalizedText, NodeId, Reference, UADataType, UAMethod,
+    UANode, UANodeBase, UAObject, UAObjectType, UAReferenceType, UAVariable, UAVariableType,
+    UAView,
 };
 use proc_macro2::{Span, TokenStream};
 use syn::{parse_quote, parse_str, Expr, Ident, ItemFn};
@@ -22,7 +22,7 @@ pub struct NodeGenMethod {
 pub struct NodeSetCodeGenerator<'a> {
     preferred_locale: String,
     empty_text: LocalizedText,
-    aliases: HashMap<&'a str, &'a str>,
+    aliases: &'a HashMap<String, String>,
     node_counter: usize,
     types: HashMap<String, XsdTypeWithPath>,
 }
@@ -30,15 +30,9 @@ pub struct NodeSetCodeGenerator<'a> {
 impl<'a> NodeSetCodeGenerator<'a> {
     pub fn new(
         preferred_locale: &str,
-        alias_table: Option<&'a AliasTable>,
+        aliases: &'a HashMap<String, String>,
         types: HashMap<String, XsdTypeWithPath>,
     ) -> Result<Self, CodeGenError> {
-        let mut aliases = HashMap::new();
-        if let Some(alias_table) = alias_table {
-            for alias in &alias_table.aliases {
-                aliases.insert(alias.alias.as_str(), alias.id.0.as_str());
-            }
-        }
         Ok(Self {
             preferred_locale: preferred_locale.to_owned(),
             empty_text: LocalizedText::default(),
@@ -49,7 +43,7 @@ impl<'a> NodeSetCodeGenerator<'a> {
     }
 
     fn resolve_node_id(&self, node_id: &NodeId) -> Result<TokenStream, CodeGenError> {
-        if let Some(&aliased) = self.aliases.get(node_id.0.as_str()) {
+        if let Some(aliased) = self.aliases.get(node_id.0.as_str()) {
             NodeId(aliased.to_owned()).render()
         } else {
             node_id.render()

--- a/code_gen_config.yml
+++ b/code_gen_config.yml
@@ -29,9 +29,6 @@ targets:
     types:
       - file: Opc.Ua.Types.xsd
         root_path: opcua::types
-    own_namespaces:
-      - "http://opcfoundation.org/UA/"
-    imported_namespaces: []
     name: CoreNamespace
     events:
       output_dir: async-opcua-core-namespace/src/events

--- a/samples/custom-codegen/code_gen_config.yml
+++ b/samples/custom-codegen/code_gen_config.yml
@@ -20,10 +20,6 @@ targets:
         root_path: crate::generated::types
       - file: Opc.Ua.Types.xsd
         root_path: opcua::types
-    own_namespaces:
-      - "http://opcfoundation.org/UA/PROFINET/"
-    imported_namespaces:
-      - "http://opcfoundation.org/UA/"
     name: ProfinetNamespace
     events:
       output_dir: src/generated/events


### PR DESCRIPTION
This is probably a better idea, as it makes it harder to make mistakes with the order and presence of namespaces in the nodeset file.

This means that `own_namespaces` and `imported_namespaces` are removed completely. If we run into a case where a single nodeset file owns multiple namespaces we can consider re-adding the "own_namespaces" thing, but I don't actually think that's allowed.