### PR TITLE
Support dependent nodesets for types codegen

### DIFF
--- a/async-opcua-codegen/sample_codegen_config.yml
+++ b/async-opcua-codegen/sample_codegen_config.yml
@@ -92,6 +92,11 @@ targets:
     # This is useful if the nodeset lacks node ID CSV files, or those files are incomplete.
     node_ids_from_nodeset: false
 
+    dependent_nodesets:
+      # This can be a path, filename, or primary namespace URI.
+      - file: Another.Namespace.Uri
+        import_path: crate::generated::another_namespace
+
   # This target generates code to generate nodes that are added to the server address space.
   # Each node in the NodeSet2 file creates a function, which is then called from
   # a large iterator that can be used as a a node set source.

--- a/async-opcua-codegen/src/input/nodeset.rs
+++ b/async-opcua-codegen/src/input/nodeset.rs
@@ -31,6 +31,7 @@ pub struct RawEncodingIds {
 #[derive(Debug, Clone)]
 pub struct TypeInfo {
     pub name: String,
+    pub namespace: String,
     pub is_abstract: bool,
     pub definition: Option<DataTypeDefinition>,
     pub encoding_ids: RawEncodingIds,
@@ -346,6 +347,7 @@ impl NodeSetInput {
                             is_abstract: data_type.base.is_abstract,
                             definition: data_type.definition.clone(),
                             encoding_ids,
+                            namespace: self.uri.clone(),
                         },
                     );
                 }

