### PR TITLE
Respect dependent types in events codegen

### DIFF
--- a/async-opcua-codegen/src/nodeset/events/mod.rs
+++ b/async-opcua-codegen/src/nodeset/events/mod.rs
@@ -8,12 +8,18 @@ use gen::{EventGenerator, EventItem};
 use opcua_xml::schema::ua_node_set::UANodeSet;
 use syn::Item;
 
-use crate::{base_native_type_mappings, CodeGenError, GeneratedOutput, BASE_NAMESPACE};
+use crate::{
+    base_native_type_mappings, nodeset::XsdTypeWithPath, CodeGenError, GeneratedOutput,
+    BASE_NAMESPACE,
+};
 
 mod collector;
 mod gen;
 
-pub fn generate_events(nodesets: &[(&UANodeSet, &str)]) -> Result<Vec<EventItem>, CodeGenError> {
+pub fn generate_events(
+    nodesets: &[(&UANodeSet, &str)],
+    types: &HashMap<String, XsdTypeWithPath>,
+) -> Result<Vec<EventItem>, CodeGenError> {
     let mut pairs = Vec::new();
     let mut namespaces = Vec::new();
     namespaces.push(BASE_NAMESPACE.to_owned());
@@ -51,6 +57,7 @@ pub fn generate_events(nodesets: &[(&UANodeSet, &str)]) -> Result<Vec<EventItem>
 
     let gen = EventGenerator::new(
         collected,
+        types,
         &namespaces,
         base_native_type_mappings(),
         nodesets.len() - 1,

--- a/async-opcua-codegen/src/nodeset/gen.rs
+++ b/async-opcua-codegen/src/nodeset/gen.rs
@@ -29,7 +29,7 @@ pub struct NodeSetCodeGenerator<'a> {
     empty_text: LocalizedText,
     aliases: &'a HashMap<String, String>,
     node_counter: usize,
-    types: HashMap<String, XsdTypeWithPath>,
+    types: &'a HashMap<String, XsdTypeWithPath>,
     type_info: &'a HashMap<ParsedNodeId, TypeInfo>,
 }
 
@@ -37,7 +37,7 @@ impl<'a> NodeSetCodeGenerator<'a> {
     pub fn new(
         preferred_locale: &str,
         aliases: &'a HashMap<String, String>,
-        types: HashMap<String, XsdTypeWithPath>,
+        types: &'a HashMap<String, XsdTypeWithPath>,
         type_info: &'a HashMap<ParsedNodeId, TypeInfo>,
     ) -> Result<Self, CodeGenError> {
         Ok(Self {
@@ -268,7 +268,7 @@ impl<'a> NodeSetCodeGenerator<'a> {
         let data_type = self.resolve_node_id(&node.data_type)?;
         let historizing = node.historizing;
         let value_rank = node.value_rank.0;
-        let value = render_value(node.value.as_ref(), &self.types)?;
+        let value = render_value(node.value.as_ref(), self.types)?;
         let access_level = node.access_level.0;
         let user_access_level = node.user_access_level.0;
         let array_dimensions = self
@@ -337,7 +337,7 @@ impl<'a> NodeSetCodeGenerator<'a> {
         let data_type = self.resolve_node_id(&node.data_type)?;
         let is_abstract = node.base.is_abstract;
         let value_rank = node.value_rank.0;
-        let value = render_value(node.value.as_ref(), &self.types)?;
+        let value = render_value(node.value.as_ref(), self.types)?;
         let array_dimensions = self
             .parse_array_dimensions(&node.array_dimensions)?
             .as_ref()

--- a/async-opcua-codegen/src/nodeset/mod.rs
+++ b/async-opcua-codegen/src/nodeset/mod.rs
@@ -81,7 +81,7 @@ pub struct EventsTarget {
 }
 
 /// Create a map of type name to type definition from the given codegen target.
-fn make_type_dict(
+pub fn make_type_dict(
     target: &NodeSetCodeGenTarget,
     cache: &SchemaCache,
 ) -> Result<HashMap<String, XsdTypeWithPath>, CodeGenError> {
@@ -176,9 +176,8 @@ pub fn generate_target(
     config: &NodeSetCodeGenTarget,
     input: &NodeSetInput,
     preferred_locale: &str,
-    cache: &SchemaCache,
+    types: &HashMap<String, XsdTypeWithPath>,
 ) -> Result<Vec<NodeSetChunk>, CodeGenError> {
-    let types = make_type_dict(config, cache)?;
     let type_info = input.get_type_names()?;
 
     let mut generator =

--- a/async-opcua-core-namespace/src/events/generated.rs
+++ b/async-opcua-core-namespace/src/events/generated.rs
@@ -11,8 +11,6 @@ mod opcua {
     pub(super) use opcua_nodes::{Event, EventField};
     pub(super) use opcua_types as types;
 }
-#[allow(unused)]
-use opcua_types as types;
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2881")]
 pub struct AcknowledgeableConditionType {
@@ -36,16 +34,16 @@ pub struct AlarmConditionType {
     pub first_in_group: AlarmGroupType,
     pub first_in_group_flag: bool,
     pub get_group_memberships: opcua::nodes::MethodEventField,
-    pub input_node: types::NodeId,
+    pub input_node: opcua::types::NodeId,
     pub latched_state: TwoStateVariableType,
-    pub max_time_shelved: types::Duration,
-    pub off_delay: types::Duration,
-    pub on_delay: types::Duration,
+    pub max_time_shelved: opcua::types::Duration,
+    pub off_delay: opcua::types::Duration,
+    pub on_delay: opcua::types::Duration,
     pub out_of_service_state: TwoStateVariableType,
     pub place_in_service: opcua::nodes::MethodEventField,
     pub place_in_service_2: opcua::nodes::MethodEventField,
     pub re_alarm_repeat_count: i16,
-    pub re_alarm_time: types::Duration,
+    pub re_alarm_time: opcua::types::Duration,
     pub remove_from_service: opcua::nodes::MethodEventField,
     pub remove_from_service_2: opcua::nodes::MethodEventField,
     pub reset: opcua::nodes::MethodEventField,
@@ -69,7 +67,7 @@ pub struct AlarmGroupType {
 #[derive(Debug, opcua::EventField, Default)]
 pub struct AudioVariableType {
     pub node_id: opcua::types::NodeId,
-    pub value: types::AudioDataType,
+    pub value: opcua::types::AudioDataType,
     pub agency_id: opcua::types::UAString,
     pub list_id: opcua::types::UAString,
     pub version_id: opcua::types::UAString,
@@ -78,8 +76,8 @@ pub struct AudioVariableType {
 #[opcua(identifier = "i=2075")]
 pub struct AuditActivateSessionEventType {
     pub base: AuditSessionEventType,
-    pub client_software_certificates: types::SignedSoftwareCertificate,
-    pub current_role_ids: types::NodeId,
+    pub client_software_certificates: opcua::types::SignedSoftwareCertificate,
+    pub current_role_ids: opcua::types::NodeId,
     pub secure_channel_id: opcua::types::UAString,
     pub user_identity_token: opcua::types::ExtensionObject,
 }
@@ -87,13 +85,13 @@ pub struct AuditActivateSessionEventType {
 #[opcua(identifier = "i=2091")]
 pub struct AuditAddNodesEventType {
     pub base: AuditNodeManagementEventType,
-    pub nodes_to_add: types::AddNodesItem,
+    pub nodes_to_add: opcua::types::AddNodesItem,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2095")]
 pub struct AuditAddReferencesEventType {
     pub base: AuditNodeManagementEventType,
-    pub references_to_add: types::AddReferencesItem,
+    pub references_to_add: opcua::types::AddReferencesItem,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2078")]
@@ -112,7 +110,7 @@ pub struct AuditCertificateDataMismatchEventType {
 #[opcua(identifier = "i=2080")]
 pub struct AuditCertificateEventType {
     pub base: AuditSecurityEventType,
-    pub certificate: types::ByteString,
+    pub certificate: opcua::types::ByteString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2085")]
@@ -149,38 +147,38 @@ pub struct AuditChannelEventType {
 #[opcua(identifier = "i=23606")]
 pub struct AuditClientEventType {
     pub base: AuditEventType,
-    pub server_uri: types::UriString,
+    pub server_uri: opcua::types::UriString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=23926")]
 pub struct AuditClientUpdateMethodResultEventType {
     pub base: AuditClientEventType,
     pub input_arguments: opcua::types::ExtensionObject,
-    pub method_id: types::ExpandedNodeId,
-    pub object_id: types::ExpandedNodeId,
+    pub method_id: opcua::types::ExpandedNodeId,
+    pub object_id: opcua::types::ExpandedNodeId,
     pub output_arguments: opcua::types::ExtensionObject,
-    pub status_code_id: types::StatusCode,
+    pub status_code_id: opcua::types::StatusCode,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=8944")]
 pub struct AuditConditionAcknowledgeEventType {
     pub base: AuditConditionEventType,
-    pub comment: types::LocalizedText,
-    pub condition_event_id: types::ByteString,
+    pub comment: opcua::types::LocalizedText,
+    pub condition_event_id: opcua::types::ByteString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2829")]
 pub struct AuditConditionCommentEventType {
     pub base: AuditConditionEventType,
-    pub comment: types::LocalizedText,
-    pub condition_event_id: types::ByteString,
+    pub comment: opcua::types::LocalizedText,
+    pub condition_event_id: opcua::types::ByteString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=8961")]
 pub struct AuditConditionConfirmEventType {
     pub base: AuditConditionEventType,
-    pub comment: types::LocalizedText,
-    pub condition_event_id: types::ByteString,
+    pub comment: opcua::types::LocalizedText,
+    pub condition_event_id: opcua::types::ByteString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2803")]
@@ -212,7 +210,7 @@ pub struct AuditConditionRespondEventType {
 #[opcua(identifier = "i=11093")]
 pub struct AuditConditionShelvingEventType {
     pub base: AuditConditionEventType,
-    pub shelving_time: types::Duration,
+    pub shelving_time: opcua::types::Duration,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=17242")]
@@ -228,28 +226,28 @@ pub struct AuditConditionSuppressionEventType {
 #[opcua(identifier = "i=2071")]
 pub struct AuditCreateSessionEventType {
     pub base: AuditSessionEventType,
-    pub client_certificate: types::ByteString,
+    pub client_certificate: opcua::types::ByteString,
     pub client_certificate_thumbprint: opcua::types::UAString,
-    pub revised_session_timeout: types::Duration,
+    pub revised_session_timeout: opcua::types::Duration,
     pub secure_channel_id: opcua::types::UAString,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2093")]
 pub struct AuditDeleteNodesEventType {
     pub base: AuditNodeManagementEventType,
-    pub nodes_to_delete: types::DeleteNodesItem,
+    pub nodes_to_delete: opcua::types::DeleteNodesItem,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2097")]
 pub struct AuditDeleteReferencesEventType {
     pub base: AuditNodeManagementEventType,
-    pub references_to_delete: types::DeleteReferencesItem,
+    pub references_to_delete: opcua::types::DeleteReferencesItem,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2052")]
 pub struct AuditEventType {
     pub base: opcua::nodes::BaseEventType,
-    pub action_time_stamp: types::UtcTime,
+    pub action_time_stamp: opcua::types::UtcTime,
     pub client_audit_entry_id: opcua::types::UAString,
     pub client_user_id: opcua::types::UAString,
     pub server_id: opcua::types::UAString,
@@ -259,24 +257,24 @@ pub struct AuditEventType {
 #[opcua(identifier = "i=19095")]
 pub struct AuditHistoryAnnotationUpdateEventType {
     pub base: AuditHistoryUpdateEventType,
-    pub new_values: types::Annotation,
-    pub old_values: types::Annotation,
-    pub perform_insert_replace: types::PerformUpdateType,
+    pub new_values: opcua::types::Annotation,
+    pub old_values: opcua::types::Annotation,
+    pub perform_insert_replace: opcua::types::PerformUpdateType,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=3019")]
 pub struct AuditHistoryAtTimeDeleteEventType {
     pub base: AuditHistoryDeleteEventType,
-    pub old_values: types::DataValue,
-    pub req_times: types::UtcTime,
+    pub old_values: opcua::types::DataValue,
+    pub req_times: opcua::types::UtcTime,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=32803")]
 pub struct AuditHistoryBulkInsertEventType {
     pub base: AuditEventType,
-    pub end_time: types::UtcTime,
-    pub start_time: types::UtcTime,
-    pub updated_node: types::NodeId,
+    pub end_time: opcua::types::UtcTime,
+    pub start_time: opcua::types::UtcTime,
+    pub updated_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=32758")]
@@ -287,48 +285,48 @@ pub struct AuditHistoryConfigurationChangeEventType {
 #[opcua(identifier = "i=3012")]
 pub struct AuditHistoryDeleteEventType {
     pub base: AuditHistoryUpdateEventType,
-    pub updated_node: types::NodeId,
+    pub updated_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=3022")]
 pub struct AuditHistoryEventDeleteEventType {
     pub base: AuditHistoryDeleteEventType,
-    pub event_ids: types::ByteString,
-    pub old_values: types::HistoryEventFieldList,
+    pub event_ids: opcua::types::ByteString,
+    pub old_values: opcua::types::HistoryEventFieldList,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2999")]
 pub struct AuditHistoryEventUpdateEventType {
     pub base: AuditHistoryUpdateEventType,
-    pub filter: types::EventFilter,
-    pub new_values: types::HistoryEventFieldList,
-    pub old_values: types::HistoryEventFieldList,
-    pub perform_insert_replace: types::PerformUpdateType,
-    pub updated_node: types::NodeId,
+    pub filter: opcua::types::EventFilter,
+    pub new_values: opcua::types::HistoryEventFieldList,
+    pub old_values: opcua::types::HistoryEventFieldList,
+    pub perform_insert_replace: opcua::types::PerformUpdateType,
+    pub updated_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=3014")]
 pub struct AuditHistoryRawModifyDeleteEventType {
     pub base: AuditHistoryDeleteEventType,
-    pub end_time: types::UtcTime,
+    pub end_time: opcua::types::UtcTime,
     pub is_delete_modified: bool,
-    pub old_values: types::DataValue,
-    pub start_time: types::UtcTime,
+    pub old_values: opcua::types::DataValue,
+    pub start_time: opcua::types::UtcTime,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2104")]
 pub struct AuditHistoryUpdateEventType {
     pub base: AuditUpdateEventType,
-    pub parameter_data_type_id: types::NodeId,
+    pub parameter_data_type_id: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=3006")]
 pub struct AuditHistoryValueUpdateEventType {
     pub base: AuditHistoryUpdateEventType,
-    pub new_values: types::DataValue,
-    pub old_values: types::DataValue,
-    pub perform_insert_replace: types::PerformUpdateType,
-    pub updated_node: types::NodeId,
+    pub new_values: opcua::types::DataValue,
+    pub old_values: opcua::types::DataValue,
+    pub perform_insert_replace: opcua::types::PerformUpdateType,
+    pub updated_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2090")]
@@ -339,12 +337,12 @@ pub struct AuditNodeManagementEventType {
 #[opcua(identifier = "i=2060")]
 pub struct AuditOpenSecureChannelEventType {
     pub base: AuditChannelEventType,
-    pub certificate_error_event_id: types::ByteString,
-    pub client_certificate: types::ByteString,
+    pub certificate_error_event_id: opcua::types::ByteString,
+    pub client_certificate: opcua::types::ByteString,
     pub client_certificate_thumbprint: opcua::types::UAString,
-    pub request_type: types::SecurityTokenRequestType,
-    pub requested_lifetime: types::Duration,
-    pub security_mode: types::MessageSecurityMode,
+    pub request_type: opcua::types::SecurityTokenRequestType,
+    pub requested_lifetime: opcua::types::Duration,
+    pub security_mode: opcua::types::MessageSecurityMode,
     pub security_policy_uri: opcua::types::UAString,
 }
 #[derive(Debug, opcua::Event)]
@@ -357,13 +355,13 @@ pub struct AuditProgramTransitionEventType {
 #[opcua(identifier = "i=2058")]
 pub struct AuditSecurityEventType {
     pub base: AuditEventType,
-    pub status_code_id: types::StatusCode,
+    pub status_code_id: opcua::types::StatusCode,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2069")]
 pub struct AuditSessionEventType {
     pub base: AuditSecurityEventType,
-    pub session_id: types::NodeId,
+    pub session_id: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2099")]
@@ -375,9 +373,9 @@ pub struct AuditUpdateEventType {
 pub struct AuditUpdateMethodEventType {
     pub base: AuditEventType,
     pub input_arguments: opcua::types::ExtensionObject,
-    pub method_id: types::NodeId,
+    pub method_id: opcua::types::NodeId,
     pub output_arguments: opcua::types::ExtensionObject,
-    pub status_code_id: types::StatusCode,
+    pub status_code_id: opcua::types::StatusCode,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2315")]
@@ -397,7 +395,7 @@ pub struct AuditUrlMismatchEventType {
 pub struct AuditWriteUpdateEventType {
     pub base: AuditUpdateEventType,
     pub attribute_id: u32,
-    pub index_range: types::NumericRange,
+    pub index_range: opcua::types::NumericRange,
     pub new_value: opcua::types::ExtensionObject,
     pub old_value: opcua::types::ExtensionObject,
 }
@@ -410,17 +408,17 @@ pub struct BaseModelChangeEventType {
 #[opcua(identifier = "i=13225")]
 pub struct CertificateExpirationAlarmType {
     pub base: SystemOffNormalAlarmType,
-    pub certificate: types::ByteString,
-    pub certificate_type: types::NodeId,
-    pub expiration_date: types::DateTime,
-    pub expiration_limit: types::Duration,
+    pub certificate: opcua::types::ByteString,
+    pub certificate_type: opcua::types::NodeId,
+    pub expiration_date: opcua::types::DateTime,
+    pub expiration_limit: opcua::types::Duration,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=12620")]
 pub struct CertificateUpdatedAuditEventType {
     pub base: AuditUpdateMethodEventType,
-    pub certificate_group: types::NodeId,
-    pub certificate_type: types::NodeId,
+    pub certificate_group: opcua::types::NodeId,
+    pub certificate_type: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=32306")]
@@ -432,16 +430,16 @@ pub struct CertificateUpdateRequestedAuditEventType {
 pub struct ConditionType {
     pub base: opcua::nodes::BaseEventType,
     pub add_comment: opcua::nodes::MethodEventField,
-    pub branch_id: types::NodeId,
+    pub branch_id: opcua::types::NodeId,
     pub client_user_id: opcua::types::UAString,
     pub comment: ConditionVariableType,
-    pub condition_class_id: types::NodeId,
-    pub condition_class_name: types::LocalizedText,
+    pub condition_class_id: opcua::types::NodeId,
+    pub condition_class_name: opcua::types::LocalizedText,
     pub condition_name: opcua::types::UAString,
     pub condition_refresh: opcua::nodes::MethodEventField,
     pub condition_refresh_2: opcua::nodes::MethodEventField,
-    pub condition_sub_class_id: types::NodeId,
-    pub condition_sub_class_name: types::LocalizedText,
+    pub condition_sub_class_id: opcua::types::NodeId,
+    pub condition_sub_class_name: opcua::types::LocalizedText,
     pub disable: opcua::nodes::MethodEventField,
     pub enable: opcua::nodes::MethodEventField,
     pub enabled_state: TwoStateVariableType,
@@ -454,7 +452,7 @@ pub struct ConditionType {
 pub struct ConditionVariableType {
     pub node_id: opcua::types::NodeId,
     pub value: opcua::types::ExtensionObject,
-    pub source_timestamp: types::UtcTime,
+    pub source_timestamp: opcua::types::UtcTime,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2131")]
@@ -471,17 +469,17 @@ pub struct DialogConditionType {
     pub enabled_state: TwoStateVariableType,
     pub last_response: i32,
     pub ok_response: i32,
-    pub prompt: types::LocalizedText,
+    pub prompt: opcua::types::LocalizedText,
     pub respond: opcua::nodes::MethodEventField,
     pub respond_2: opcua::nodes::MethodEventField,
-    pub response_option_set: types::LocalizedText,
+    pub response_option_set: opcua::types::LocalizedText,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=17080")]
 pub struct DiscrepancyAlarmType {
     pub base: AlarmConditionType,
-    pub expected_time: types::Duration,
-    pub target_value_node: types::NodeId,
+    pub expected_time: opcua::types::Duration,
+    pub target_value_node: opcua::types::NodeId,
     pub tolerance: f64,
 }
 #[derive(Debug, opcua::Event)]
@@ -498,8 +496,8 @@ pub struct EventQueueOverflowEventType {
 #[opcua(identifier = "i=9764")]
 pub struct ExclusiveDeviationAlarmType {
     pub base: ExclusiveLimitAlarmType,
-    pub base_setpoint_node: types::NodeId,
-    pub setpoint_node: types::NodeId,
+    pub base_setpoint_node: opcua::types::NodeId,
+    pub setpoint_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=9482")]
@@ -530,14 +528,14 @@ pub struct ExclusiveLimitStateMachineType {
 #[opcua(identifier = "i=9623")]
 pub struct ExclusiveRateOfChangeAlarmType {
     pub base: ExclusiveLimitAlarmType,
-    pub engineering_units: types::EUInformation,
+    pub engineering_units: opcua::types::EUInformation,
 }
 #[derive(Debug, opcua::EventField, Default)]
 pub struct FiniteStateMachineType {
     pub base: StateMachineType,
     pub node_id: opcua::types::NodeId,
-    pub available_states: types::NodeId,
-    pub available_transitions: types::NodeId,
+    pub available_states: opcua::types::NodeId,
+    pub available_transitions: opcua::types::NodeId,
     pub current_state: FiniteStateVariableType,
     pub last_transition: FiniteTransitionVariableType,
 }
@@ -545,19 +543,19 @@ pub struct FiniteStateMachineType {
 pub struct FiniteStateVariableType {
     pub base: StateVariableType,
     pub node_id: opcua::types::NodeId,
-    pub id: types::NodeId,
+    pub id: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::EventField, Default)]
 pub struct FiniteTransitionVariableType {
     pub base: TransitionVariableType,
     pub node_id: opcua::types::NodeId,
-    pub id: types::NodeId,
+    pub id: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2133")]
 pub struct GeneralModelChangeEventType {
     pub base: BaseModelChangeEventType,
-    pub changes: types::ModelChangeStructureDataType,
+    pub changes: opcua::types::ModelChangeStructureDataType,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=18347")]
@@ -606,8 +604,8 @@ pub struct LimitAlarmType {
 #[opcua(identifier = "i=10368")]
 pub struct NonExclusiveDeviationAlarmType {
     pub base: NonExclusiveLimitAlarmType,
-    pub base_setpoint_node: types::NodeId,
-    pub setpoint_node: types::NodeId,
+    pub base_setpoint_node: opcua::types::NodeId,
+    pub setpoint_node: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=10060")]
@@ -628,13 +626,13 @@ pub struct NonExclusiveLimitAlarmType {
 #[opcua(identifier = "i=10214")]
 pub struct NonExclusiveRateOfChangeAlarmType {
     pub base: NonExclusiveLimitAlarmType,
-    pub engineering_units: types::EUInformation,
+    pub engineering_units: opcua::types::EUInformation,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=10637")]
 pub struct OffNormalAlarmType {
     pub base: DiscreteAlarmType,
-    pub normal_state: types::NodeId,
+    pub normal_state: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=3806")]
@@ -659,15 +657,15 @@ pub struct ProgressEventType {
 #[opcua(identifier = "i=15563")]
 pub struct PubSubCommunicationFailureEventType {
     pub base: PubSubStatusEventType,
-    pub error: types::StatusCode,
+    pub error: opcua::types::StatusCode,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=15535")]
 pub struct PubSubStatusEventType {
     pub base: SystemEventType,
-    pub connection_id: types::NodeId,
-    pub group_id: types::NodeId,
-    pub state: types::PubSubState,
+    pub connection_id: opcua::types::NodeId,
+    pub group_id: opcua::types::NodeId,
+    pub state: opcua::types::PubSubState,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=15548")]
@@ -700,7 +698,7 @@ pub struct RoleMappingRuleChangedAuditEventType {
 #[opcua(identifier = "i=2738")]
 pub struct SemanticChangeEventType {
     pub base: opcua::nodes::BaseEventType,
-    pub changes: types::SemanticChangeStructureDataType,
+    pub changes: opcua::types::SemanticChangeStructureDataType,
 }
 #[derive(Debug, opcua::EventField, Default)]
 pub struct ShelvedStateMachineType {
@@ -718,7 +716,7 @@ pub struct ShelvedStateMachineType {
     pub timed_shelved_to_unshelved: TransitionType,
     pub unshelve: opcua::nodes::MethodEventField,
     pub unshelve_2: opcua::nodes::MethodEventField,
-    pub unshelve_time: types::Duration,
+    pub unshelve_time: opcua::types::Duration,
     pub unshelved: StateType,
     pub unshelved_to_one_shot_shelved: TransitionType,
     pub unshelved_to_timed_shelved: TransitionType,
@@ -737,10 +735,10 @@ pub struct StateType {
 #[derive(Debug, opcua::EventField, Default)]
 pub struct StateVariableType {
     pub node_id: opcua::types::NodeId,
-    pub value: types::LocalizedText,
-    pub effective_display_name: types::LocalizedText,
+    pub value: opcua::types::LocalizedText,
+    pub effective_display_name: opcua::types::LocalizedText,
     pub id: opcua::types::ExtensionObject,
-    pub name: types::QualifiedName,
+    pub name: opcua::types::QualifiedName,
     pub number: u32,
 }
 #[derive(Debug, opcua::Event)]
@@ -762,7 +760,7 @@ pub struct SystemOffNormalAlarmType {
 #[opcua(identifier = "i=11446")]
 pub struct SystemStatusChangeEventType {
     pub base: SystemEventType,
-    pub system_state: types::ServerState,
+    pub system_state: opcua::types::ServerState,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=2311")]
@@ -780,12 +778,12 @@ pub struct TransitionType {
 #[derive(Debug, opcua::EventField, Default)]
 pub struct TransitionVariableType {
     pub node_id: opcua::types::NodeId,
-    pub value: types::LocalizedText,
-    pub effective_transition_time: types::UtcTime,
+    pub value: opcua::types::LocalizedText,
+    pub effective_transition_time: opcua::types::UtcTime,
     pub id: opcua::types::ExtensionObject,
-    pub name: types::QualifiedName,
+    pub name: opcua::types::QualifiedName,
     pub number: u32,
-    pub transition_time: types::UtcTime,
+    pub transition_time: opcua::types::UtcTime,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=10751")]
@@ -796,15 +794,15 @@ pub struct TripAlarmType {
 #[opcua(identifier = "i=19297")]
 pub struct TrustListOutOfDateAlarmType {
     pub base: SystemOffNormalAlarmType,
-    pub last_update_time: types::UtcTime,
-    pub trust_list_id: types::NodeId,
-    pub update_frequency: types::Duration,
+    pub last_update_time: opcua::types::UtcTime,
+    pub trust_list_id: opcua::types::NodeId,
+    pub update_frequency: opcua::types::Duration,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=12561")]
 pub struct TrustListUpdatedAuditEventType {
     pub base: AuditUpdateMethodEventType,
-    pub trust_list_id: types::NodeId,
+    pub trust_list_id: opcua::types::NodeId,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(identifier = "i=32260")]
@@ -815,9 +813,9 @@ pub struct TrustListUpdateRequestedAuditEventType {
 pub struct TwoStateVariableType {
     pub base: StateVariableType,
     pub node_id: opcua::types::NodeId,
-    pub effective_transition_time: types::UtcTime,
-    pub false_state: types::LocalizedText,
+    pub effective_transition_time: opcua::types::UtcTime,
+    pub false_state: opcua::types::LocalizedText,
     pub id: bool,
-    pub transition_time: types::UtcTime,
-    pub true_state: types::LocalizedText,
+    pub transition_time: opcua::types::UtcTime,
+    pub true_state: opcua::types::LocalizedText,
 }

--- a/async-opcua-core-namespace/src/events/mod.rs
+++ b/async-opcua-core-namespace/src/events/mod.rs
@@ -11,7 +11,5 @@ mod opcua {
     pub(super) use opcua_nodes::{Event, EventField};
     pub(super) use opcua_types as types;
 }
-#[allow(unused)]
-use opcua_types as types;
 pub mod generated;
 pub use generated::*;

--- a/code_gen_config.yml
+++ b/code_gen_config.yml
@@ -35,8 +35,6 @@ targets:
       extra_header: |
         #[allow(unused)]
         mod opcua { pub(super) use opcua_types as types; pub(super) use opcua_nodes as nodes; pub(super) use opcua_nodes::{Event, EventField}; }
-        #[allow(unused)]
-        use opcua_types as types;
   - type: ids
     file_path: schemas/1.05/NodeIds.csv
     extra_header: |

--- a/samples/custom-codegen/code_gen_config.yml
+++ b/samples/custom-codegen/code_gen_config.yml
@@ -26,12 +26,6 @@ targets:
       dependent_nodesets:
         - file: Opc.Ua.NodeSet2.xml
           import_path: "opcua::core_namespace::events::"
-      extra_header: |
-        #[allow(unused)]
-        mod types {
-          pub use crate::generated::types::*;
-          pub use ::opcua::types::*;
-        }
   - type: ids
     file_path: schema/Opc.Ua.Pn.NodeIds.csv
     output_file: src/generated/node_ids.rs

--- a/samples/custom-codegen/src/generated/events/generated.rs
+++ b/samples/custom-codegen/src/generated/events/generated.rs
@@ -5,11 +5,6 @@
 // OPCUA for Rust
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Einar Omang
-#[allow(unused)]
-mod types {
-    pub use crate::generated::types::*;
-    pub use ::opcua::types::*;
-}
 #[derive(Debug, opcua::Event)]
 #[opcua(
     identifier = "i=1003",
@@ -18,8 +13,8 @@ mod types {
 pub struct PnAssetChangedEventType {
     pub base: opcua::nodes::BaseEventType,
     pub own_namespace_index: u16,
-    pub asset_change: types::PnAssetChangeEnumeration,
-    pub asset_type: types::PnAssetTypeEnumeration,
+    pub asset_change: crate::generated::types::PnAssetChangeEnumeration,
+    pub asset_type: crate::generated::types::PnAssetTypeEnumeration,
 }
 #[derive(Debug, opcua::Event)]
 #[opcua(
@@ -30,21 +25,21 @@ pub struct PnDiagnosisAlarmType {
     pub base: opcua::core_namespace::events::AlarmConditionType,
     pub own_namespace_index: u16,
     pub api: u32,
-    pub accumulative: types::PnChannelAccumulativeEnumeration,
+    pub accumulative: crate::generated::types::PnChannelAccumulativeEnumeration,
     pub channel_error_type: u16,
     pub channel_number: u16,
-    pub direction: types::PnChannelDirectionEnumeration,
+    pub direction: crate::generated::types::PnChannelDirectionEnumeration,
     pub ext_channel_add_value: u32,
     pub ext_channel_error_type: u16,
-    pub help_text: types::LocalizedText,
-    pub maintenance: types::PnChannelMaintenanceEnumeration,
-    pub manufacturer_data: types::ByteString,
+    pub help_text: opcua::types::LocalizedText,
+    pub maintenance: crate::generated::types::PnChannelMaintenanceEnumeration,
+    pub manufacturer_data: opcua::types::ByteString,
     pub qualified_channel_qualifier: u32,
     pub slot: u16,
-    pub specifier: types::PnChannelSpecifierEnumeration,
+    pub specifier: crate::generated::types::PnChannelSpecifierEnumeration,
     pub subslot: u16,
     #[opcua(rename = "Type")]
-    pub __type: types::PnChannelTypeEnumeration,
+    pub __type: crate::generated::types::PnChannelTypeEnumeration,
     pub user_structure_identifier: u16,
 }
 #[derive(Debug, opcua::Event)]

--- a/samples/custom-codegen/src/generated/events/mod.rs
+++ b/samples/custom-codegen/src/generated/events/mod.rs
@@ -5,10 +5,5 @@
 // OPCUA for Rust
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Einar Omang
-#[allow(unused)]
-mod types {
-    pub use crate::generated::types::*;
-    pub use ::opcua::types::*;
-}
 pub mod generated;
 pub use generated::*;


### PR DESCRIPTION
This was done kinda lazily, with just a blanket "types" module that needed to contain everything needed. This instead uses the `types` argument to the main nodeset generation to infer type paths.