### PR TITLE
Be more careful about adding timestamps

### DIFF
--- a/async-opcua-server/src/node_manager/utils/sync_sampler.rs
+++ b/async-opcua-server/src/node_manager/utils/sync_sampler.rs
@@ -37,9 +37,6 @@ impl SamplerItem {
         }
         self.sampling_interval = interval;
         self.enabled = enabled;
-        if self.last_sample > (Instant::now() + self.sampling_interval) {
-            self.last_sample = Instant::now() + self.sampling_interval;
-        }
     }
 }
 
@@ -188,7 +185,11 @@ impl SyncSampler {
                     if !sampler.enabled {
                         return None;
                     }
-                    if sampler.last_sample + sampler.sampling_interval > now {
+                    if sampler
+                        .last_sample
+                        .checked_add(sampler.sampling_interval)
+                        .is_none_or(|v| v > now)
+                    {
                         return None;
                     }
                     let value = (sampler.sampler)()?;

--- a/async-opcua-server/src/subscriptions/monitored_item.rs
+++ b/async-opcua-server/src/subscriptions/monitored_item.rs
@@ -526,16 +526,15 @@ impl MonitoredItem {
         // If we're outside the sampling interval, keep the value for now,
         // but shift it to the next sample.
         if !matches_sampling_interval {
-            value.source_timestamp = Some(
-                (self
-                    .last_data_value
-                    .as_ref()
-                    .and_then(|dv| dv.source_timestamp)
-                    .unwrap_or(*now)
-                    .as_chrono()
-                    + self.sampling_interval_as_time_delta())
-                .into(),
-            );
+            value.source_timestamp = self
+                .last_data_value
+                .as_ref()
+                .and_then(|dv| dv.source_timestamp)
+                .unwrap_or(*now)
+                .as_chrono()
+                .checked_add_signed(self.sampling_interval_as_time_delta())
+                .map(|v| v.into());
+
             self.sample_skipped_data_value = Some(value);
             // We need to return true here, so that the subscription knows it needs to tick this
             // monitored item later.


### PR DESCRIPTION
This can in some cases panic, see #148. This fixes #148.

The case in that issue doesn't really make any sense to me. I don't think the check we do there makes any sense.

That said, we do add `sampling_interval` in a few other places, we should be careful about not overflowing and causing a panic.