### PR TITLE
Support for the OfType operator

### DIFF
--- a/async-opcua-macros/src/events/gen.rs
+++ b/async-opcua-macros/src/events/gen.rs
@@ -156,6 +156,10 @@ pub(crate) fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStrea
             fn time(&self) -> &opcua::types::DateTime {
                 self.base.time()
             }
+
+            fn event_type_id(&self) -> &opcua::types::NodeId {
+                self.base.event_type_id()
+            }
         }
 
         impl opcua::nodes::EventField for #ident {

--- a/async-opcua-nodes/src/events/evaluate.rs
+++ b/async-opcua-nodes/src/events/evaluate.rs
@@ -8,6 +8,8 @@ use opcua_types::{
     VariantScalarTypeId, VariantTypeId,
 };
 
+use crate::TypeTree;
+
 use super::{
     event::Event,
     validation::{
@@ -19,8 +21,13 @@ impl ParsedEventFilter {
     /// Evaluate the event filter, returning `None` if the
     /// filter does not accept the event, and a list of event fields fetched from
     /// the event if it does.
-    pub fn evaluate(&self, event: &dyn Event, client_handle: u32) -> Option<EventFieldList> {
-        if !self.content_filter.evaluate(event) {
+    pub fn evaluate(
+        &self,
+        event: &dyn Event,
+        client_handle: u32,
+        type_tree: &dyn TypeTree,
+    ) -> Option<EventFieldList> {
+        if !self.content_filter.evaluate(event, type_tree) {
             return None;
         }
 
@@ -37,11 +44,11 @@ impl ParsedEventFilter {
 }
 
 macro_rules! cmp_op {
-    ($slf:ident, $evt:ident, $op:ident, $pt:pat) => {
+    ($slf:ident, $evt:ident, $tt:ident, $op:ident, $pt:pat) => {
         matches!(
             ParsedContentFilter::compare_op(
-                $slf.evaluate_operand($evt, &$op.operands[0]),
-                $slf.evaluate_operand($evt, &$op.operands[1]),
+                $slf.evaluate_operand($evt, $tt, &$op.operands[0]),
+                $slf.evaluate_operand($evt, $tt, &$op.operands[1]),
             ),
             $pt
         )
@@ -81,6 +88,9 @@ pub trait AttributeQueryable: Copy {
         attribute_id: AttributeId,
         index_range: &NumericRange,
     ) -> Variant;
+
+    /// Get the type definition of the item.
+    fn get_type(&self) -> NodeId;
 }
 
 impl AttributeQueryable for &dyn Event {
@@ -93,6 +103,10 @@ impl AttributeQueryable for &dyn Event {
     ) -> Variant {
         self.get_field(type_definition_id, attribute_id, index_range, browse_path)
     }
+
+    fn get_type(&self) -> NodeId {
+        self.event_type_id().clone()
+    }
 }
 
 enum BitOperation {
@@ -103,80 +117,119 @@ enum BitOperation {
 impl ParsedContentFilter {
     /// Evaluate the content filter, returning `true` if it
     /// passes the filter.
-    pub fn evaluate(&self, item: impl AttributeQueryable) -> bool {
+    pub fn evaluate(&self, item: impl AttributeQueryable, type_tree: &dyn TypeTree) -> bool {
         if self.elements.is_empty() {
             return true;
         }
-        matches!(self.evulate_element(item, 0), Variant::Boolean(true))
+        matches!(
+            self.evulate_element(item, type_tree, 0),
+            Variant::Boolean(true)
+        )
     }
 
-    fn evulate_element(&self, item: impl AttributeQueryable, index: usize) -> Variant {
+    fn evulate_element(
+        &self,
+        item: impl AttributeQueryable,
+        type_tree: &dyn TypeTree,
+        index: usize,
+    ) -> Variant {
         let Some(op) = self.elements.get(index) else {
             return Variant::Empty;
         };
 
         match op.operator {
-            FilterOperator::Equals => cmp_op!(self, item, op, Some(Ordering::Equal)),
+            FilterOperator::Equals => cmp_op!(self, item, type_tree, op, Some(Ordering::Equal)),
             FilterOperator::IsNull => {
-                (self.evaluate_operand(item, &op.operands[0]) == Variant::Empty).into()
+                (self.evaluate_operand(item, type_tree, &op.operands[0]) == Variant::Empty).into()
             }
-            FilterOperator::GreaterThan => cmp_op!(self, item, op, Some(Ordering::Greater)),
-            FilterOperator::LessThan => cmp_op!(self, item, op, Some(Ordering::Less)),
+            FilterOperator::GreaterThan => {
+                cmp_op!(self, item, type_tree, op, Some(Ordering::Greater))
+            }
+            FilterOperator::LessThan => cmp_op!(self, item, type_tree, op, Some(Ordering::Less)),
             FilterOperator::GreaterThanOrEqual => {
-                cmp_op!(self, item, op, Some(Ordering::Equal | Ordering::Greater))
+                cmp_op!(
+                    self,
+                    item,
+                    type_tree,
+                    op,
+                    Some(Ordering::Equal | Ordering::Greater)
+                )
             }
             FilterOperator::LessThanOrEqual => {
-                cmp_op!(self, item, op, Some(Ordering::Equal | Ordering::Less))
+                cmp_op!(
+                    self,
+                    item,
+                    type_tree,
+                    op,
+                    Some(Ordering::Equal | Ordering::Less)
+                )
             }
             FilterOperator::Like => Self::like(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
             )
             .into(),
-            FilterOperator::Not => Self::not(self.evaluate_operand(item, &op.operands[0])),
+            FilterOperator::Not => {
+                Self::not(self.evaluate_operand(item, type_tree, &op.operands[0]))
+            }
             FilterOperator::Between => Self::between(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
-                self.evaluate_operand(item, &op.operands[2]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[2]),
             )
             .into(),
             FilterOperator::InList => Self::in_list(
-                self.evaluate_operand(item, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
                 op.operands
                     .iter()
                     .skip(1)
-                    .map(|o| self.evaluate_operand(item, o)),
+                    .map(|o| self.evaluate_operand(item, type_tree, o)),
             )
             .into(),
             FilterOperator::And => Self::and(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
             ),
             FilterOperator::Or => Self::or(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
             ),
             FilterOperator::Cast => Self::cast(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
             ),
             FilterOperator::BitwiseAnd => Self::bitwise_op(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
                 BitOperation::And,
             ),
             FilterOperator::BitwiseOr => Self::bitwise_op(
-                self.evaluate_operand(item, &op.operands[0]),
-                self.evaluate_operand(item, &op.operands[1]),
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                self.evaluate_operand(item, type_tree, &op.operands[1]),
                 BitOperation::Or,
             ),
+            FilterOperator::OfType => Self::of_type(
+                self.evaluate_operand(item, type_tree, &op.operands[0]),
+                item,
+                type_tree,
+            )
+            .into(),
+            // TODO: Support RelatedTo. InView is not really possible until we build
+            // proper view support.
             _ => Variant::Empty,
         }
     }
 
-    fn evaluate_operand(&self, item: impl AttributeQueryable, op: &ParsedOperand) -> Variant {
+    fn evaluate_operand(
+        &self,
+        item: impl AttributeQueryable,
+        type_tree: &dyn TypeTree,
+        op: &ParsedOperand,
+    ) -> Variant {
         match op {
-            ParsedOperand::ElementOperand(o) => self.evulate_element(item, o.index as usize),
+            ParsedOperand::ElementOperand(o) => {
+                self.evulate_element(item, type_tree, o.index as usize)
+            }
             ParsedOperand::LiteralOperand(o) => o.value.clone(),
             ParsedOperand::AttributeOperand(_) => unreachable!(),
             ParsedOperand::SimpleAttributeOperand(o) => item.get_attribute(
@@ -298,6 +351,13 @@ impl ParsedContentFilter {
             (Variant::Boolean(lhs), Variant::Boolean(rhs)) => Some(lhs.cmp(&rhs)),
             _ => None,
         }
+    }
+
+    fn of_type(lhs: Variant, item: impl AttributeQueryable, type_tree: &dyn TypeTree) -> bool {
+        let type_id = as_type!(lhs, NodeId, false);
+
+        let item_type = item.get_type();
+        type_tree.is_subtype_of(&item_type, &type_id)
     }
 }
 
@@ -523,7 +583,7 @@ mod tests {
             },
             type_tree,
             false,
-            false,
+            true,
         );
         f.unwrap()
     }
@@ -556,7 +616,7 @@ mod tests {
             &type_tree,
         );
         let event = event(2);
-        assert!(!f.evaluate(&event as &dyn Event));
+        assert!(!f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -572,7 +632,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -586,7 +646,7 @@ mod tests {
             &type_tree,
         );
         let event = event(2);
-        assert!(!f.evaluate(&event as &dyn Event));
+        assert!(!f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -602,7 +662,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -618,7 +678,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(!f.evaluate(&event as &dyn Event));
+        assert!(!f.evaluate(&event as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -632,7 +692,7 @@ mod tests {
             &type_tree,
         );
         let event = event(2);
-        assert!(!f.evaluate(&event as &dyn Event));
+        assert!(!f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -648,7 +708,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -664,7 +724,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -678,7 +738,7 @@ mod tests {
             &type_tree,
         );
         let event = event(2);
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -694,7 +754,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -710,7 +770,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(!f.evaluate(&event as &dyn Event));
+        assert!(!f.evaluate(&event as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -724,7 +784,7 @@ mod tests {
             &type_tree,
         );
         let event = event(2);
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -740,7 +800,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -756,7 +816,7 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&event as &dyn Event));
+        assert!(f.evaluate(&event as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -767,7 +827,7 @@ mod tests {
             &type_tree,
         );
         let evt = event(2);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
 
         let f = filter(
             vec![
@@ -787,9 +847,9 @@ mod tests {
             ],
             &type_tree,
         );
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(3);
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -807,7 +867,7 @@ mod tests {
             &type_tree,
         );
         let evt = event(2);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -824,15 +884,15 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(9);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(10);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(8);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(11);
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -846,7 +906,7 @@ mod tests {
             &type_tree,
         );
         let evt = event(2);
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
         let f = filter(
             vec![
                 filter_elem(
@@ -873,9 +933,9 @@ mod tests {
             &type_tree,
         );
 
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(3);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -889,7 +949,7 @@ mod tests {
             &type_tree,
         );
         let evt = event(2);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let f = filter(
             vec![
                 filter_elem(
@@ -916,9 +976,9 @@ mod tests {
             &type_tree,
         );
 
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(3);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
     }
 
     #[test]
@@ -937,7 +997,7 @@ mod tests {
             &type_tree,
         );
         let evt = event(2);
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let f = filter(
             vec![filter_elem(
                 &[
@@ -955,8 +1015,44 @@ mod tests {
             )],
             &type_tree,
         );
-        assert!(f.evaluate(&evt as &dyn Event));
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
         let evt = event(4);
-        assert!(!f.evaluate(&evt as &dyn Event));
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
+    }
+
+    #[test]
+    fn test_of_type() {
+        let type_tree = type_tree();
+        let f = filter(
+            vec![filter_elem(
+                &[Operand::literal(NodeId::new(1, 123))],
+                FilterOperator::OfType,
+            )],
+            &type_tree,
+        );
+        let evt = event(2);
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
+
+        // Test a non-match as well...
+        let f = filter(
+            vec![filter_elem(
+                &[Operand::literal(NodeId::new(1, 456))],
+                FilterOperator::OfType,
+            )],
+            &type_tree,
+        );
+        let evt = event(2);
+        assert!(!f.evaluate(&evt as &dyn Event, &type_tree));
+
+        // And with the super-type
+        let f = filter(
+            vec![filter_elem(
+                &[Operand::literal(ObjectTypeId::BaseEventType)],
+                FilterOperator::OfType,
+            )],
+            &type_tree,
+        );
+        let evt = event(2);
+        assert!(f.evaluate(&evt as &dyn Event, &type_tree));
     }
 }

--- a/async-opcua-nodes/src/events/event.rs
+++ b/async-opcua-nodes/src/events/event.rs
@@ -21,6 +21,9 @@ pub trait Event: EventField {
 
     /// Get the `Time` of this event.
     fn time(&self) -> &DateTime;
+
+    /// Get the event type ID of this event.
+    fn event_type_id(&self) -> &NodeId;
 }
 
 #[derive(Debug, Default)]
@@ -86,6 +89,10 @@ impl Event for BaseEventType {
         } else {
             Variant::Empty
         }
+    }
+
+    fn event_type_id(&self) -> &NodeId {
+        &self.event_type
     }
 }
 

--- a/async-opcua-nodes/src/events/validation.rs
+++ b/async-opcua-nodes/src/events/validation.rs
@@ -173,7 +173,7 @@ fn validate(
         }
     }
     let (where_clause_result, parsed_where_clause) =
-        validate_where_clause(event_filter.where_clause, type_tree, false, false);
+        validate_where_clause(event_filter.where_clause, type_tree, false, true);
 
     (
         EventFilterResult {

--- a/async-opcua-server/src/node_manager/mod.rs
+++ b/async-opcua-server/src/node_manager/mod.rs
@@ -40,7 +40,7 @@ use super::{
 pub use {
     attributes::{ParsedReadValueId, ParsedWriteValue, ReadNode, WriteNode},
     build::NodeManagerBuilder,
-    context::{RequestContext, TypeTreeForUser, TypeTreeReadContext},
+    context::{RequestContext, TypeTreeForUser, TypeTreeForUserStatic, TypeTreeReadContext},
     history::{HistoryNode, HistoryResult, HistoryUpdateDetails, HistoryUpdateNode},
     method::MethodCall,
     monitored_items::{MonitoredItemRef, MonitoredItemUpdateRef},

--- a/async-opcua-server/src/subscriptions/monitored_item.rs
+++ b/async-opcua-server/src/subscriptions/monitored_item.rs
@@ -453,7 +453,7 @@ impl MonitoredItem {
         true
     }
 
-    pub(super) fn notify_event(&mut self, event: &dyn Event) -> bool {
+    pub(super) fn notify_event(&mut self, event: &dyn Event, type_tree: &dyn TypeTree) -> bool {
         if self.monitoring_mode == MonitoringMode::Disabled {
             return false;
         }
@@ -462,7 +462,7 @@ impl MonitoredItem {
             return false;
         };
 
-        let Some(notif) = filter.evaluate(event, self.client_handle) else {
+        let Some(notif) = filter.evaluate(event, self.client_handle, type_tree) else {
             return false;
         };
 

--- a/async-opcua-server/src/subscriptions/subscription.rs
+++ b/async-opcua-server/src/subscriptions/subscription.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use opcua_core::handle::Handle;
-use opcua_nodes::Event;
+use opcua_nodes::{Event, TypeTree};
 use opcua_types::{DataValue, DateTime, DateTimeUtc, NotificationMessage, StatusCode};
 use tracing::{debug, trace, warn};
 
@@ -229,9 +229,9 @@ impl Subscription {
     }
 
     /// Notify the given monitored item of a new event.
-    pub fn notify_event(&mut self, id: &u32, event: &dyn Event) {
+    pub fn notify_event(&mut self, id: &u32, event: &dyn Event, type_tree: &dyn TypeTree) {
         if let Some(item) = self.monitored_items.get_mut(id) {
-            if item.notify_event(event) {
+            if item.notify_event(event, type_tree) {
                 self.notified_monitored_items.insert(*id);
             }
         }

--- a/async-opcua-types/src/operand.rs
+++ b/async-opcua-types/src/operand.rs
@@ -10,9 +10,10 @@ use std::convert::TryFrom;
 
 use crate::{
     attribute::AttributeId, match_extension_object_owned, status_code::StatusCode,
-    AttributeOperand, ContentFilter, ContentFilterElement, ElementOperand, ExtensionObject,
-    FilterOperator, LiteralOperand, NodeId, NumericRange, QualifiedName, SimpleAttributeOperand,
-    Variant,
+    AttributeOperand, ContentFilter, ContentFilterElement, DataTypeId, ElementOperand,
+    ExtensionObject, FilterOperator, LiteralOperand, MethodId, NodeId, NumericRange, ObjectId,
+    ObjectTypeId, QualifiedName, ReferenceTypeId, SimpleAttributeOperand, VariableId,
+    VariableTypeId, Variant,
 };
 
 #[derive(PartialEq)]
@@ -98,6 +99,54 @@ impl From<bool> for LiteralOperand {
 impl From<&str> for LiteralOperand {
     fn from(v: &str) -> Self {
         Self::from(Variant::from(v))
+    }
+}
+
+impl From<NodeId> for LiteralOperand {
+    fn from(v: NodeId) -> Self {
+        Self::from(Variant::from(v))
+    }
+}
+
+impl From<ObjectId> for LiteralOperand {
+    fn from(v: ObjectId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<VariableId> for LiteralOperand {
+    fn from(v: VariableId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<MethodId> for LiteralOperand {
+    fn from(v: MethodId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<DataTypeId> for LiteralOperand {
+    fn from(v: DataTypeId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<ObjectTypeId> for LiteralOperand {
+    fn from(v: ObjectTypeId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<VariableTypeId> for LiteralOperand {
+    fn from(v: VariableTypeId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
+    }
+}
+
+impl From<ReferenceTypeId> for LiteralOperand {
+    fn from(v: ReferenceTypeId) -> Self {
+        Self::from(Variant::NodeId(Box::new(v.into())))
     }
 }
 
@@ -409,6 +458,14 @@ impl ContentFilterBuilder {
         self.add_element(FilterOperator::BitwiseOr, vec![o1.into(), o2.into()])
     }
 
+    /// Add an "of type" operand. `type_id` must resolve to a node ID.
+    pub fn of_type<T>(self, type_id: T) -> Self
+    where
+        T: Into<Operand>,
+    {
+        self.add_element(FilterOperator::OfType, vec![type_id.into()])
+    }
+
     /// Build a content filter.
     pub fn build(self) -> ContentFilter {
         ContentFilter {
@@ -445,5 +502,19 @@ impl SimpleAttributeOperand {
             attribute_id: attribute_id as u32,
             index_range,
         }
+    }
+
+    /// Create a new simple attribute operand targeting the `Value` attribute with
+    /// no index range.
+    pub fn new_value<T>(type_definition_id: T, browse_path: &str) -> Self
+    where
+        T: Into<NodeId>,
+    {
+        Self::new(
+            type_definition_id,
+            browse_path,
+            AttributeId::Value,
+            NumericRange::None,
+        )
     }
 }


### PR DESCRIPTION
IIRC I didn't do this originally because it was hard to fit into the server architecture. We're a bit more settled now, and it is possible to implement.

Still, it's a little annoying to do, since now evaluating event filters requires the type tree, meaning that we need to share that somehow. I made it so that SessionSubscriptions holds a reference to a type tree for the user it belongs to, which _should_ be sufficient. It does mean we take a read lock on the type tree whenever we notify about subscriptions. The hope is that most servers will only rarely take a write lock on the type tree, so this should have low contention.

This does require passing the type_tree along a bunch when evaluating `ParsedContentFilter`.

I also realized we don't have _any_ tests for event subscriptions, so I wrote a proper one with some filtering. No major issues there though, it worked fine out of the gate. There's probably still more we can do to make event filter building a little bit more ergonomic.