### PR TITLE
Ignore port when matching endpoints

### DIFF
--- a/async-opcua-core/src/comms/tcp_types.rs
+++ b/async-opcua-core/src/comms/tcp_types.rs
@@ -551,7 +551,9 @@ mod tests {
         h.endpoint_url = UAString::from("opc.tcp://bar/"); // Ignore hostname
         assert!(h.matches_endpoint(&endpoints));
         h.endpoint_url = UAString::from((0..4096).map(|_| 'A').collect::<String>());
-        assert!(h.is_endpoint_valid_length())
+        assert!(h.is_endpoint_valid_length());
+        h.endpoint_url = UAString::from("opc.tcp://foo:1234"); // Ignore port
+        assert!(h.matches_endpoint(&endpoints));
     }
 
     #[test]

--- a/async-opcua-core/src/comms/url.rs
+++ b/async-opcua-core/src/comms/url.rs
@@ -37,13 +37,12 @@ pub fn url_with_replaced_hostname(url: &str, hostname: &str) -> Result<String, u
 /// Test if the two urls match except for the hostname. Can be used by a server whose endpoint doesn't
 /// exactly match the incoming connection, e.g. 127.0.0.1 vs localhost.
 pub fn url_matches_except_host(url1: &str, url2: &str) -> bool {
-    if let Ok(mut url1) = opc_url_from_str(url1) {
-        if let Ok(mut url2) = opc_url_from_str(url2) {
-            // Both hostnames are set to xxxx so the comparison should come out as the same url
-            // if they actually match one another.
-            if url1.set_host(Some("xxxx")).is_ok() && url2.set_host(Some("xxxx")).is_ok() {
-                return url1.as_str().trim_end_matches("/") == url2.as_str().trim_end_matches("/");
-            }
+    if let Ok(url1) = opc_url_from_str(url1) {
+        if let Ok(url2) = opc_url_from_str(url2) {
+            return url1.scheme() == url2.scheme() // Scheme must match
+                && url1.path().trim_end_matches("/") == url2.path().trim_end_matches("/") // Path must match, except for trailing /
+                && url1.query() == url2.query() // Scheme and query must match, most OPC-UA endpoints won't have these.
+                && url1.fragment() == url2.fragment();
         } else {
             error!("Cannot parse url \"{}\"", url2);
         }

--- a/async-opcua/tests/integration/core_tests.rs
+++ b/async-opcua/tests/integration/core_tests.rs
@@ -471,7 +471,7 @@ async fn issued_token_test() {
         .await
         .unwrap();
     lp.spawn();
-    tokio::time::timeout(Duration::from_secs(2), session.wait_for_connection())
+    tokio::time::timeout(Duration::from_secs(5), session.wait_for_connection())
         .await
         .unwrap();
 

--- a/samples/custom-codegen/Cargo.toml
+++ b/samples/custom-codegen/Cargo.toml
@@ -19,4 +19,4 @@ env_logger = { workspace = true }
 
 [dependencies.async-opcua]
 path = "../../async-opcua"
-features = ["client"]
+features = ["client", "server"]


### PR DESCRIPTION
In fact, use a slightly more clever method for matching endpoint URLs.

This should fix #94.