### PR TITLE
Fix panic in monitored item

### DIFF
--- a/async-opcua-nodes/src/variable.rs
+++ b/async-opcua-nodes/src/variable.rs
@@ -456,10 +456,10 @@ impl Variable {
     /// Read the value of the variable.
     pub fn value(
         &self,
-        _timestamps_to_return: TimestampsToReturn,
+        timestamps_to_return: TimestampsToReturn,
         index_range: &NumericRange,
         _data_encoding: &DataEncoding,
-        max_age: f64,
+        _max_age: f64,
     ) -> DataValue {
         let data_value = &self.value;
         let mut result = DataValue {
@@ -483,10 +483,25 @@ impl Variable {
                 }
             }
         }
-        if max_age > 0.0 && max_age <= i32::MAX as f64 {
-            // Update the server timestamp to now as a "best effort" attempt to get the latest value
-            result.server_timestamp = Some(DateTime::now());
+
+        match timestamps_to_return {
+            TimestampsToReturn::Source => {
+                result.server_timestamp = None;
+                result.server_picoseconds = None;
+            }
+            TimestampsToReturn::Server => {
+                result.source_timestamp = None;
+                result.source_picoseconds = None;
+            }
+            TimestampsToReturn::Neither => {
+                result.server_timestamp = None;
+                result.source_timestamp = None;
+                result.server_picoseconds = None;
+                result.source_picoseconds = None;
+            }
+            _ => (),
         }
+
         result
         //}
     }

--- a/async-opcua-server/src/subscriptions/monitored_item.rs
+++ b/async-opcua-server/src/subscriptions/monitored_item.rs
@@ -370,11 +370,20 @@ impl MonitoredItem {
             return true;
         };
 
-        let elapsed = new
+        let elapsed = match new
             .as_chrono()
             .signed_duration_since(old.as_chrono())
             .to_std()
-            .unwrap();
+        {
+            Ok(e) => e,
+            Err(_) => {
+                // We somehow assigned a value in the past, but the old value is in the future.
+                // This isn't really a good situation to be in, but there isn't a lot we can do about it here.
+                // Node managers should avoid this, if possible. The standard doesn't specify what we should do,
+                // so we just allow the value through.
+                return true;
+            }
+        };
         let sampling_interval =
             std::time::Duration::from_micros((self.sampling_interval * 1000f64) as u64);
         elapsed >= sampling_interval


### PR DESCRIPTION
This happens if a value is written that is _earlier_ than the last reported value. In this case the server is saying that an old value is newer than the newest value, which doesn't really make much sense, but it would create difficulties if we didn't accept it. We just treat it as a new value. Node managers that want to prevent users from writing values in the past should do so.

Also makes `timestamps_to_return` do something in `read`, and `max-age` do nothing. max_age doesn't make any sense here, it would need to be used by node managers.