### PR TITLE
Extract the subscription event loop

### DIFF
--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -156,6 +156,11 @@ pub mod services {
         SetPublishingMode, SetTriggering, TransferSubscriptions, TranslateBrowsePaths,
         UnregisterNodes, Write,
     };
+
+    /// Utilities for working with subscriptions.
+    pub mod subscriptions {
+        pub use crate::session::{PublishLimits, SubscriptionCache, SubscriptionEventLoopState};
+    }
 }
 
 pub use identity_token::{IdentityToken, IssuedTokenSource, IssuedTokenWrapper, Password};

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -60,13 +60,12 @@ pub use services::method::Call;
 pub use services::node_management::{AddNodes, AddReferences, DeleteNodes, DeleteReferences};
 pub use services::session::{ActivateSession, Cancel, CloseSession, CreateSession};
 use services::subscriptions::state::SubscriptionState;
-use services::subscriptions::PublishLimits;
 pub use services::subscriptions::{
     CreateMonitoredItems, CreateSubscription, DataChangeCallback, DeleteMonitoredItems,
     DeleteSubscriptions, EventCallback, ModifyMonitoredItems, ModifySubscription, MonitoredItem,
-    OnSubscriptionNotification, OnSubscriptionNotificationCore, Publish, Republish,
+    OnSubscriptionNotification, OnSubscriptionNotificationCore, Publish, PublishLimits, Republish,
     SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription, SubscriptionActivity,
-    SubscriptionCallbacks, TransferSubscriptions,
+    SubscriptionCache, SubscriptionCallbacks, SubscriptionEventLoopState, TransferSubscriptions,
 };
 pub use services::view::{
     Browse, BrowseNext, RegisterNodes, TranslateBrowsePaths, UnregisterNodes,

--- a/async-opcua-client/src/session/services/subscriptions/event_loop.rs
+++ b/async-opcua-client/src/session/services/subscriptions/event_loop.rs
@@ -1,11 +1,12 @@
 use std::{sync::Arc, time::Instant};
 
-use futures::{future::Either, stream::FuturesUnordered, Future, Stream, StreamExt};
+use futures::Stream;
 use opcua_types::StatusCode;
-use tracing::debug;
 
 use crate::{
-    session::{session_debug, session_error},
+    session::services::subscriptions::event_loop_state::{
+        SubscriptionCache, SubscriptionEventLoopState,
+    },
     Session,
 };
 
@@ -31,13 +32,6 @@ pub enum SubscriptionActivity {
 pub(crate) struct SubscriptionEventLoop {
     session: Arc<Session>,
     trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
-    last_external_trigger: Instant,
-    // This is true if the client has received BadTooManyPublishRequests
-    // and is waiting for a response before making further requests.
-    waiting_for_response: bool,
-    // This is true if the client has received a no_subscriptions response,
-    // and is waiting for a manual trigger or successful response before resuming publishing.
-    no_active_subscription: bool,
 }
 
 impl SubscriptionEventLoop {
@@ -53,154 +47,44 @@ impl SubscriptionEventLoop {
         session: Arc<Session>,
         trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
     ) -> Self {
-        let last_external_trigger = *trigger_publish_recv.borrow();
         Self {
-            last_external_trigger,
             trigger_publish_recv,
             session,
-            waiting_for_response: false,
-            no_active_subscription: false,
         }
     }
 
     /// Run the subscription event loop, returning a stream that produces
     /// [SubscriptionActivity] enums, reporting activity to the session event loop.
     pub(crate) fn run(self) -> impl Stream<Item = SubscriptionActivity> {
+        let session_ref = self.session.clone();
+
         futures::stream::unfold(
-            (self, FuturesUnordered::new()),
-            |(mut slf, mut futures)| async move {
-                // Store the next publish time, or None if there are no active subscriptions.
-                let mut next = slf.session.next_publish_time(false);
-                let mut recv: tokio::sync::watch::Receiver<Instant> =
-                    slf.trigger_publish_recv.clone();
-
-                let res = loop {
-                    // Future for the next periodic publish. We do not send publish requests
-                    // if there are no active subscriptions. In this case, simply return the
-                    // non-terminating future.
-                    let next_tick_fut = if let Some(next) = next {
-                        if slf.waiting_for_response && !futures.is_empty() {
-                            Either::Right(futures::future::pending::<()>())
-                        } else {
-                            Either::Left(tokio::time::sleep_until(next.into()))
-                        }
-                    } else {
-                        Either::Right(futures::future::pending::<()>())
-                    };
-
-                    // If FuturesUnordered is empty, it will immediately yield `None`. We don't
-                    // want that, so if it is empty we return the non-terminating future.
-                    let next_publish_fut = if futures.is_empty() {
-                        Either::Left(futures::future::pending())
-                    } else {
-                        Either::Right(futures.next())
-                    };
-
-                    tokio::select! {
-                        // Both internal ticks and external triggers result in publish requests.
-                        v = recv.wait_for(|i| i > &slf.last_external_trigger) => {
-                            if let Ok(v) = v {
-                                if !slf.waiting_for_response {
-                                    debug!("Sending publish due to external trigger");
-                                    // On an external trigger, we always publish.
-                                    futures.push(slf.static_publish());
-                                    next = slf.session.next_publish_time(true);
-                                    slf.last_external_trigger = *v;
-                                } else {
-                                    debug!("Skipping publish due BadTooManyPublishRequests");
-                                }
-                            }
-                            slf.no_active_subscription = false;
-                        }
-                        _ = next_tick_fut => {
-                            // Avoid publishing if there are too many inflight publish requests.
-                            if !slf.no_active_subscription && futures.len()
-                                < slf
-                                    .session
-                                    .publish_limits_watch_rx
-                                    .borrow()
-                                    .max_publish_requests
-                            {
-                                if !slf.waiting_for_response {
-                                    debug!("Sending publish due to internal tick");
-                                    futures.push(slf.static_publish());
-                                } else {
-                                    debug!("Skipping publish due BadTooManyPublishRequests");
-                                }
-                            }
-                            next = slf.session.next_publish_time(true);
-                        }
-                        res = next_publish_fut => {
-                            match res {
-                                Some(Ok(more_notifications)) => {
-                                    if more_notifications
-                                        || futures.len()
-                                            < slf
-                                                .session
-                                                .publish_limits_watch_rx
-                                                .borrow()
-                                                .min_publish_requests
-                                    {
-                                        if !slf.waiting_for_response {
-                                            debug!("Sending publish after receiving response");
-                                            futures.push(slf.static_publish());
-                                            // Set the last publish time to to avoid a buildup
-                                            // of publish requests if exhausting the queue takes
-                                            // more time than a single publishing interval.
-                                            slf.session.next_publish_time(true);
-                                        } else {
-                                            debug!("Skipping publish due BadTooManyPublishRequests");
-                                        }
-                                    }
-                                    slf.waiting_for_response = false;
-                                    slf.no_active_subscription = false;
-                                    break SubscriptionActivity::Publish
-                                }
-                                Some(Err(e)) => {
-                                    match e {
-                                        StatusCode::BadTimeout => {
-                                            session_debug!(slf.session, "Publish request timed out");
-                                        }
-                                        StatusCode::BadTooManyPublishRequests => {
-                                            session_debug!(
-                                                slf.session,
-                                                "Server returned BadTooManyPublishRequests, backing off",
-                                            );
-                                            slf.waiting_for_response = true;
-                                        }
-                                        StatusCode::BadSessionClosed
-                                        | StatusCode::BadSessionIdInvalid => {
-                                            // If this happens we will probably eventually fail keep-alive, defer to that.
-                                            session_error!(slf.session, "Publish response indicates session is dead");
-                                            break SubscriptionActivity::FatalFailure(e);
-                                        }
-                                        StatusCode::BadNoSubscription => {
-                                            session_debug!(
-                                                slf.session,
-                                                "Publish response indicates that there are no subscriptions"
-                                            );
-                                            slf.no_active_subscription = true;
-                                        },
-                                        _ => ()
-                                    }
-                                    break SubscriptionActivity::PublishFailed(e)
-                                }
-                                // Should be impossible.
-                                None => break SubscriptionActivity::PublishFailed(
-                                    StatusCode::BadInvalidState,
-                                )
-                            }
-                        }
-                    }
-                };
-
-                Some((res, (slf, futures)))
+            SubscriptionEventLoopState::new(
+                self.session.session_id(),
+                self.trigger_publish_recv,
+                self.session.publish_limits_watch_rx.clone(),
+                move || {
+                    let session = session_ref.clone();
+                    async move { session.publish().await }
+                },
+                SessionSubscriptionCache {
+                    inner: self.session.clone(),
+                },
+            ),
+            |mut state| async move {
+                let res = state.iter_loop().await;
+                Some((res, state))
             },
         )
     }
+}
 
-    fn static_publish(&self) -> impl Future<Output = Result<bool, StatusCode>> + 'static {
-        let inner_session = self.session.clone();
-        async move { inner_session.publish().await }
+struct SessionSubscriptionCache {
+    inner: Arc<Session>,
+}
+
+impl SubscriptionCache for SessionSubscriptionCache {
+    fn next_publish_time(&mut self, update: bool) -> Option<Instant> {
+        self.inner.next_publish_time(update)
     }
 }

--- a/async-opcua-client/src/session/services/subscriptions/event_loop_state.rs
+++ b/async-opcua-client/src/session/services/subscriptions/event_loop_state.rs
@@ -1,0 +1,216 @@
+use std::{future::Future, time::Instant};
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use opcua_types::StatusCode;
+use tokio::{select, sync::watch::Receiver};
+use tracing::debug;
+
+use crate::{
+    session::{services::subscriptions::PublishLimits, session_debug, session_error},
+    SubscriptionActivity,
+};
+
+/// A trait for managing subscription state in the event loop.
+///
+/// This is just a handle to something that track subscriptions,
+/// letting us query when the next publish should be sent.
+pub trait SubscriptionCache {
+    /// Get and update the time for the next publish. If `set_last_publish` is true,
+    /// the last publish time is updated to now, affecting future calls to this method.
+    fn next_publish_time(&mut self, set_last_publish: bool) -> Option<Instant>;
+}
+
+/// The state machine for the subscription event loop.
+///
+/// This is made generic and removed from the subscription event loop to make it
+/// possible for users to implement their own event loop that doesn't depend on the
+/// `Session`, which can allow for several useful features that we are unlikely to implement
+/// in the `Session` itself, such as:
+///
+///  - Backpressure, letting users replace the `publish` implementation with one that
+///    waits for the consumer to be ready before passing the publish response to the
+///    event loop.
+///  - Custom subscription caches, for example for persisting subscription state.
+pub struct SubscriptionEventLoopState<T, R, S> {
+    trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
+    futures: FuturesUnordered<T>,
+    last_external_trigger: Instant,
+    // This is true if the client has received BadTooManyPublishRequests
+    // and is waiting for a response before making further requests.
+    waiting_for_response: bool,
+    // This is true if the client has received a no_subscriptions response,
+    // and is waiting for a manual trigger or successful response before resuming publishing.
+    no_active_subscription: bool,
+    /// Receiver for publish limits updates
+    publish_limits_rx: Receiver<PublishLimits>,
+    publish_source: R,
+    subscription_cache: S,
+    session_id: u32,
+}
+
+enum ActivityOrNext {
+    Activity(SubscriptionActivity),
+    Next(Option<Instant>),
+}
+
+impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: SubscriptionCache>
+    SubscriptionEventLoopState<T, R, S>
+{
+    /// Construct a new subscription cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The session id for logging purposes.
+    /// * `trigger_publish_recv` - A channel used to transmit external publish triggers.
+    ///   This is used to trigger publish outside of the normal schedule, for example when
+    ///   a new subscription is created.
+    /// * `publish_limits_rx` - A channel used to receive updates to publish limits.
+    /// * `publish_source` - A function that produces a future that performs a publish operation.
+    /// * `subscription_cache` - An implementation of the [SubscriptionCache] trait.
+    pub fn new(
+        session_id: u32,
+        trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
+        publish_limits_rx: Receiver<PublishLimits>,
+        publish_source: R,
+        subscription_cache: S,
+    ) -> Self {
+        let last_external_trigger = *trigger_publish_recv.borrow();
+        Self {
+            last_external_trigger,
+            trigger_publish_recv,
+            futures: FuturesUnordered::new(),
+            waiting_for_response: false,
+            no_active_subscription: true,
+            publish_limits_rx,
+            publish_source,
+            subscription_cache,
+            session_id,
+        }
+    }
+
+    fn wait_for_next_tick(
+        &self,
+        next_publish: Option<Instant>,
+    ) -> impl Future<Output = ()> + 'static {
+        // Deliberately create a future that doesn't capture `self` at all.
+        let should_wait_for_response = self.waiting_for_response && !self.futures.is_empty();
+        async move {
+            if should_wait_for_response {
+                futures::future::pending().await
+            } else if let Some(next_publish) = next_publish {
+                tokio::time::sleep_until(next_publish.into()).await;
+            } else {
+                futures::future::pending().await
+            }
+        }
+    }
+
+    async fn wait_for_next_publish(&mut self) -> Result<bool, StatusCode> {
+        if self.futures.is_empty() {
+            futures::future::pending().await
+        } else {
+            self.futures
+                .next()
+                .await
+                .unwrap_or(Err(StatusCode::BadInvalidState))
+        }
+    }
+
+    fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    /// Run an iteration of the event loop, returning each time a publish message is received.
+    pub async fn iter_loop(&mut self) -> SubscriptionActivity {
+        let mut next = self.subscription_cache.next_publish_time(false);
+        let mut recv = self.trigger_publish_recv.clone();
+        loop {
+            match self.tick(next, &mut recv).await {
+                ActivityOrNext::Activity(a) => return a,
+                ActivityOrNext::Next(n) => next = n,
+            }
+        }
+    }
+
+    async fn tick(
+        &mut self,
+        mut next_publish: Option<Instant>,
+        recv: &mut Receiver<Instant>,
+    ) -> ActivityOrNext {
+        let last_external_trigger = self.last_external_trigger;
+        select! {
+            v = recv.wait_for(|i| i > &last_external_trigger) => {
+                if let Ok(v) = v {
+                    if !self.waiting_for_response {
+                        debug!("Sending publish due to external trigger");
+                        // On an external trigger, we always publish.
+                        self.futures.push((self.publish_source)());
+                        next_publish = self.subscription_cache.next_publish_time(true);
+                        self.last_external_trigger = *v;
+                    } else {
+                        debug!("Skipping publish due BadTooManyPublishRequests");
+                    }
+                }
+                self.no_active_subscription = false;
+                ActivityOrNext::Next(next_publish)
+            }
+            _ = self.wait_for_next_tick(next_publish) => ActivityOrNext::Next(next_publish),
+            res = self.wait_for_next_publish() => {
+                match res {
+                    Ok(more_notifications) => {
+                        if more_notifications
+                            || self.futures.len()
+                                < self
+                                    .publish_limits_rx
+                                    .borrow()
+                                    .min_publish_requests
+                        {
+                            if !self.waiting_for_response {
+                                debug!("Sending publish after receiving response");
+                                self.futures.push((self.publish_source)());
+                                // Set the last publish time to to avoid a buildup
+                                // of publish requests if exhausting the queue takes
+                                // more time than a single publishing interval.
+                                self.subscription_cache.next_publish_time(true);
+                            } else {
+                                debug!("Skipping publish due BadTooManyPublishRequests");
+                            }
+                        }
+                        self.waiting_for_response = false;
+                        self.no_active_subscription = false;
+                        ActivityOrNext::Activity(SubscriptionActivity::Publish)
+                    }
+                    Err(e) => {
+                        match e {
+                            StatusCode::BadTimeout => {
+                                session_debug!(self, "Publish request timed out");
+                            }
+                            StatusCode::BadTooManyPublishRequests => {
+                                session_debug!(
+                                    self,
+                                    "Server returned BadTooManyPublishRequests, backing off",
+                                );
+                                self.waiting_for_response = true;
+                            }
+                            StatusCode::BadSessionClosed
+                            | StatusCode::BadSessionIdInvalid => {
+                                // If this happens we will probably eventually fail keep-alive, defer to that.
+                                session_error!(self, "Publish response indicates session is dead");
+                                return ActivityOrNext::Activity(SubscriptionActivity::FatalFailure(e))
+                            }
+                            StatusCode::BadNoSubscription => {
+                                session_debug!(
+                                    self,
+                                    "Publish response indicates that there are no subscriptions"
+                                );
+                                self.no_active_subscription = true;
+                            },
+                            _ => ()
+                        }
+                        ActivityOrNext::Activity(SubscriptionActivity::PublishFailed(e))
+                    }
+                }
+            },
+        }
+    }
+}

--- a/async-opcua-client/src/session/services/subscriptions/mod.rs
+++ b/async-opcua-client/src/session/services/subscriptions/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod event_loop;
 pub use event_loop::SubscriptionActivity;
 
 mod callbacks;
+mod event_loop_state;
 mod service;
 pub(crate) mod state;
 
@@ -22,6 +23,8 @@ pub use service::{
     ModifyMonitoredItems, ModifySubscription, Publish, Republish, SetMonitoringMode,
     SetPublishingMode, SetTriggering, TransferSubscriptions,
 };
+
+pub use event_loop_state::{SubscriptionCache, SubscriptionEventLoopState};
 
 pub(crate) struct CreateMonitoredItem {
     pub id: u32,
@@ -349,7 +352,9 @@ impl<'a> MonitoredItemMap<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) struct PublishLimits {
+/// Limits for publish requests, calculated based on the number of subscriptions
+/// and the expected publish interval and message roundtrip time.
+pub struct PublishLimits {
     message_roundtrip: Duration,
     publish_interval: Duration,
     subscriptions: usize,


### PR DESCRIPTION
Another slightly weird feature that I want for some stuff I'm working on. One thing I'm increasingly looking at is having ways to create "advanced" clients using the SDK without relying on the `Session` directly.

A barrier to that is the subscription event loop. It's challenging to implement yourself, and we will likely iterate on it in the future as well, meaning that implementations are likely to get out of sync without noticing.

This PR pulls most of the event loop out into a separate file using generics, so that users could define their own event loop, with other ways to make publish requests. This would also let us make small modifications to make the event loop more modular and configurable.

As a side-benefit, it also splits the very large subscription event loop function up a bit, and makes the state a bit more explict, which is probably a good thing.