### PR TITLE
Add a convenient type for ValueRank.

### DIFF
--- a/async-opcua-types/src/lib.rs
+++ b/async-opcua-types/src/lib.rs
@@ -277,7 +277,9 @@ pub mod response_header;
 pub mod status_code;
 pub mod string;
 pub mod type_loader;
+pub mod value_rank;
 pub mod variant;
+
 #[cfg(feature = "xml")]
 pub mod xml;
 

--- a/async-opcua-types/src/value_rank.rs
+++ b/async-opcua-types/src/value_rank.rs
@@ -1,0 +1,78 @@
+//! Convenient implementation of the `ValueRank` type in OPC-UA,
+//! representing the rank of an OPC-UA variable.
+
+use crate::{IntoVariant, Variant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A representation of the ValueRank type in OPC-UA.
+///
+/// ValueRank indicates the number of dimensions a variable has.
+///
+///  - A ValueRank of -1 indicates a scalar value.
+///  - A ValueRank of 0 indicates one or more dimensions.
+///  - A ValueRank of -2 indicates any value rank.
+///  - A ValueRank of -3 indicates a scalar or one dimensional array.
+///  - A ValueRank of n (n >= 1) indicates exactly n dimensions.
+pub struct ValueRank(i32);
+
+impl From<i32> for ValueRank {
+    fn from(value: i32) -> Self {
+        if value < -3 {
+            return ValueRank::ANY;
+        }
+        ValueRank(value)
+    }
+}
+
+impl From<ValueRank> for i32 {
+    fn from(value: ValueRank) -> Self {
+        value.0
+    }
+}
+
+impl IntoVariant for ValueRank {
+    fn into_variant(self) -> Variant {
+        Variant::Int32(self.0)
+    }
+}
+
+impl ValueRank {
+    /// ValueRank indicating a scalar value.
+    pub const SCALAR: ValueRank = ValueRank(-1);
+    /// ValueRank indicating one or more dimensions.
+    pub const ONE_OR_MORE_DIMENSIONS: ValueRank = ValueRank(0);
+    /// ValueRank indicating any value rank.
+    pub const ANY: ValueRank = ValueRank(-2);
+    /// ValueRank indicating a scalar or one dimensional array.
+    pub const SCALAR_OR_ONE_DIMENSION: ValueRank = ValueRank(-3);
+
+    /// Create a new ValueRank, returning None if the value is invalid.
+    pub fn new_checked(value: i32) -> Option<Self> {
+        if value < -3 {
+            None
+        } else {
+            Some(ValueRank(value))
+        }
+    }
+
+    /// Create a new ValueRank from an i32 value. If the value is invalid
+    /// (less than -3), it will be set to ANY.
+    pub fn new(value: i32) -> Self {
+        ValueRank::from(value)
+    }
+
+    /// Check if the ValueRank represents a scalar value.
+    pub fn is_scalar(&self) -> bool {
+        self == &ValueRank::SCALAR
+    }
+
+    /// Create a ValueRank inidicating exactly `n` dimensions.
+    pub fn n_dimensions(n: u32) -> Self {
+        ValueRank(n as i32)
+    }
+
+    /// Get the i32 representation of the ValueRank.
+    pub fn to_i32(self) -> i32 {
+        self.0
+    }
+}

--- a/samples/node-managers/src/node_managers/tags.rs
+++ b/samples/node-managers/src/node_managers/tags.rs
@@ -15,9 +15,9 @@ use opcua::{
     },
     sync::RwLock,
     types::{
-        AccessLevelExType, DataTypeId, DataValue, IdType, Identifier, LocalizedText, NodeClass,
-        NodeId, QualifiedName, ReferenceDescription, ReferenceTypeId, StatusCode,
-        TimestampsToReturn, VariableTypeId, Variant, WriteMask,
+        value_rank::ValueRank, AccessLevelExType, DataTypeId, DataValue, IdType, Identifier,
+        LocalizedText, NodeClass, NodeId, QualifiedName, ReferenceDescription, ReferenceTypeId,
+        StatusCode, TimestampsToReturn, VariableTypeId, Variant, WriteMask,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -492,7 +492,7 @@ impl TagNodeManager {
                     opcua::types::AttributeId::DataType => {
                         NodeId::from(tag.value.data_type()).into()
                     }
-                    opcua::types::AttributeId::ValueRank => (-1i32).into(),
+                    opcua::types::AttributeId::ValueRank => ValueRank::SCALAR.into(),
                     opcua::types::AttributeId::AccessLevel => {
                         AccessLevel::CURRENT_READ.bits().into()
                     }
@@ -534,9 +534,7 @@ impl TagNodeManager {
                     opcua::types::AttributeId::UserWriteMask => WriteMask::empty().bits().into(),
                     opcua::types::AttributeId::Value => meta.clone().into(),
                     opcua::types::AttributeId::DataType => NodeId::from(DataTypeId::String).into(),
-                    // TODO: Write a proper type for ValueRank. I messed up twice remembering what the
-                    // value for "scalar" was. Maybe a nice enum?
-                    opcua::types::AttributeId::ValueRank => (-1i32).into(),
+                    opcua::types::AttributeId::ValueRank => ValueRank::SCALAR.into(),
                     opcua::types::AttributeId::AccessLevel => {
                         AccessLevel::CURRENT_READ.bits().into()
                     }


### PR DESCRIPTION
This really _is_ just an integer on an OPC-UA type level, but it is convenient to have a wrapper around it, to make it easier and clearer to set the value rank of a variable explicitly.