### PR TITLE
Fix nonces created as part of CreateSession

### DIFF
--- a/async-opcua-client/src/builder.rs
+++ b/async-opcua-client/src/builder.rs
@@ -306,4 +306,10 @@ impl ClientBuilder {
         self.config.session_timeout = session_timeout;
         self
     }
+
+    /// Set the length of the nonce generated for CreateSession requests.
+    pub fn session_nonce_length(mut self, session_nonce_length: usize) -> Self {
+        self.config.session_nonce_length = session_nonce_length;
+        self
+    }
 }

--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -250,6 +250,9 @@ pub struct ClientConfig {
     pub(crate) endpoints: BTreeMap<String, ClientEndpoint>,
     /// User tokens
     pub(crate) user_tokens: BTreeMap<String, ClientUserToken>,
+    /// Length of the nonce generated for CreateSession requests.
+    #[serde(default = "defaults::session_nonce_length")]
+    pub(crate) session_nonce_length: usize,
     /// Requested channel lifetime in milliseconds.
     #[serde(default = "defaults::channel_lifetime")]
     pub(crate) channel_lifetime: u32,
@@ -566,6 +569,10 @@ mod defaults {
     pub(super) fn session_timeout() -> u32 {
         60_000
     }
+
+    pub(super) fn session_nonce_length() -> usize {
+        32
+    }
 }
 
 impl ClientConfig {
@@ -605,6 +612,7 @@ impl ClientConfig {
             recreate_subscriptions: defaults::recreate_subscriptions(),
             session_name: "Rust OPC UA Client".into(),
             session_timeout: defaults::session_timeout(),
+            session_nonce_length: defaults::session_nonce_length(),
         }
     }
 }

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -184,6 +184,7 @@ pub struct Session {
     pub(super) publish_limits_watch_tx: tokio::sync::watch::Sender<PublishLimits>,
     pub(super) monitored_item_handle: AtomicHandle,
     pub(super) trigger_publish_tx: tokio::sync::watch::Sender<Instant>,
+    pub(super) session_nonce_length: usize,
     decoding_options: DecodingOptions,
 }
 
@@ -226,6 +227,7 @@ impl Session {
             publish_limits_watch_rx,
             publish_limits_watch_tx,
             trigger_publish_tx,
+            session_nonce_length: config.session_nonce_length,
             decoding_options,
         });
 

--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -69,11 +69,6 @@ impl AsyncSecureChannel {
         self.state.request_handle()
     }
 
-    pub(crate) fn client_nonce(&self) -> ByteString {
-        let secure_channel = trace_read_lock!(self.secure_channel);
-        secure_channel.local_nonce_as_byte_string()
-    }
-
     pub(crate) fn update_from_created_session(
         &self,
         nonce: &ByteString,

--- a/async-opcua-client/src/transport/state.rs
+++ b/async-opcua-client/src/transport/state.rs
@@ -182,6 +182,7 @@ impl SecureChannelState {
                     && (secure_channel.security_mode() == MessageSecurityMode::Sign
                         || secure_channel.security_mode() == MessageSecurityMode::SignAndEncrypt)
                 {
+                    secure_channel.validate_secure_channel_nonce_length(&response.server_nonce)?;
                     secure_channel.set_remote_nonce_from_byte_string(&response.server_nonce)?;
                     secure_channel.derive_keys();
                 }

--- a/async-opcua-core/src/tests/comms.rs
+++ b/async-opcua-core/src/tests/comms.rs
@@ -10,28 +10,28 @@ fn secure_channel_nonce_basic128rsa15() {
     sc.set_security_policy(SecurityPolicy::Basic128Rsa15);
     // Nonce which is not 32 bytes long is an error
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::null())
+        .validate_secure_channel_nonce_length(&ByteString::null())
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b""))
+        .validate_secure_channel_nonce_length(&ByteString::from(b""))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"1"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"1"))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"012345678901234"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"012345678901234"))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"01234567890123456"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"01234567890123456"))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(
+        .validate_secure_channel_nonce_length(&ByteString::from(
             b"01234567890123456789012345678901".as_ref()
         ))
         .is_err());
     // Nonce which is 16 bytes long is good
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"0123456789012345"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"0123456789012345"))
         .is_ok());
 }
 
