### PR TITLE
Bump num-bigint-dig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "const-oid",
  "gethostname",
  "hmac",
+ "num-bigint-dig",
  "rand 0.8.5",
  "rsa",
  "serde",
@@ -1518,17 +1519,17 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
  "rand 0.8.5",
+ "serde",
  "smallvec",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures = "^0.3"
 gethostname = "^0.5"
 hashbrown = "^0.15"
 log = "^0.4"
+num-bigint-dig = "^0.8.6"
 parking_lot = { version = "^0.12", features = ["send_guard"] }
 postcard = { version = "^1", features = ["use-std"] }
 proc-macro2 = "^1"

--- a/async-opcua-crypto/Cargo.toml
+++ b/async-opcua-crypto/Cargo.toml
@@ -21,6 +21,7 @@ name = "opcua_crypto"
 [dependencies]
 chrono = { workspace = true }
 gethostname = { workspace = true }
+num-bigint-dig = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 


### PR DESCRIPTION
We're getting a future-incompatibility warning. Turns out we can just bump the dependency directly.