--- a/async-opcua-codegen/src/types/loaders/binary_schema.rs
+++ b/async-opcua-codegen/src/types/loaders/binary_schema.rs
@@ -51,7 +51,10 @@ impl<'a> BsdTypeLoader<'a> {
     fn get_field_type(field: &str) -> FieldType {
         match field {
             "ExtensionObject" | "OptionSet" => FieldType::ExtensionObject(None),
-            _ => FieldType::Normal(field.to_owned()),
+            _ => FieldType::Normal {
+                name: field.to_owned(),
+                namespace: None,
+            },
         }
     }
 
@@ -114,7 +117,10 @@ impl<'a> BsdTypeLoader<'a> {
                 Some("ua:ExtensionObject" | "ua:OptionSet") => {
                     Some(FieldType::ExtensionObject(None))
                 }
-                Some(base) => Some(FieldType::Normal(self.massage_type_name(base))),
+                Some(base) => Some(FieldType::Normal {
+                    name: self.massage_type_name(base),
+                    namespace: Some(self.target_namespace()),
+                }),
                 None => None,
             },
             is_union: false,

--- a/async-opcua-codegen/src/types/loaders/nodeset.rs
+++ b/async-opcua-codegen/src/types/loaders/nodeset.rs
@@ -5,7 +5,7 @@ use opcua_xml::schema::ua_node_set::{DataTypeField, LocalizedText, UADataType, U
 use crate::{
     input::{NodeSetInput, SchemaCache, TypeInfo},
     utils::{split_qualified_name, to_snake_case, NodeIdVariant, ParsedNodeId},
-    CodeGenError,
+    CodeGenError, BASE_NAMESPACE,
 };
 
 use super::{
@@ -67,7 +67,10 @@ impl<'a> NodeSetTypeLoader<'a> {
         } else if info.name == "Structure" || info.name == "OptionSet" {
             FieldType::ExtensionObject(Some(info.encoding_ids))
         } else {
-            FieldType::Normal(info.name)
+            FieldType::Normal {
+                name: info.name,
+                namespace: Some(info.namespace),
+            }
         }
     }
 
@@ -283,6 +286,7 @@ impl<'a> NodeSetTypeLoader<'a> {
                 is_abstract: false,
                 definition: None,
                 encoding_ids: Default::default(),
+                namespace: BASE_NAMESPACE.to_owned(),
             })
         } else {
             Ok(r)

--- a/async-opcua-codegen/src/types/loaders/types.rs
+++ b/async-opcua-codegen/src/types/loaders/types.rs
@@ -18,14 +18,24 @@ pub struct StructureField {
 pub enum FieldType {
     Abstract(#[allow(unused)] String),
     ExtensionObject(Option<RawEncodingIds>),
-    Normal(String),
+    Normal {
+        name: String,
+        namespace: Option<String>,
+    },
 }
 
 impl FieldType {
     pub fn as_type_str(&self) -> &str {
         match self {
             FieldType::Abstract(_) | FieldType::ExtensionObject(_) => "ExtensionObject",
-            FieldType::Normal(s) => s,
+            FieldType::Normal { name, .. } => name,
+        }
+    }
+
+    pub fn namespace(&self) -> Option<&str> {
+        match self {
+            FieldType::Normal { namespace, .. } => namespace.as_deref(),
+            _ => None,
         }
     }
 }

--- a/codegen-tests/build.rs
+++ b/codegen-tests/build.rs
@@ -7,18 +7,34 @@ use opcua_codegen::{CodeGenConfig, CodeGenSource, CodeGenTarget, TypeCodeGenTarg
 fn main() {
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let target_dir = format!("{}/opcua_generated", out_dir);
+    println!("cargo:rerun-if-changed=schemas/Async.Opcua.Test.NodeSet2.xml");
+    println!("cargo:rerun-if-changed=schemas/Async.Opcua.Test.Ext.NodeSet2.xml");
     println!("cargo:rustc-env=OPCUA_GENERATED_DIR={}", target_dir);
     run_codegen(
         &CodeGenConfig {
-            targets: vec![CodeGenTarget::Types(TypeCodeGenTarget {
-                file: "Async.Opcua.Test.NodeSet2.xml".to_owned(),
-                output_dir: target_dir,
-                enums_single_file: true,
-                structs_single_file: true,
-                node_ids_from_nodeset: true,
-                default_excluded: ["SimpleEnum".to_string()].into_iter().collect(),
-                ..Default::default()
-            })],
+            targets: vec![
+                CodeGenTarget::Types(TypeCodeGenTarget {
+                    file: "Async.Opcua.Test.NodeSet2.xml".to_owned(),
+                    output_dir: format!("{}/base", target_dir),
+                    enums_single_file: true,
+                    structs_single_file: true,
+                    node_ids_from_nodeset: true,
+                    default_excluded: ["SimpleEnum".to_string()].into_iter().collect(),
+                    ..Default::default()
+                }),
+                CodeGenTarget::Types(TypeCodeGenTarget {
+                    file: "Async.Opcua.Test.Ext.NodeSet2.xml".to_owned(),
+                    output_dir: format!("{}/ext", target_dir),
+                    enums_single_file: true,
+                    structs_single_file: true,
+                    node_ids_from_nodeset: true,
+                    dependent_nodesets: vec![opcua_codegen::DependentNodeset {
+                        file: "Async.Opcua.Test.NodeSet2.xml".to_owned(),
+                        import_path: "crate::generated::base".to_owned(),
+                    }],
+                    ..Default::default()
+                }),
+            ],
             sources: vec![
                 CodeGenSource::Implicit("./schemas".to_owned()),
                 CodeGenSource::Implicit("../schemas/1.05".to_owned()),

--- a/codegen-tests/schemas/Async.Opcua.Test.Ext.NodeSet2.xml
+++ b/codegen-tests/schemas/Async.Opcua.Test.Ext.NodeSet2.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" LastModified="2025-09-30T00:00:00Z" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+    <NamespaceUris>
+        <Uri>http://github.com/freeopcua/async-opcua/codegen-tests</Uri>
+        <Uri>http://github.com/freeopcua/async-opcua/codegen-tests/ext</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://github.com/freeopcua/async-opcua/codegen-tests/ext" Version="1.0.1" PublicationDate="2021-04-13T00:00:00Z">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.5.4" PublicationDate="2025-01-08T00:00:00Z" />
+            <RequiredModel ModelUri="http://github.com/freeopcua/async-opcua/codegen-tests" Version="1.0.1" PublicationDate="2021-04-13T00:00:00Z" />
+        </Model>
+    </Models>
+    <Aliases>
+        <Alias Alias="Boolean">i=1</Alias>
+        <Alias Alias="SByte">i=2</Alias>
+        <Alias Alias="Byte">i=3</Alias>
+        <Alias Alias="Int16">i=4</Alias>
+        <Alias Alias="UInt16">i=5</Alias>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="UInt32">i=7</Alias>
+        <Alias Alias="Int64">i=8</Alias>
+        <Alias Alias="UInt64">i=9</Alias>
+        <Alias Alias="Float">i=10</Alias>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="DateTime">i=13</Alias>
+        <Alias Alias="String">i=12</Alias>
+        <Alias Alias="ByteString">i=15</Alias>
+        <Alias Alias="Guid">i=14</Alias>
+        <Alias Alias="XmlElement">i=16</Alias>
+        <Alias Alias="NodeId">i=17</Alias>
+        <Alias Alias="ExpandedNodeId">i=18</Alias>
+        <Alias Alias="QualifiedName">i=20</Alias>
+        <Alias Alias="LocalizedText">i=21</Alias>
+        <Alias Alias="StatusCode">i=19</Alias>
+        <Alias Alias="Structure">i=22</Alias>
+        <Alias Alias="Number">i=26</Alias>
+        <Alias Alias="Integer">i=27</Alias>
+        <Alias Alias="UInteger">i=28</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="HasProperty">i=46</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasEventSource">i=36</Alias>
+        <Alias Alias="HasNotifier">i=48</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+        <Alias Alias="HasDescription">i=39</Alias>
+        <Alias Alias="EnumValueType">i=7594</Alias>
+    </Aliases>
+
+    <!-- A struct that depends on the other nodeset -->
+    <UADataType NodeId="ns=2;i=1" BrowseName="1:ExtStruct">
+        <DisplayName>ExtStruct</DisplayName>
+        <Documentation>A struct containing types from the base nodeset.</Documentation>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=2;i=1001</Reference>
+            <Reference ReferenceType="HasEncoding">ns=2;i=1011</Reference>
+            <Reference ReferenceType="HasEncoding">ns=2;i=1021</Reference>
+        </References>
+        <Definition Name="2:ExtStruct" SymbolicName="ExtStruct" BaseType="Structure">
+            <Field Name="Simple" DataType="ns=1;i=3" />
+            <Field Name="Extended" DataType="ns=1;i=4" />
+            <Field Name="Baz" DataType="Boolean" />
+            <Field Name="SimpleEnum" DataType="ns=1;i=1" />
+        </Definition>
+    </UADataType>
+    <UAObject NodeId="ns=2;i=1001" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject NodeId="ns=2;i=1011" BrowseName="Default XML" SymbolicName="DefaultXml">
+        <DisplayName>Default XML</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject NodeId="ns=2;i=1021" BrowseName="Default JSON" SymbolicName="DefaultJson">
+        <DisplayName>Default JSON</DisplayName>
+            <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+</UANodeSet>

--- a/codegen-tests/src/lib.rs
+++ b/codegen-tests/src/lib.rs
@@ -3,10 +3,15 @@
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::derivable_impls)]
 
-use crate::generated::SimpleEnum;
+use crate::generated::base::SimpleEnum;
 
 pub mod generated {
-    include!(concat!(env!("OPCUA_GENERATED_DIR"), "/mod.rs"));
+    pub mod base {
+        include!(concat!(env!("OPCUA_GENERATED_DIR"), "/base/mod.rs"));
+    }
+    pub mod ext {
+        include!(concat!(env!("OPCUA_GENERATED_DIR"), "/ext/mod.rs"));
+    }
 }
 
 impl Default for SimpleEnum {

--- a/codegen-tests/src/tests/types.rs
+++ b/codegen-tests/src/tests/types.rs
@@ -21,14 +21,17 @@ use opcua::types::xml::XmlEncodable;
 use opcua::xml::XmlStreamReader;
 use opcua::xml::XmlStreamWriter;
 
-use crate::generated::enums::*;
-use crate::generated::structs::*;
+use crate::generated::base::enums::*;
+use crate::generated::base::structs::*;
+use crate::generated::ext::structs::*;
 
 fn ctx() -> ContextOwned {
     let mut namespaces = NamespaceMap::new();
     namespaces.add_namespace("http://github.com/freeopcua/async-opcua/codegen-tests");
+    namespaces.add_namespace("http://github.com/freeopcua/async-opcua/codegen-tests/ext");
     let mut loaders = TypeLoaderCollection::new();
-    loaders.add_type_loader(crate::generated::GeneratedTypeLoader);
+    loaders.add_type_loader(crate::generated::base::GeneratedTypeLoader);
+    loaders.add_type_loader(crate::generated::ext::GeneratedTypeLoader);
     let ctx_owned = ContextOwned::new(namespaces, loaders, DecodingOptions::default());
     ctx_owned
 }
@@ -191,6 +194,31 @@ fn test_container_struct() {
                 description: "Second unit".into(),
             },
         ]),
+    };
+    encoding_roundtrip_extension_object(s);
+}
+
+#[test]
+fn test_external_struct() {
+    let s = ExtStruct {
+        simple: SimpleStruct {
+            foo: "hello".into(),
+            bar: 42,
+            baz: true,
+            simple_enum: SimpleEnum::Bar,
+            numbers: Some(vec![1.0, 2.0, 3.0]),
+        },
+        extended: ExtendedStruct {
+            foo: "hello".into(),
+            bar: 42,
+            baz: true,
+            simple_enum: SimpleEnum::Bar,
+            numbers: Some(vec![1.0, 2.0, 3.0]),
+            bar_2: -12345,
+            foo_2: "world".into(),
+        },
+        baz: true,
+        simple_enum: SimpleEnum::Foo,
     };
     encoding_roundtrip_extension_object(s);
 }


### PR DESCRIPTION
This is a relatively simple implementation of this. Let users list dependent nodesets with import paths, like we allow for events. When actually generating the types, we store this as a map from namespace to import path, and during loading we just get the namespace of the type being loaded.

This only really works for nodeset2 files, but since there exists a workaround, this isn't critical. We can improve on this in the future.

With the codegen tests we can actually test stuff like this, which is quite nice.

This should fix #159.