@@ -42,25 +42,27 @@ fn secure_channel_nonce_basic256() {
     sc.set_security_policy(SecurityPolicy::Basic256);
     // Nonce which is not 32 bytes long is an error
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::null())
+        .validate_secure_channel_nonce_length(&ByteString::null())
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b""))
+        .validate_secure_channel_nonce_length(&ByteString::from(b""))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"1"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"1"))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"0123456789012345678901234567890"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"0123456789012345678901234567890"))
         .is_err());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(
+        .validate_secure_channel_nonce_length(&ByteString::from(
             b"012345678901234567890123456789012".as_ref()
         ))
         .is_err());
     // Nonce which is 32 bytes long is good
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"01234567890123456789012345678901"))
+        .validate_secure_channel_nonce_length(&ByteString::from(
+            b"01234567890123456789012345678901"
+        ))
         .is_ok());
 }
 
@@ -72,13 +74,15 @@ fn secure_channel_nonce_none() {
     sc.set_security_policy(SecurityPolicy::None);
     // Nonce which is 32 bytes long is good
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"01234567890123456789012345678901"))
+        .validate_secure_channel_nonce_length(&ByteString::from(
+            b"01234567890123456789012345678901"
+        ))
         .is_ok());
     // Nonce which is not 32 bytes long is good
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b"012"))
+        .validate_secure_channel_nonce_length(&ByteString::from(b"012"))
         .is_ok());
     assert!(sc
-        .set_remote_nonce_from_byte_string(&ByteString::from(b""))
+        .validate_secure_channel_nonce_length(&ByteString::from(b""))
         .is_ok());
 }

--- a/async-opcua-server/src/config/server.rs
+++ b/async-opcua-server/src/config/server.rs
@@ -236,6 +236,9 @@ pub struct ServerConfig {
     /// Enable server diagnostics.
     #[serde(default)]
     pub diagnostics: bool,
+    /// Length of the nonce generated for CreateSession responses.
+    #[serde(default = "defaults::session_nonce_length")]
+    pub session_nonce_length: usize,
 }
 
 mod defaults {
@@ -259,6 +262,10 @@ mod defaults {
 
     pub(super) fn max_session_timeout_ms() -> u64 {
         constants::MAX_SESSION_TIMEOUT
+    }
+
+    pub(super) fn session_nonce_length() -> usize {
+        32
     }
 }
 
@@ -389,6 +396,7 @@ impl Default for ServerConfig {
             max_secure_channel_token_lifetime_ms: defaults::max_secure_channel_token_lifetime_ms(),
             max_session_timeout_ms: defaults::max_session_timeout_ms(),
             diagnostics: false,
+            session_nonce_length: defaults::session_nonce_length(),
         }
     }
 }

--- a/async-opcua-types/src/byte_string.rs
+++ b/async-opcua-types/src/byte_string.rs
@@ -292,6 +292,15 @@ impl ByteString {
             Err(OutOfRange)
         }
     }
+
+    /// Length of the byte string in bytes.
+    pub fn len(&self) -> usize {
+        if let Some(ref v) = self.value {
+            v.len()
+        } else {
+            0
+        }
+    }
 }
 
 #[test]

--- a/dotnet-tests/external-tests/src/tests/client/connect.rs
+++ b/dotnet-tests/external-tests/src/tests/client/connect.rs
@@ -68,13 +68,11 @@ pub async fn run_connect_tests(runner: &Runner, ctx: &mut ClientTestState) {
             SecurityPolicy::Aes256Sha256RsaPss,
             MessageSecurityMode::SignAndEncrypt,
         ),
-        // The .NET SDK is hard to use with these, since its configuration around minimum
-        // required nonce length is really weird.
-        /*(SecurityPolicy::Basic128Rsa15, MessageSecurityMode::Sign),
+        (SecurityPolicy::Basic128Rsa15, MessageSecurityMode::Sign),
         (
             SecurityPolicy::Basic128Rsa15,
             MessageSecurityMode::SignAndEncrypt,
-        ), */
+        ),
         (SecurityPolicy::Basic256, MessageSecurityMode::Sign),
         (
             SecurityPolicy::Basic256,

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -37,6 +37,7 @@ user_tokens:
   sample_user2:
     user: sample2
     password: sample2pwd
+session_nonce_length: 32
 channel_lifetime: 60000
 decoding_options:
   max_message_size: 327675


### PR DESCRIPTION
Turns out, according to the standard, these are _not_ generated using the length given by the security policy, but instead use a common length of at least 32 bytes. This just happens to work fine since all security policies except one use 32 bit keys...

I'm still slightly unclear on what the `remote_nonce` thing in the secure channel actually is, I suspect it may represent different things at different stages of the connection, but it just so happens to work fine if we only keep the last value given by either OpenSecureChannel or CreateSession, I believe it is used for the next step in the chain, i.e. OpenSecureChannel gives a nonce used by CreateSession, which gives a nonce used by ActivateSession... This may cause issues if you had multiple sessions in a single secure channel. We may want to clean this up in the future.