### PR TITLE
Fix available sequence numbers empty.

### DIFF
--- a/async-opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/async-opcua-server/src/subscriptions/session_subscriptions.rs
@@ -644,8 +644,6 @@ impl SessionSubscriptions {
         {
             let is_last = idx == num_responses - 1;
 
-            let available_sequence_numbers = self.available_sequence_numbers(subscription_id);
-
             if self.retransmission_queue.len() >= self.max_publish_requests() * 2 {
                 self.retransmission_queue.pop_front();
             }
@@ -653,6 +651,11 @@ impl SessionSubscriptions {
                 message: notification.clone(),
                 subscription_id,
             });
+
+            // Take note of the available sequence numbers after we have added the NonAckedPublish
+            // to the list. This makes sure that the available sequence numbers list is not empty and contains
+            // the NonAckedPublish we just added.
+            let available_sequence_numbers = self.available_sequence_numbers(subscription_id);
 
             let _ = publish_request.response.send(
                 PublishResponse {


### PR DESCRIPTION
UAExpert shows the following issue:
<img width="1310" height="155" alt="image" src="https://github.com/user-attachments/assets/766c6e13-f368-4937-9c98-50728d342e61" />

If you look at the Wireshark trace this is indeed correct. AvailableSequenceNumbers is indeed empty:
<img width="609" height="407" alt="image" src="https://github.com/user-attachments/assets/7abfa7c4-9c5a-41b8-b6e9-b3c3d930e581" />

This PR moves the calculation of the available sequence numbers until after we have added the `NonAckedPublish` of the current `PublishRequest`. This means that this list can never be empty. I can not find the exact place in the OPC UA standard that mentions this functionality, but I do see that e.g. `node-opcua` does it [this way](https://github.com/node-opcua/node-opcua/blob/e0a948ac5379ae8d9cc8200a1b4a31515a35be37/packages/node-opcua-server/source/server_subscription.ts#L1422)
