### PR TITLE
chore: publish MonitoredItemMap to allow implementing OnSubscriptionNotificationCore in client crates

### DIFF
--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -125,7 +125,7 @@ pub use config::{ClientConfig, ClientEndpoint, ClientUserToken, ANONYMOUS_USER_T
 pub use retry::{ExponentialBackoff, SessionRetryPolicy};
 pub use session::{
     Client, ConnectionSource, DataChangeCallback, DefaultRetryPolicy, DirectConnectionSource,
-    EventCallback, HistoryReadAction, HistoryUpdateAction, MonitoredItem,
+    EventCallback, HistoryReadAction, HistoryUpdateAction, MonitoredItem, MonitoredItemMap,
     OnSubscriptionNotification, OnSubscriptionNotificationCore, RequestRetryPolicy, Session,
     SessionActivity, SessionBuilder, SessionConnectMode, SessionEventLoop, SessionPollResult,
     Subscription, SubscriptionActivity, SubscriptionCallbacks, UARequest,

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -63,9 +63,9 @@ use services::subscriptions::state::SubscriptionState;
 pub use services::subscriptions::{
     CreateMonitoredItems, CreateSubscription, DataChangeCallback, DeleteMonitoredItems,
     DeleteSubscriptions, EventCallback, ModifyMonitoredItems, ModifySubscription, MonitoredItem,
-    OnSubscriptionNotification, OnSubscriptionNotificationCore, Publish, PublishLimits, Republish,
-    SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription, SubscriptionActivity,
-    SubscriptionCache, SubscriptionCallbacks, SubscriptionEventLoopState, TransferSubscriptions,
+    MonitoredItemMap, OnSubscriptionNotification, OnSubscriptionNotificationCore, Publish, PublishLimits,
+    Republish, SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription,
+    SubscriptionActivity, SubscriptionCache, SubscriptionCallbacks, SubscriptionEventLoopState, TransferSubscriptions,
 };
 pub use services::view::{
     Browse, BrowseNext, RegisterNodes, TranslateBrowsePaths, UnregisterNodes,

--- a/async-opcua-client/src/session/services/subscriptions/mod.rs
+++ b/async-opcua-client/src/session/services/subscriptions/mod.rs
@@ -344,6 +344,7 @@ impl<'a> MonitoredItemMap<'a> {
         }
     }
 
+    /// get monitored item by client handle
     pub fn get(&self, client_handle: u32) -> Option<&'a MonitoredItem> {
         self.client_handles
             .get(&client_handle)


### PR DESCRIPTION
Hi,

thank you for this very nice crate!

I just bumped upon a minor problem - I need to batch the updates from OPC/UA server and push Vec of them into message queue.

If I understand it correctly, it's required to implement `trait OnSubscriptionNotificationCore`.

That's straightforward, but `struct MonitoredItemMap` referenced in `fn on_subscription_notification` is not public,
so it's impossible to implement the trait.

So please accept this tiny PR.