### PR TITLE
chore(codegen): correct `file` key in sample config

### DIFF
--- a/async-opcua-codegen/sample_codegen_config.yml
+++ b/async-opcua-codegen/sample_codegen_config.yml
@@ -109,7 +109,7 @@ targets:
     # List of XML files to load types from.
     types:
         # This can be a path, filename, or primary namespace URI.
-      - source: schemas/MySchema.Types.xsd
+      - file: schemas/MySchema.Types.xsd
         # Rust path to import these types from.
         root_path: crate::types
     # Name of the generated module.


### PR DESCRIPTION
Fixes the sample config to be in line with the [struct](https://github.com/FreeOpcUa/async-opcua/blob/master/async-opcua-codegen/src/nodeset/mod.rs#L38) that it gets parsed into.