### PR TITLE
Avoid write lock on channel in client

### DIFF
--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -280,7 +280,7 @@ impl AsyncSecureChannel {
         debug!("Connect");
         let security_policy =
             SecurityPolicy::from_str(self.endpoint_info.endpoint.security_policy_uri.as_ref())
-                .unwrap();
+                .map_err(|_| StatusCode::BadSecurityPolicyRejected)?;
 
         if security_policy == SecurityPolicy::Unknown {
             error!(

--- a/async-opcua-core/src/tests/chunk.rs
+++ b/async-opcua-core/src/tests/chunk.rs
@@ -551,9 +551,6 @@ fn asymmetric_decrypt_and_verify_sample_chunk() {
     let their_cert_data = include_bytes!("test_data/their_cert.der");
     let their_cert = X509::from_der(&their_cert_data[..]).unwrap();
 
-    let their_key_data = include_bytes!("test_data/their_private.pem");
-    let their_key = PrivateKey::from_pem(&their_key_data[..]).unwrap();
-
     let our_cert_data = include_bytes!("test_data/our_cert.der");
     let our_cert = X509::from_der(&our_cert_data[..]).unwrap();
 
@@ -573,7 +570,7 @@ fn asymmetric_decrypt_and_verify_sample_chunk() {
     secure_channel.set_private_key(Some(our_key));
 
     let _ = secure_channel
-        .verify_and_remove_security_forensic(&message_data, Some(their_key))
+        .verify_and_remove_security(message_data)
         .unwrap();
 }
 

--- a/async-opcua-core/src/tests/secure_channel.rs
+++ b/async-opcua-core/src/tests/secure_channel.rs
@@ -15,8 +15,7 @@ fn test_symmetric_encrypt_decrypt(
     security_mode: MessageSecurityMode,
     security_policy: SecurityPolicy,
 ) {
-    let (secure_channel1, mut secure_channel2) =
-        make_secure_channels(security_mode, security_policy);
+    let (secure_channel1, secure_channel2) = make_secure_channels(security_mode, security_policy);
 
     let mut chunks = Chunker::encode(
         SequenceNumberHandle::new(true),
@@ -41,7 +40,7 @@ fn test_symmetric_encrypt_decrypt(
         // Decrypted message should identical to original with same length and
         // no signature or padding
         let chunk2 = secure_channel2
-            .verify_and_remove_security(&encrypted_data[..encrypted_size])
+            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec())
             .unwrap();
 
         assert_eq!(&chunk.data, &chunk2.data);
@@ -110,7 +109,7 @@ fn test_asymmetric_encrypt_decrypt(
 
         // Compare up to original length
         let chunk2 = secure_channel
-            .verify_and_remove_security(&encrypted_data[..encrypted_size])
+            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec())
             .unwrap();
         assert_eq!(chunk.data.len(), chunk2.data.len());
         assert_eq!(&chunk.data, &chunk2.data);

--- a/async-opcua-crypto/src/lib.rs
+++ b/async-opcua-crypto/src/lib.rs
@@ -144,7 +144,6 @@ pub fn verify_signature_data(
             &verification_key,
             &data,
             signature.signature.as_ref(),
-            None,
         )?;
         Ok(())
     } else {

--- a/async-opcua-crypto/src/security_policy.rs
+++ b/async-opcua-crypto/src/security_policy.rs
@@ -581,7 +581,6 @@ impl SecurityPolicy {
         verification_key: &PublicKey,
         data: &[u8],
         signature: &[u8],
-        #[allow(unused)] their_private_key: Option<PrivateKey>,
     ) -> Result<(), Error> {
         // Asymmetric verify signature against supplied certificate
         let result = match self {
@@ -601,19 +600,6 @@ impl SecurityPolicy {
         if result {
             Ok(())
         } else {
-            // For debugging / unit testing purposes we might have a their_key to see the source of the error
-            #[cfg(debug_assertions)]
-            if let Some(their_key) = their_private_key {
-                use crate::pkey::KeySize;
-                use tracing::trace;
-                // Calculate the signature using their key, see what we were expecting versus theirs
-                let mut their_signature = vec![0u8; their_key.size()];
-                self.asymmetric_sign(&their_key, data, their_signature.as_mut_slice())?;
-                trace!(
-                    "Using their_key, signature should be {:?}",
-                    &their_signature
-                );
-            }
             Err(Error::new(
                 StatusCode::BadSecurityChecksFailed,
                 "Signature mismatch",

--- a/async-opcua-server/src/transport/tcp.rs
+++ b/async-opcua-server/src/transport/tcp.rs
@@ -389,7 +389,7 @@ impl TcpTransport {
                     self.pending_chunks.clear();
                     Ok(None)
                 } else {
-                    let chunk = channel.verify_and_remove_security(&chunk.data)?;
+                    let chunk = channel.verify_and_remove_security_server(chunk.data)?;
 
                     if self.send_buffer.max_chunk_count > 0
                         && self.pending_chunks.len() == self.send_buffer.max_chunk_count

--- a/async-opcua/tests/integration/read.rs
+++ b/async-opcua/tests/integration/read.rs
@@ -1153,7 +1153,7 @@ async fn test_diagnostics() {
         .await
         .unwrap();
     lp.spawn();
-    tokio::time::timeout(Duration::from_secs(2), session.wait_for_connection())
+    tokio::time::timeout(Duration::from_secs(5), session.wait_for_connection())
         .await
         .unwrap();
 


### PR DESCRIPTION
This came with a bit of a refactor. In practice, we want to behave slightly differently on the client and server, because the client is always the party that _decides_ the security policy, so setting security policy based on an open secure channel request only really makes sense on the server.

There's some minor code duplication, but I couldn't think of a way to express this (only the server needs a mutable reference) in a cleaner way.

I'm hoping to start work on ECC next, which will require a series of refactors to our sign/encrypt code, hopefully making it easier to read as well.