### PR TITLE
Refactor building server connector

### DIFF
--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -447,19 +447,25 @@ impl ClientConfig {
         &self,
         client_endpoint: &ClientEndpoint,
         endpoints: &[EndpointDescription],
-    ) -> Result<EndpointDescription, String> {
+    ) -> Result<EndpointDescription, Error> {
         let security_policy =
             SecurityPolicy::from_str(&client_endpoint.security_policy).map_err(|_| {
-                format!(
-                    "Endpoint {} security policy {} is invalid",
-                    client_endpoint.url, client_endpoint.security_policy
+                Error::new(
+                    StatusCode::BadSecurityPolicyRejected,
+                    format!(
+                        "Endpoint {} security policy {} is invalid",
+                        client_endpoint.url, client_endpoint.security_policy
+                    ),
                 )
             })?;
         let security_mode = MessageSecurityMode::from(client_endpoint.security_mode.as_ref());
         if security_mode == MessageSecurityMode::Invalid {
-            return Err(format!(
-                "Endpoint {} security mode {} is invalid",
-                client_endpoint.url, client_endpoint.security_mode
+            return Err(Error::new(
+                StatusCode::BadSecurityModeRejected,
+                format!(
+                    "Endpoint {} security mode {} is invalid",
+                    client_endpoint.url, client_endpoint.security_mode
+                ),
             ));
         }
         let endpoint_url = client_endpoint.url.clone();
@@ -470,8 +476,11 @@ impl ClientConfig {
             security_mode,
         )
         .ok_or_else(|| {
-            format!(
-                "Endpoint {endpoint_url}, {security_policy:?} / {security_mode:?} does not match any supplied by the server"
+            Error::new(
+                StatusCode::BadTcpEndpointUrlInvalid,
+                format!(
+                    "Endpoint {endpoint_url}, {security_policy:?} / {security_mode:?} does not match any supplied by the server"
+                ),
             )
         })?;
 

--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -124,11 +124,11 @@ pub use builder::ClientBuilder;
 pub use config::{ClientConfig, ClientEndpoint, ClientUserToken, ANONYMOUS_USER_TOKEN_ID};
 pub use retry::{ExponentialBackoff, SessionRetryPolicy};
 pub use session::{
-    Client, DataChangeCallback, DefaultRetryPolicy, EventCallback, HistoryReadAction,
-    HistoryUpdateAction, MonitoredItem, OnSubscriptionNotification, OnSubscriptionNotificationCore,
-    RequestRetryPolicy, Session, SessionActivity, SessionBuilder, SessionConnectMode,
-    SessionEventLoop, SessionPollResult, Subscription, SubscriptionActivity, SubscriptionCallbacks,
-    UARequest,
+    Client, ConnectionSource, DataChangeCallback, DefaultRetryPolicy, DirectConnectionSource,
+    EventCallback, HistoryReadAction, HistoryUpdateAction, MonitoredItem,
+    OnSubscriptionNotification, OnSubscriptionNotificationCore, RequestRetryPolicy, Session,
+    SessionActivity, SessionBuilder, SessionConnectMode, SessionEventLoop, SessionPollResult,
+    Subscription, SubscriptionActivity, SubscriptionCallbacks, UARequest,
 };
 pub use transport::AsyncSecureChannel;
 

--- a/async-opcua-client/src/session/connection.rs
+++ b/async-opcua-client/src/session/connection.rs
@@ -1,14 +1,15 @@
 use std::{str::FromStr, sync::Arc};
 
-use crate::{
-    transport::{tcp::TransportConfiguration, Connector, ConnectorBuilder},
-    AsyncSecureChannel, ClientConfig, IdentityToken,
-};
 use opcua_core::{comms::url::is_opc_ua_binary_url, config::Config, sync::RwLock};
 use opcua_crypto::{CertificateStore, SecurityPolicy};
 use opcua_types::{
     ContextOwned, EndpointDescription, Error, MessageSecurityMode, NamespaceMap, NodeId,
     StatusCode, TypeLoader, UserTokenType,
+};
+
+use crate::{
+    transport::{tcp::TransportConfiguration, Connector, ConnectorBuilder},
+    AsyncSecureChannel, ClientConfig, IdentityToken,
 };
 
 use super::{Client, EndpointInfo, Session, SessionEventLoop};
@@ -150,9 +151,9 @@ impl<'a, T, R, C> SessionBuilder<'a, T, R, C> {
 
     /// Set the connection source to use. This is used to create the transport
     /// connector. Defaults to a direct TCP connection, implemented by `()`.
-    pub fn with_connector<C2>(self, connection_source: C2) -> SessionBuilder<'a, T, R, C2>
+    pub fn with_connector<CS>(self, connection_source: CS) -> SessionBuilder<'a, T, R, CS>
     where
-        C2: ConnectionSource,
+        CS: ConnectionSource,
     {
         SessionBuilder {
             inner: self.inner,
@@ -378,7 +379,7 @@ where
         identity_token: IdentityToken,
         endpoint: EndpointDescription,
         config: &ClientConfig,
-        connector: Arc<dyn Connector + Send + Sync + 'static>,
+        connector: Box<dyn Connector + Send + Sync + 'static>,
         ctx: ContextOwned,
     ) -> AsyncSecureChannel {
         AsyncSecureChannel::new(

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -45,7 +45,7 @@ use std::time::{Duration, Instant};
 use arc_swap::ArcSwap;
 pub use client::Client;
 pub use connect::SessionConnectMode;
-pub use connection::SessionBuilder;
+pub use connection::{ConnectionSource, DirectConnectionSource, SessionBuilder};
 pub use event_loop::{SessionActivity, SessionEventLoop, SessionPollResult};
 use opcua_core::handle::AtomicHandle;
 use opcua_core::sync::{Mutex, RwLock};
@@ -271,7 +271,6 @@ impl Session {
             .is_ok();
 
         // Compiler limitation
-        #[allow(clippy::let_and_return)]
         res
     }
 

--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -39,7 +39,7 @@ pub struct AsyncSecureChannel {
     transport_config: TransportConfiguration,
     state: SecureChannelState,
     issue_channel_lock: tokio::sync::Mutex<()>,
-    connector: Arc<dyn Connector>,
+    connector: Box<dyn Connector>,
     channel_lifetime: u32,
 
     request_send: ArcSwapOption<RequestSend>,
@@ -134,7 +134,7 @@ impl AsyncSecureChannel {
         ignore_clock_skew: bool,
         auth_token: Arc<ArcSwap<NodeId>>,
         transport_config: TransportConfiguration,
-        connector: Arc<dyn Connector>,
+        connector: Box<dyn Connector>,
         channel_lifetime: u32,
         encoding_context: Arc<RwLock<ContextOwned>>,
     ) -> Self {

--- a/async-opcua-client/src/transport/connect.rs
+++ b/async-opcua-client/src/transport/connect.rs
@@ -36,23 +36,23 @@ pub trait Connector: Send + Sync {
 /// Implemented for `String`, `&str`, `&String`, and any type that implements the `Connector` trait.
 pub trait ConnectorBuilder: Send + Sync {
     /// Create a new connector for the specific endpoint URL.
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error>;
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error>;
 }
 
 impl ConnectorBuilder for String {
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error> {
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error> {
         ConnectorBuilder::build(self.as_str())
     }
 }
 
 impl ConnectorBuilder for &str {
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error> {
-        Ok(Arc::new(TcpConnector::new(self)?))
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error> {
+        Ok(Box::new(TcpConnector::new(self)?))
     }
 }
 
 impl ConnectorBuilder for &String {
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error> {
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error> {
         ConnectorBuilder::build(self.as_str())
     }
 }
@@ -61,13 +61,13 @@ impl<T> ConnectorBuilder for T
 where
     T: Connector + Send + Sync + 'static,
 {
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error> {
-        Ok(Arc::new(self))
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error> {
+        Ok(Box::new(self))
     }
 }
 
-impl ConnectorBuilder for Arc<dyn Connector + Send + Sync> {
-    fn build(self) -> Result<Arc<dyn Connector + Send + Sync>, Error> {
+impl ConnectorBuilder for Box<dyn Connector + Send + Sync> {
+    fn build(self) -> Result<Box<dyn Connector + Send + Sync>, Error> {
         Ok(self)
     }
 }

--- a/async-opcua-client/src/transport/mod.rs
+++ b/async-opcua-client/src/transport/mod.rs
@@ -7,7 +7,7 @@ mod state;
 pub(super) mod tcp;
 
 pub use channel::{AsyncSecureChannel, SecureChannelEventLoop};
-pub use connect::{Connector, Transport};
+pub use connect::{Connector, ConnectorBuilder, Transport};
 pub(crate) use core::OutgoingMessage;
 pub use core::TransportPollResult;
 pub use tcp::TcpConnector;

--- a/async-opcua-server/src/discovery.rs
+++ b/async-opcua-server/src/discovery.rs
@@ -28,8 +28,19 @@ async fn register_with_discovery_server(
     match client.find_servers(discovery_server_url, None, None).await {
         Ok(servers) => {
             debug!("Servers on the discovery endpoint - {:?}", servers);
+            let endpoint = match client.get_best_endpoint(discovery_server_url).await {
+                Ok(endpoint) => endpoint,
+                Err(err) => {
+                    error!(
+                        "Cannot find a valid endpoint on discovery url {}, error = {}",
+                        discovery_server_url, err
+                    );
+                    return;
+                }
+            };
+
             match client
-                .register_server(discovery_server_url, registered_server)
+                .register_server(endpoint.endpoint_url.as_ref(), &endpoint, registered_server)
                 .await
             {
                 Ok(_) => {}

--- a/async-opcua/tests/utils/tester.rs
+++ b/async-opcua/tests/utils/tester.rs
@@ -17,7 +17,7 @@ use opcua::{
 };
 use opcua_core::config::Config;
 use opcua_crypto::CertificateStore;
-use opcua_types::ApplicationDescription;
+use opcua_types::{ApplicationDescription, Error};
 use tokio::net::TcpListener;
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -387,7 +387,7 @@ impl Tester {
         security_policy: SecurityPolicy,
         security_mode: MessageSecurityMode,
         user_identity: IdentityToken,
-    ) -> Result<(Arc<Session>, SessionEventLoop), StatusCode> {
+    ) -> Result<(Arc<Session>, SessionEventLoop), Error> {
         self.client
             .connect_to_matching_endpoint(
                 (
@@ -406,7 +406,7 @@ impl Tester {
         security_mode: MessageSecurityMode,
         user_identity: IdentityToken,
         path: &str,
-    ) -> Result<(Arc<Session>, SessionEventLoop), StatusCode> {
+    ) -> Result<(Arc<Session>, SessionEventLoop), Error> {
         self.client
             .connect_to_matching_endpoint(
                 (
@@ -448,9 +448,7 @@ impl Tester {
     }
 
     #[allow(unused)]
-    pub async fn connect_default(
-        &mut self,
-    ) -> Result<(Arc<Session>, SessionEventLoop), StatusCode> {
+    pub async fn connect_default(&mut self) -> Result<(Arc<Session>, SessionEventLoop), Error> {
         self.connect(
             SecurityPolicy::None,
             MessageSecurityMode::None,


### PR DESCRIPTION
This is necessary if we want to let users swap out the connector. The final implementation is moderately hairy, because we connection establishement has several stages:

 - Fetch endpoint URLs from the server _or_ use an explicit endpoint.
 - Create a reusable TCP connector.
 - Connect to the server.

Because we want old methods on the clinet to keep working, I add layer in-between the new `ConnectionSource` trait, and the `Connector`, which is essentially just `TryInto<Arc<dyn Connector>>`, `ConnectorBuilder`.

This means that the flow is

 - `ConnectionSource` accepts an endpoint URL and produces a `ConnectorBuilder`.
 - `ConnectorBuilder` creates a `Connector`.
 - `Connector` is reused each time we need to re-connect to create a `TcpConnection`.

In the future we might even want to be able to create a different type of `Connection`, but I would want us to look into how we can ensure that is still efficient, i.e. avoid boxing futures too much.

Currently this doesn't change much at all. It changes the signature for the client connect methods in a backwards compatible way, and it makes it possible to define custom connectors, but the real purpose of this change is to be able to add support for `ReverseConnect`.