### PR TITLE
Verify server signature during CreateSession

### DIFF
--- a/async-opcua-server/src/session/controller.rs
+++ b/async-opcua-server/src/session/controller.rs
@@ -684,20 +684,13 @@ impl SessionController {
 
         // Check the requested security mode
         debug!("Message security mode == {:?}", request.security_mode);
-        match request.security_mode {
-            MessageSecurityMode::None
-            | MessageSecurityMode::Sign
-            | MessageSecurityMode::SignAndEncrypt => {
-                // TODO validate NONCE
-            }
-            _ => {
-                error!("Security mode is invalid");
-                return Ok(ServiceFault::new(
-                    &request.request_header,
-                    StatusCode::BadSecurityModeRejected,
-                )
-                .into());
-            }
+        if matches!(request.security_mode, MessageSecurityMode::Invalid) {
+            error!("Security mode is invalid");
+            return Ok(ServiceFault::new(
+                &request.request_header,
+                StatusCode::BadSecurityModeRejected,
+            )
+            .into());
         }
 
         // Process the request


### PR DESCRIPTION
We set this properly on the server, but there was a TODO here to actually verify the signature. Easy enough to do, we do have a method in the crypto library to do this.