### PR TITLE
Use max_chunk_count for incoming limits in the client

### DIFF
--- a/async-opcua-client/src/session/client.rs
+++ b/async-opcua-client/src/session/client.rs
@@ -228,7 +228,6 @@ impl Client {
             self.config.performance.ignore_clock_skew,
             Arc::default(),
             TransportConfiguration {
-                max_pending_incoming: 5,
                 send_buffer_size: self.config.decoding_options.max_chunk_size,
                 recv_buffer_size: self.config.decoding_options.max_incoming_chunk_size,
                 max_message_size: self.config.decoding_options.max_message_size,

--- a/async-opcua-client/src/session/connection.rs
+++ b/async-opcua-client/src/session/connection.rs
@@ -321,7 +321,6 @@ impl<R> SessionBuilder<'_, EndpointDescription, R> {
             config.performance.ignore_clock_skew,
             Arc::default(),
             TransportConfiguration {
-                max_pending_incoming: 5,
                 send_buffer_size: config.decoding_options.max_chunk_size,
                 recv_buffer_size: config.decoding_options.max_incoming_chunk_size,
                 max_message_size: config.decoding_options.max_message_size,

--- a/async-opcua-client/src/transport/tcp.rs
+++ b/async-opcua-client/src/transport/tcp.rs
@@ -42,7 +42,6 @@ pub struct TcpTransport {
 
 #[derive(Debug, Clone)]
 pub struct TransportConfiguration {
-    pub max_pending_incoming: usize,
     pub send_buffer_size: usize,
     pub recv_buffer_size: usize,
     pub max_message_size: usize,
@@ -178,7 +177,7 @@ impl Connector for TcpConnector {
             state: TransportState::new(
                 channel,
                 outgoing_recv,
-                config.max_pending_incoming,
+                config.max_chunk_count,
                 ack.send_buffer_size.min(config.recv_buffer_size as u32) as usize,
             ),
             read: framed_read,

--- a/async-opcua-server/src/transport/tcp.rs
+++ b/async-opcua-server/src/transport/tcp.rs
@@ -376,7 +376,9 @@ impl TcpTransport {
                 } else {
                     let chunk = channel.verify_and_remove_security(&chunk.data)?;
 
-                    if self.pending_chunks.len() == self.send_buffer.max_chunk_count {
+                    if self.send_buffer.max_chunk_count > 0
+                        && self.pending_chunks.len() == self.send_buffer.max_chunk_count
+                    {
                         return Err(Error::decoding(format!(
                             "Message has more than {} chunks, exceeding negotiated limits",
                             self.send_buffer.max_chunk_count


### PR DESCRIPTION
For some reason we were still using a somewhat vague "max_pending_incoming" option there that was hard coded to 5? No real reason for this when we have `max_chunk_count` which is intended for this exact purpose.

Aligned error message with the one we use on the server.