### PR TITLE
do not try to parse empty remote certificate

### DIFF
--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -350,7 +350,7 @@ impl SecureChannel {
         &mut self,
         remote_cert: &ByteString,
     ) -> Result<(), StatusCode> {
-        self.remote_cert = if remote_cert.is_null() {
+        self.remote_cert = if remote_cert.is_null() || remote_cert.is_empty() {
             None
         } else {
             Some(X509::from_byte_string(remote_cert)?)


### PR DESCRIPTION
found out a server was returning

 "REMOTE CERT" = "REMOTE CERT"
[/home/olivier/dev/async-opcua/async-opcua-core/src/comms/secure_channel.rs:353:9] &remote_cert = ByteString {
    value: Some(
        [],
    ),
}

or in whireshark 
<img width="781" height="293" alt="image" src="https://github.com/user-attachments/assets/a85f49c7-a513-42e2-8d71-6fc01c90e512" />

and the rust client was trying to parse that and failed with invalid certificate. That simple line change fixes it for me. but I am far from sure this is correct