### PR TITLE
Reuse sequence numbers for keep alive messages

### DIFF
--- a/async-opcua-core/src/handle.rs
+++ b/async-opcua-core/src/handle.rs
@@ -35,6 +35,11 @@ impl Handle {
         next
     }
 
+    /// Peek the next value of the handle, without incrementing.
+    pub fn peek_next(&self) -> u32 {
+        self.next
+    }
+
     /// Set the next handle value manually.
     pub fn set_next(&mut self, next: u32) {
         self.next = next;

--- a/async-opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/async-opcua-server/src/subscriptions/session_subscriptions.rs
@@ -602,6 +602,7 @@ impl SessionSubscriptions {
             // Get notifications and publish request pairs while there are any of either left.
             while !self.publish_request_queue.is_empty() {
                 if let Some(notification_message) = subscription.take_notification() {
+                    tracing::trace!("Sending notification message {:?}", notification_message);
                     let publish_request = self.publish_request_queue.pop_front().unwrap();
                     responses.push((publish_request, notification_message, sub_id));
                 } else {


### PR DESCRIPTION
This is related to #102, where a client is producing a warning due to sequence numbers not being the expected value. We don't currently verify these in the client, which we may do in the future.

The issue appears to be that the keep-alive messages should not increment the sequence number, but the standard is _really_ vague on this stuff. The only real source is this haphazard list of rules, https://reference.opcfoundation.org/Core/Part4/v104/docs/5.13.1.1, of which the relevant part is 

> Each keep-alive [Message](https://reference.opcfoundation.org/search/17?t=Message) is a response to a [Publish](https://reference.opcfoundation.org/search/17?t=Publish) request in which the [notificationMessage](https://reference.opcfoundation.org/search/17?t=notificationMessage) parameter does not contain any [Notifications](https://reference.opcfoundation.org/search/17?t=Notifications) and that contains the sequence number of the next [NotificationMessage](https://reference.opcfoundation.org/search/17?t=NotificationMessage) that is to be sent

Also, it seems like after this, the rest of the page treats `NotificationMessage` as a separate concept from `notificationMessage` (not even a little confusing), where the latter is an OPC-UA type, and the former is a `notificationMessage` containing at least one notification.

Except, _status_ messages do not contain notifications, but _do_ increment the sequence number, so the standard is wrong!

Either way, I looked at the reference SDK, and it does it this way, though in a very roundabout manner.