### PR TITLE
Add methods to get config by reference in builder

### DIFF
--- a/async-opcua-client/src/builder.rs
+++ b/async-opcua-client/src/builder.rs
@@ -39,10 +39,18 @@ impl ClientBuilder {
         }
     }
 
+    /// Get a reference to the internal [`ClientConfig`].
+    pub fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
+    /// Get a mutable reference to the internal [`ClientConfig`].
+    pub fn config_mut(&mut self) -> &mut ClientConfig {
+        &mut self.config
+    }
+
     /// Yields a [`ClientConfig`] from the values set by the builder.
-    ///
-    /// [`ClientConfig`]: ../config/struct.ClientConfig.html
-    pub fn config(self) -> ClientConfig {
+    pub fn into_config(self) -> ClientConfig {
         self.config
     }
 

--- a/async-opcua-client/src/config.rs
+++ b/async-opcua-client/src/config.rs
@@ -702,7 +702,7 @@ mod tests {
     }
 
     fn default_sample_config() -> ClientConfig {
-        sample_builder().config()
+        sample_builder().into_config()
     }
 
     #[test]


### PR DESCRIPTION
Fixes #135. It does make more sense to have `config()` return a reference to the config, and rename the current method to `into_config`, which is what we use when we finally construct the client.