### PR TITLE
Add Binary Default as DefaultEncodingId to DataTypeDefinition

### DIFF
--- a/async-opcua-codegen/src/nodeset/mod.rs
+++ b/async-opcua-codegen/src/nodeset/mod.rs
@@ -152,7 +152,8 @@ pub fn generate_target(
     let types = make_type_dict(config, cache)?;
     let type_info = input.get_type_names()?;
 
-    let mut generator = NodeSetCodeGenerator::new(preferred_locale, &input.aliases, types, type_info)?;
+    let mut generator =
+        NodeSetCodeGenerator::new(preferred_locale, &input.aliases, types, type_info)?;
 
     let mut fns = Vec::with_capacity(input.xml.nodes.len());
     for node in &input.xml.nodes {

--- a/async-opcua-codegen/src/nodeset/mod.rs
+++ b/async-opcua-codegen/src/nodeset/mod.rs
@@ -150,8 +150,9 @@ pub fn generate_target(
     cache: &SchemaCache,
 ) -> Result<Vec<NodeSetChunk>, CodeGenError> {
     let types = make_type_dict(config, cache)?;
+    let type_info = input.get_type_names()?;
 
-    let mut generator = NodeSetCodeGenerator::new(preferred_locale, &input.aliases, types)?;
+    let mut generator = NodeSetCodeGenerator::new(preferred_locale, &input.aliases, types, type_info)?;
 
     let mut fns = Vec::with_capacity(input.xml.nodes.len());
     for node in &input.xml.nodes {

--- a/async-opcua-codegen/src/utils/node_id.rs
+++ b/async-opcua-codegen/src/utils/node_id.rs
@@ -99,6 +99,25 @@ impl ParsedNodeId {
     }
 }
 
+impl RenderExpr for ParsedNodeId {
+    fn render(&self) -> Result<TokenStream, CodeGenError> {
+        let id_item = self.value.render()?;
+        let namespace = self.namespace;
+
+        let ns_item = if self.namespace == 0 {
+            quote! { 0u16 }
+        } else {
+            quote! {
+                ns_map.get_index(#namespace).unwrap()
+            }
+        };
+
+        Ok(quote! {
+            opcua::types::NodeId::new(#ns_item, #id_item)
+        })
+    }
+}
+
 impl RenderExpr for opcua_xml::schema::ua_node_set::NodeId {
     fn render(&self) -> Result<TokenStream, CodeGenError> {
         let id = &self.0;

--- a/async-opcua-codegen/src/utils/node_id.rs
+++ b/async-opcua-codegen/src/utils/node_id.rs
@@ -120,23 +120,7 @@ impl RenderExpr for ParsedNodeId {
 
 impl RenderExpr for opcua_xml::schema::ua_node_set::NodeId {
     fn render(&self) -> Result<TokenStream, CodeGenError> {
-        let id = &self.0;
-        let ParsedNodeId { value, namespace } = ParsedNodeId::parse(id)?;
-
-        // Do as much parsing as possible here, to optimize performance and get the errors as early as possible.
-        let id_item = value.render()?;
-
-        let ns_item = if namespace == 0 {
-            quote! { 0u16 }
-        } else {
-            quote! {
-                ns_map.get_index(#namespace).unwrap()
-            }
-        };
-
-        Ok(quote! {
-            opcua::types::NodeId::new(#ns_item, #id_item)
-        })
+        ParsedNodeId::parse(&self.0)?.render()
     }
 }
 

--- a/async-opcua-core-namespace/src/generated/nodeset_1.rs
+++ b/async-opcua-core-namespace/src/generated/nodeset_1.rs
@@ -193,7 +193,7 @@ fn make_data_type_1000(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18817u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -227,7 +227,7 @@ fn make_data_type_1001(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18818u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -289,7 +289,7 @@ fn make_data_type_1002(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18819u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -323,7 +323,7 @@ fn make_data_type_1003(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18820u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -385,7 +385,7 @@ fn make_data_type_1004(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18821u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -419,7 +419,7 @@ fn make_data_type_1005(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18822u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -472,7 +472,7 @@ fn make_data_type_1006(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18823u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -691,7 +691,7 @@ fn make_data_type_1149(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15736u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -881,7 +881,7 @@ fn make_data_type_129(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12766u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1004,7 +1004,7 @@ fn make_data_type_1341(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23507u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1066,7 +1066,7 @@ fn make_data_type_1390(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32560u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1137,7 +1137,7 @@ fn make_data_type_1391(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32561u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1301,7 +1301,7 @@ fn make_data_type_1394(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32562u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1806,7 +1806,7 @@ fn make_data_type_2029(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12680u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1946,7 +1946,7 @@ fn make_data_type_2303(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32382u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2095,7 +2095,7 @@ fn make_data_type_2636(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15676u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2148,7 +2148,7 @@ fn make_data_type_2637(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 125u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2190,7 +2190,7 @@ fn make_data_type_2638(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 126u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2243,7 +2243,7 @@ fn make_data_type_2639(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 127u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2296,7 +2296,7 @@ fn make_data_type_2640(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15421u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2358,7 +2358,7 @@ fn make_data_type_2641(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15422u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2411,7 +2411,7 @@ fn make_data_type_2642(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 24108u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2464,7 +2464,7 @@ fn make_data_type_2643(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 24109u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2517,7 +2517,7 @@ fn make_data_type_2644(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 24110u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2666,7 +2666,7 @@ fn make_data_type_2647(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 124u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2791,7 +2791,7 @@ fn make_data_type_2648(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14839u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2887,7 +2887,7 @@ fn make_data_type_2651(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14847u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2967,7 +2967,7 @@ fn make_data_type_2652(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15677u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3001,7 +3001,7 @@ fn make_data_type_2653(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15678u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3108,7 +3108,7 @@ fn make_data_type_2654(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14323u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3150,7 +3150,7 @@ fn make_data_type_2655(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15679u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3212,7 +3212,7 @@ fn make_data_type_2656(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15681u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3254,7 +3254,7 @@ fn make_data_type_2657(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 25529u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3316,7 +3316,7 @@ fn make_data_type_2658(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18598u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3369,7 +3369,7 @@ fn make_data_type_2659(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18599u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3479,7 +3479,7 @@ fn make_data_type_2662(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18600u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3521,7 +3521,7 @@ fn make_data_type_2663(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18795u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3712,7 +3712,7 @@ fn make_data_type_2666(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15682u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3746,7 +3746,7 @@ fn make_data_type_2667(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15683u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3780,7 +3780,7 @@ fn make_data_type_2668(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15688u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3878,7 +3878,7 @@ fn make_data_type_2669(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15689u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3994,7 +3994,7 @@ fn make_data_type_2670(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21150u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4028,7 +4028,7 @@ fn make_data_type_2671(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15691u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4062,7 +4062,7 @@ fn make_data_type_2672(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15693u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4178,7 +4178,7 @@ fn make_data_type_2673(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15694u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4212,7 +4212,7 @@ fn make_data_type_2674(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15695u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4254,7 +4254,7 @@ fn make_data_type_2675(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21151u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4296,7 +4296,7 @@ fn make_data_type_2676(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21152u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4358,7 +4358,7 @@ fn make_data_type_2677(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21153u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4392,7 +4392,7 @@ fn make_data_type_2678(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15701u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4426,7 +4426,7 @@ fn make_data_type_2679(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15702u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4614,7 +4614,7 @@ fn make_data_type_2680(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15703u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4648,7 +4648,7 @@ fn make_data_type_2681(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15705u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4682,7 +4682,7 @@ fn make_data_type_2682(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15706u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4716,7 +4716,7 @@ fn make_data_type_2683(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15707u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4758,7 +4758,7 @@ fn make_data_type_2684(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15712u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4856,7 +4856,7 @@ fn make_data_type_2685(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14848u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4966,7 +4966,7 @@ fn make_data_type_2688(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15713u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5028,7 +5028,7 @@ fn make_data_type_2689(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21154u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5070,7 +5070,7 @@ fn make_data_type_2690(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23851u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5141,7 +5141,7 @@ fn make_data_type_2691(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23852u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5257,7 +5257,7 @@ fn make_data_type_2692(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23853u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5373,7 +5373,7 @@ fn make_data_type_2693(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 25530u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5471,7 +5471,7 @@ fn make_data_type_2694(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23854u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }

--- a/async-opcua-core-namespace/src/generated/nodeset_2.rs
+++ b/async-opcua-core-namespace/src/generated/nodeset_2.rs
@@ -290,7 +290,7 @@ fn make_data_type_2699(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15715u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -462,7 +462,7 @@ fn make_data_type_2702(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15717u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -578,7 +578,7 @@ fn make_data_type_2703(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15718u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -701,7 +701,7 @@ fn make_data_type_2706(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15719u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -854,7 +854,7 @@ fn make_data_type_2709(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15724u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -907,7 +907,7 @@ fn make_data_type_2710(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15725u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -941,7 +941,7 @@ fn make_data_type_2711(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23855u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -975,7 +975,7 @@ fn make_data_type_2712(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23856u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1017,7 +1017,7 @@ fn make_data_type_2713(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23857u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1051,7 +1051,7 @@ fn make_data_type_2714(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23860u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1093,7 +1093,7 @@ fn make_data_type_2715(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23861u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1135,7 +1135,7 @@ fn make_data_type_2716(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 17468u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1206,7 +1206,7 @@ fn make_data_type_2717(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23864u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1259,7 +1259,7 @@ fn make_data_type_2718(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 21155u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1339,7 +1339,7 @@ fn make_data_type_2719(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23865u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1410,7 +1410,7 @@ fn make_data_type_2720(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23866u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1490,7 +1490,7 @@ fn make_data_type_2721(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18930u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1543,7 +1543,7 @@ fn make_data_type_2722(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15479u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1683,7 +1683,7 @@ fn make_data_type_2725(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15727u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1772,7 +1772,7 @@ fn make_data_type_2726(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15729u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1852,7 +1852,7 @@ fn make_data_type_2727(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15733u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2144,7 +2144,7 @@ fn make_data_type_3089(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 25531u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2206,7 +2206,7 @@ fn make_data_type_3090(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 25532u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2494,7 +2494,7 @@ fn make_data_type_3832(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 23499u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2690,7 +2690,7 @@ fn make_data_type_3864(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 24292u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3665,7 +3665,7 @@ fn make_data_type_4027(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 25239u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3754,7 +3754,7 @@ fn make_data_type_4028(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 19079u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3825,7 +3825,7 @@ fn make_data_type_4029(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 19080u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3878,7 +3878,7 @@ fn make_data_type_4030(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 19081u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4087,7 +4087,7 @@ fn make_data_type_4140(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32661u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4149,7 +4149,7 @@ fn make_data_type_4141(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32662u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4844,7 +4844,7 @@ fn make_data_type_4156(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 128u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4878,7 +4878,7 @@ fn make_data_type_4157(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 121u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5045,7 +5045,7 @@ fn make_data_type_4160(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14844u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5116,7 +5116,7 @@ fn make_data_type_4161(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 122u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5158,7 +5158,7 @@ fn make_data_type_4162(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 123u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5238,7 +5238,7 @@ fn make_data_type_4163(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 298u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5300,7 +5300,7 @@ fn make_data_type_4164(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 8251u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5342,7 +5342,7 @@ fn make_data_type_4165(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14845u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5395,7 +5395,7 @@ fn make_data_type_4166(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12765u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5656,7 +5656,7 @@ fn make_data_type_4175(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 8917u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5869,7 +5869,7 @@ fn make_data_type_4180(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 310u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5966,7 +5966,7 @@ fn make_data_type_4182(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12207u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -6198,7 +6198,7 @@ fn make_data_type_4188(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 306u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -6305,7 +6305,7 @@ fn make_data_type_4189(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 314u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }

--- a/async-opcua-core-namespace/src/generated/nodeset_3.rs
+++ b/async-opcua-core-namespace/src/generated/nodeset_3.rs
@@ -212,7 +212,7 @@ fn make_data_type_4190(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 434u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -246,7 +246,7 @@ fn make_data_type_4191(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12900u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -299,7 +299,7 @@ fn make_data_type_4192(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12901u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -403,7 +403,7 @@ fn make_data_type_4195(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 346u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -471,7 +471,7 @@ fn make_data_type_4197(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 318u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -505,7 +505,7 @@ fn make_data_type_4198(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 321u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -567,7 +567,7 @@ fn make_data_type_4199(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 324u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -609,7 +609,7 @@ fn make_data_type_4200(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 327u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -662,7 +662,7 @@ fn make_data_type_4201(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 940u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1009,7 +1009,7 @@ fn make_data_type_4204(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 378u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1098,7 +1098,7 @@ fn make_data_type_4205(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 381u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1151,7 +1151,7 @@ fn make_data_type_4206(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 384u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1231,7 +1231,7 @@ fn make_data_type_4207(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 387u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1523,7 +1523,7 @@ fn make_data_type_4211(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 539u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1565,7 +1565,7 @@ fn make_data_type_4212(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 542u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1733,7 +1733,7 @@ fn make_data_type_4215(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 333u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1933,7 +1933,7 @@ fn make_data_type_4218(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 585u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1975,7 +1975,7 @@ fn make_data_type_4219(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 588u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2009,7 +2009,7 @@ fn make_data_type_4220(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 591u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2051,7 +2051,7 @@ fn make_data_type_4221(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 594u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2093,7 +2093,7 @@ fn make_data_type_4222(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 597u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2173,7 +2173,7 @@ fn make_data_type_4223(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 600u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2244,7 +2244,7 @@ fn make_data_type_4224(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 603u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2306,7 +2306,7 @@ fn make_data_type_4225(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 11226u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2348,7 +2348,7 @@ fn make_data_type_4226(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 661u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2390,7 +2390,7 @@ fn make_data_type_4227(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32825u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2556,7 +2556,7 @@ fn make_data_type_4232(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 721u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2609,7 +2609,7 @@ fn make_data_type_4233(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 727u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2689,7 +2689,7 @@ fn make_data_type_4234(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 950u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2731,7 +2731,7 @@ fn make_data_type_4235(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 922u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -2820,7 +2820,7 @@ fn make_data_type_4236(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 340u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3044,7 +3044,7 @@ fn make_data_type_4241(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 855u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3086,7 +3086,7 @@ fn make_data_type_4242(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 11957u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3139,7 +3139,7 @@ fn make_data_type_4243(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 11958u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3210,7 +3210,7 @@ fn make_data_type_4244(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 858u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3353,7 +3353,7 @@ fn make_data_type_4245(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 861u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3442,7 +3442,7 @@ fn make_data_type_4246(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 864u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3864,7 +3864,7 @@ fn make_data_type_4247(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 867u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -3980,7 +3980,7 @@ fn make_data_type_4248(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 870u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4033,7 +4033,7 @@ fn make_data_type_4249(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 873u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4086,7 +4086,7 @@ fn make_data_type_4250(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 301u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4400,7 +4400,7 @@ fn make_data_type_4251(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 876u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4462,7 +4462,7 @@ fn make_data_type_4252(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 879u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4515,7 +4515,7 @@ fn make_data_type_4253(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 899u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4568,7 +4568,7 @@ fn make_data_type_4254(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 886u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4639,7 +4639,7 @@ fn make_data_type_4255(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 889u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4749,7 +4749,7 @@ fn make_data_type_4258(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12181u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4802,7 +4802,7 @@ fn make_data_type_4259(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12182u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4882,7 +4882,7 @@ fn make_data_type_4260(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12089u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -4935,7 +4935,7 @@ fn make_data_type_4261(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 12090u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5060,7 +5060,7 @@ fn make_data_type_4262(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 896u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5203,7 +5203,7 @@ fn make_data_type_4263(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 24034u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5265,7 +5265,7 @@ fn make_data_type_4264(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 893u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5627,7 +5627,7 @@ fn make_data_type_913(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 14846u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5669,7 +5669,7 @@ fn make_data_type_914(
                         max_string_length: 0u32,
                         is_optional: false,
                     }]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 17537u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5722,7 +5722,7 @@ fn make_data_type_915(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 17549u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5793,7 +5793,7 @@ fn make_data_type_916(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 15671u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5925,7 +5925,7 @@ fn make_data_type_997(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 32422u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -5978,7 +5978,7 @@ fn make_data_type_998(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18815u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -6012,7 +6012,7 @@ fn make_data_type_999(
             Some(
                 opcua::types::StructureDefinition {
                     fields: Some(vec![]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(0u16, 18816u32),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }

--- a/samples/custom-codegen/src/generated/nodeset/nodeset_1.rs
+++ b/samples/custom-codegen/src/generated/nodeset/nodeset_1.rs
@@ -1347,7 +1347,10 @@ fn make_data_type_36(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(
+                        ns_map.get_index(1u16).unwrap(),
+                        5004u32,
+                    ),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }
@@ -1474,7 +1477,10 @@ fn make_data_type_39(
                             is_optional: false,
                         },
                     ]),
-                    default_encoding_id: opcua::types::NodeId::null(),
+                    default_encoding_id: opcua::types::NodeId::new(
+                        ns_map.get_index(1u16).unwrap(),
+                        5007u32,
+                    ),
                     base_data_type: opcua::types::NodeId::null(),
                     structure_type: opcua::types::StructureType::Structure,
                 }


### PR DESCRIPTION
Fixes #144 .
I have tested it against a custom Information Model and it works as expected. I did not add unit or integration tests since I was unsure where / how to do that. What's your take on this?