### PR TITLE
Change TcpConfig and CertificateValidation to public.

### DIFF
--- a/async-opcua-server/src/config/mod.rs
+++ b/async-opcua-server/src/config/mod.rs
@@ -6,4 +6,5 @@ mod server;
 pub use capabilities::{HistoryServerCapabilities, ServerCapabilities};
 pub use endpoint::{EndpointIdentifier, ServerEndpoint};
 pub use limits::{Limits, OperationalLimits, SubscriptionLimits};
+pub use server::{TcpConfig, CertificateValidation};
 pub use server::{ServerConfig, ServerUserToken, ANONYMOUS_USER_TOKEN_ID};


### PR DESCRIPTION
The TcpConfig and CertificateValidation structs would be good to have as public when creating custom configuration file in eg. toml.