### PR TITLE
Update secure channel params earlier

### DIFF
--- a/async-opcua-client/src/transport/connect.rs
+++ b/async-opcua-client/src/transport/connect.rs
@@ -1,8 +1,9 @@
 use std::{future::Future, sync::Arc};
 
 use async_trait::async_trait;
-use opcua_core::{comms::secure_channel::SecureChannel, sync::RwLock};
 use opcua_types::{EndpointDescription, Error, StatusCode};
+
+use crate::transport::state::SecureChannelState;
 
 use super::{
     tcp::{TcpTransport, TransportConfiguration},
@@ -23,7 +24,7 @@ pub trait Connector: Send + Sync {
     /// calling `run` on the returned transport in order to actually send and receive messages.
     async fn connect(
         &self,
-        channel: Arc<RwLock<SecureChannel>>,
+        channel: Arc<SecureChannelState>,
         outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
         config: TransportConfiguration,
     ) -> Result<TcpTransport, StatusCode>;


### PR DESCRIPTION
Issue #175 is likely caused by a race condition, which happens because we don't update the secure channel until we've received the response over the oneshot channel from the transport.

This fixes that by giving the transport access to the secure channel state directly, and calling `end_issue_or_renew_secure_channel` there instead of as part of sending the request.

Nothing else has really changed, we still hold a lock while renewing the channel, this just makes it so that there is no way we can receive any more chunks before the secure channel has been updated.

I noticed when doing this that we hold a write lock on the secure channel which we almost never need. I'd like us to fix that, at some point.

Confirmed: this fixes #175.