### PR TITLE
Remove old single_threaded_executor option from config in samples

### DIFF
--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -290,6 +290,7 @@ pub struct ClientConfig {
     pub(crate) min_publish_interval: Duration,
 
     /// Client performance settings
+    #[serde(default)]
     pub(crate) performance: Performance,
     /// Automatically recreate subscriptions on reconnect, by first calling
     /// `transfer_subscriptions`, then attempting to recreate subscriptions if that fails.

--- a/samples/demo-server/sample.server.test.conf
+++ b/samples/demo-server/sample.server.test.conf
@@ -28,8 +28,6 @@ limits:
   max_byte_string_length: 65535
   min_sampling_interval: 0.1
   min_publishing_interval: 0.1
-performance:
-  single_threaded_executor: false
 locale_ids:
   - en
 user_tokens:

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -27,8 +27,6 @@ limits:
   max_chunk_count: 5
   send_buffer_size: 65535
   receive_buffer_size: 65535
-performance:
-  single_threaded_executor: false
 locale_ids:
 - en
 user_tokens:


### PR DESCRIPTION
This was removed before we even fully forked from opcua.