### PR TITLE
Move AES primitives into separate module

### DIFF
--- a/async-opcua-client/src/session/services/session.rs
+++ b/async-opcua-client/src/session/services/session.rs
@@ -4,8 +4,7 @@ use opcua_core::{
     comms::url::hostname_from_url, sync::RwLock, trace_read_lock, trace_write_lock, ResponseMessage,
 };
 use opcua_crypto::{
-    self, certificate_store::CertificateStore, legacy_encrypt_secret, random, PKey, SecurityPolicy,
-    X509,
+    self, legacy_encrypt_secret, random, CertificateStore, PKey, SecurityPolicy, X509,
 };
 use opcua_types::{
     ActivateSessionRequest, ActivateSessionResponse, AnonymousIdentityToken,

--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -17,11 +17,7 @@ use chrono::Duration;
 use tracing::{error, trace};
 
 use opcua_crypto::{
-    aeskey::AesKey,
-    pkey::{KeySize, PrivateKey, PublicKey},
-    random,
-    x509::X509,
-    CertificateStore, SecurityPolicy,
+    random, AesKey, CertificateStore, KeySize, PrivateKey, PublicKey, SecurityPolicy, X509,
 };
 use opcua_types::{
     status_code::StatusCode, write_bytes, write_u32, write_u8, ByteString, ChannelSecurityToken,

--- a/async-opcua-core/src/tests/mod.rs
+++ b/async-opcua-core/src/tests/mod.rs
@@ -6,11 +6,7 @@ use std::cmp::PartialEq;
 use std::fmt::Debug;
 use std::io::Cursor;
 
-use opcua_crypto::{
-    pkey::PrivateKey,
-    security_policy::SecurityPolicy,
-    x509::{X509Data, X509},
-};
+use opcua_crypto::{PrivateKey, SecurityPolicy, X509Data, X509};
 use opcua_types::{
     status_code::StatusCode, BinaryDecodable, BinaryEncodable, ByteString, ChannelSecurityToken,
     ContextOwned, DateTime, DiagnosticBits, DiagnosticInfo, ExtensionObject, GetEndpointsRequest,

--- a/async-opcua-crypto/src/aes/aeskey.rs
+++ b/async-opcua-crypto/src/aes/aeskey.rs
@@ -6,16 +6,14 @@
 
 use std::result::Result;
 
-use aes;
 #[expect(deprecated)]
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{block_padding::NoPadding, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
-use cbc;
 
 use opcua_types::status_code::StatusCode;
 use opcua_types::Error;
 
-use super::SecurityPolicy;
+use crate::SecurityPolicy;
 
 type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
 type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;

--- a/async-opcua-crypto/src/aes/mod.rs
+++ b/async-opcua-crypto/src/aes/mod.rs
@@ -1,0 +1,6 @@
+mod aeskey;
+mod rsa_private_key;
+
+pub use aeskey::AesKey;
+pub(crate) use rsa_private_key::RsaPadding;
+pub use rsa_private_key::{KeySize, PKey, PrivateKey, PublicKey};

--- a/async-opcua-crypto/src/aes/rsa_private_key.rs
+++ b/async-opcua-crypto/src/aes/rsa_private_key.rs
@@ -9,17 +9,13 @@ use std::{
     result::Result,
 };
 
-use rand;
 use rsa::pkcs1;
 use rsa::pkcs1v15;
 use rsa::pkcs8;
 use rsa::pss;
 use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
 use rsa::{Oaep, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
-use sha1;
-use sha2;
 
-use x509_cert;
 use x509_cert::spki::SubjectPublicKeyInfoOwned;
 
 use opcua_types::{status_code::StatusCode, Error};

--- a/async-opcua-crypto/src/certificate_store.rs
+++ b/async-opcua-crypto/src/certificate_store.rs
@@ -13,14 +13,12 @@ use tracing::{debug, error, info, trace, warn};
 
 use opcua_types::status_code::StatusCode;
 
+use crate::PrivateKey;
+
 use super::{
-    pkey::PrivateKey,
     security_policy::SecurityPolicy,
     x509::{X509Data, X509},
 };
-
-use rsa;
-use x509_cert;
 
 /// Default path to the applications own certificate
 const OWN_CERTIFICATE_PATH: &str = "own/cert.der";

--- a/async-opcua-crypto/src/hash.rs
+++ b/async-opcua-crypto/src/hash.rs
@@ -34,7 +34,7 @@ type Sha256Output = digest::CtOutput<HmacSha256>;
 ///   A(0) = seed
 ///   A(n) = HMAC_SHA1(secret, A(n-1))
 /// + indicates that the results are appended to previous results.
-pub fn p_sha1(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
+pub(crate) fn p_sha1(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
     let mut result = Vec::with_capacity(length);
 
     let mut hmac = Vec::with_capacity(seed.len() * 2);
@@ -67,7 +67,7 @@ pub fn p_sha1(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
 }
 
 /// Pseudo random `P_SHA256` implementation for creating a pseudo random range of bytes from an input.
-pub fn p_sha256(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
+pub(crate) fn p_sha256(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
     let mut result = Vec::with_capacity(length);
 
     let mut hmac = Vec::with_capacity(seed.len() * 2);
@@ -99,28 +99,6 @@ pub fn p_sha256(secret: &[u8], seed: &[u8], length: usize) -> Vec<u8> {
     result
 }
 
-/*
-fn hmac_vec(digest: hash::MessageDigest, key: &[u8], data: &[u8]) -> Vec<u8> {
-    // Compute a signature
-    let pkey = pkey::PKey::hmac(key).unwrap();
-    let mut signer = sign::Signer::new(digest, &pkey).unwrap();
-    signer.update(data).unwrap();
-    signer.sign_to_vec().unwrap()
-}
-
-fn hmac(
-    digest: hash::MessageDigest,
-    key: &[u8],
-    data: &[u8],
-    signature: &mut [u8],
-) -> Result<(), StatusCode> {
-    let hmac = hmac_vec(digest, key, data);
-    trace!("hmac length = {}", hmac.len());
-    signature.copy_from_slice(&hmac);
-    Ok(())
-}
-*/
-
 fn sign_sha1(key: &[u8], data: &[u8]) -> Sha1Output {
     let mut mac = HmacSha1::new_from_slice(key).unwrap();
     mac.update(data);
@@ -134,7 +112,7 @@ fn sign_sha256(key: &[u8], data: &[u8]) -> Sha256Output {
 }
 
 /// Write the SHA1 HMAC signature of `data` using `key` into `signature`.
-pub fn hmac_sha1(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), StatusCode> {
+pub(crate) fn hmac_sha1(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), StatusCode> {
     if signature.len() == SHA1_SIZE {
         let result = sign_sha1(key, data);
         signature.copy_from_slice(&result.into_bytes());
@@ -149,7 +127,7 @@ pub fn hmac_sha1(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), St
 }
 
 /// Verify that the HMAC for the data block matches the supplied signature
-pub fn verify_hmac_sha1(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
+pub(crate) fn verify_hmac_sha1(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
     if signature.len() != SHA1_SIZE {
         false
     } else {
@@ -160,7 +138,7 @@ pub fn verify_hmac_sha1(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
 }
 
 /// Write the SHA256 HMAC signature of `data` using `key` into `signature`.
-pub fn hmac_sha256(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), StatusCode> {
+pub(crate) fn hmac_sha256(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), StatusCode> {
     if signature.len() == SHA256_SIZE {
         let result = sign_sha256(key, data);
         signature.copy_from_slice(&result.into_bytes());
@@ -175,7 +153,7 @@ pub fn hmac_sha256(key: &[u8], data: &[u8], signature: &mut [u8]) -> Result<(), 
 }
 
 /// Verify that the HMAC for the data block matches the supplied signature
-pub fn verify_hmac_sha256(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
+pub(crate) fn verify_hmac_sha256(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
     if signature.len() != SHA256_SIZE {
         false
     } else {

--- a/async-opcua-crypto/src/lib.rs
+++ b/async-opcua-crypto/src/lib.rs
@@ -12,23 +12,31 @@ use opcua_types::{
     status_code::StatusCode, ByteString, EncodingResult, Error, SignatureData, UAString,
 };
 use tracing::{error, trace};
-pub use {
-    aeskey::*, certificate_store::*, hash::*, pkey::*, security_policy::*, thumbprint::*,
-    user_identity::*, x509::*,
+
+pub(crate) use crate::aes::RsaPadding;
+
+pub use crate::aes::{AesKey, KeySize, PKey, PrivateKey, PublicKey};
+pub use crate::x509::{X509Data, X509Error, X509};
+pub use certificate_store::CertificateStore;
+pub use security_policy::SecurityPolicy;
+pub use thumbprint::Thumbprint;
+pub use user_identity::{
+    legacy_decrypt_secret, legacy_encrypt_secret, verify_x509_identity_token,
+    LegacyEncryptedSecret, LegacySecret,
 };
 
 #[cfg(test)]
 mod tests;
 
-pub mod aeskey;
-pub mod certificate_store;
-pub mod hash;
-pub mod pkey;
+mod certificate_store;
+mod hash;
 pub mod random;
-pub mod security_policy;
-pub mod thumbprint;
-pub mod user_identity;
-pub mod x509;
+mod security_policy;
+mod thumbprint;
+mod user_identity;
+mod x509;
+
+mod aes;
 
 /// Size of a SHA1 hash value in bytes
 pub const SHA1_SIZE: usize = 20;

--- a/async-opcua-crypto/src/security_policy.rs
+++ b/async-opcua-crypto/src/security_policy.rs
@@ -11,15 +11,12 @@ use tracing::error;
 
 use opcua_types::{constants, status_code::StatusCode, ByteString, Error};
 
-use super::{
-    aeskey::AesKey,
-    hash,
-    pkey::{PrivateKey, PublicKey, RsaPadding},
-    random, SHA1_SIZE, SHA256_SIZE,
-};
+use crate::{aes::AesKey, PrivateKey, PublicKey, RsaPadding};
+
+use super::{hash, random, SHA1_SIZE, SHA256_SIZE};
 
 /// Trait for a security policy supported by the library.
-pub trait SecurityPolicyConstants {
+pub(crate) trait SecurityPolicyConstants {
     /// The name of the policy.
     const SECURITY_POLICY: &'static str;
     /// The URI of the policy, as defined in the OPC-UA standard.
@@ -55,7 +52,7 @@ pub trait SecurityPolicyConstants {
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-pub struct Aes128Sha256RsaOaep;
+pub(crate) struct Aes128Sha256RsaOaep;
 impl SecurityPolicyConstants for Aes128Sha256RsaOaep {
     const SECURITY_POLICY: &str = "Aes128-Sha256-RsaOaep";
     const SECURITY_POLICY_URI: &str =
@@ -82,7 +79,7 @@ impl SecurityPolicyConstants for Aes128Sha256RsaOaep {
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-pub struct Aes256Sha256RsaPss;
+pub(crate) struct Aes256Sha256RsaPss;
 impl SecurityPolicyConstants for Aes256Sha256RsaPss {
     const SECURITY_POLICY: &str = "Aes256-Sha256-RsaPss";
     const SECURITY_POLICY_URI: &str =
@@ -109,7 +106,7 @@ impl SecurityPolicyConstants for Aes256Sha256RsaPss {
 ///   DerivedSignatureKeyLength – 256 bits
 ///   AsymmetricKeyLength - 2048-4096 bits
 ///   SecureChannelNonceLength - 32 bytes
-pub struct Basic256Sha256;
+pub(crate) struct Basic256Sha256;
 impl SecurityPolicyConstants for Basic256Sha256 {
     const SECURITY_POLICY: &str = "Basic256Sha256";
     const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256";
@@ -134,7 +131,7 @@ impl SecurityPolicyConstants for Basic256Sha256 {
 ///   DerivedSignatureKeyLength – 128 bits
 ///   AsymmetricKeyLength - 1024-2048 bits
 ///   SecureChannelNonceLength - 16 bytes
-pub struct Basic128Rsa15;
+pub(crate) struct Basic128Rsa15;
 impl SecurityPolicyConstants for Basic128Rsa15 {
     const SECURITY_POLICY: &str = "Basic128Rsa15";
     const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15";
@@ -159,7 +156,7 @@ impl SecurityPolicyConstants for Basic128Rsa15 {
 ///   DerivedSignatureKeyLength – 192 bits
 ///   AsymmetricKeyLength - 1024-2048 bits
 ///   SecureChannelNonceLength - 32 bytes
-pub struct Basic256;
+pub(crate) struct Basic256;
 impl SecurityPolicyConstants for Basic256 {
     const SECURITY_POLICY: &str = "Basic256";
     const SECURITY_POLICY_URI: &str = "http://opcfoundation.org/UA/SecurityPolicy#Basic256";

--- a/async-opcua-crypto/src/tests/crypto.rs
+++ b/async-opcua-crypto/src/tests/crypto.rs
@@ -4,18 +4,16 @@ use std::io::Write;
 use opcua_types::StatusCode;
 
 use crate::{
-    aeskey::AesKey,
+    aes::AesKey,
     certificate_store::*,
-    from_hex, hash,
-    pkey::{KeySize, PrivateKey, RsaPadding},
-    random,
+    from_hex, hash, random,
     tests::{
         make_certificate_store, make_test_cert_1024, make_test_cert_2048, APPLICATION_HOSTNAME,
         APPLICATION_URI,
     },
     user_identity::{legacy_secret_decrypt, legacy_secret_encrypt},
     x509::{X509Data, X509},
-    SecurityPolicy, SHA1_SIZE, SHA256_SIZE,
+    KeySize, PrivateKey, RsaPadding, SecurityPolicy, SHA1_SIZE, SHA256_SIZE,
 };
 
 #[test]

--- a/async-opcua-crypto/src/tests/mod.rs
+++ b/async-opcua-crypto/src/tests/mod.rs
@@ -3,8 +3,8 @@ use tempdir::TempDir;
 use crate::CertificateStore;
 
 use crate::{
-    pkey::PrivateKey,
     x509::{X509Data, X509},
+    PrivateKey,
 };
 
 const APPLICATION_URI: &str = "urn:testapplication";

--- a/async-opcua-crypto/src/x509.rs
+++ b/async-opcua-crypto/src/x509.rs
@@ -16,7 +16,6 @@ use chrono::{DateTime, Utc};
 use tracing::{error, info, trace, warn};
 type ChronoUtc = DateTime<Utc>;
 
-use rsa;
 use rsa::pkcs1v15;
 use rsa::RsaPublicKey;
 use x509_cert::{
@@ -25,17 +24,14 @@ use x509_cert::{
     ext::pkix::name::GeneralName,
 };
 
-use const_oid;
 use x509::builder::Error as BuilderError;
 use x509::ext::pkix::name as xname;
 
 use opcua_types::{status_code::StatusCode, ApplicationDescription, ByteString, Error};
 
-use super::{
-    hostname,
-    pkey::{PrivateKey, PublicKey},
-    thumbprint::Thumbprint,
-};
+use crate::{KeySize, PrivateKey, PublicKey};
+
+use super::{hostname, thumbprint::Thumbprint};
 
 const DEFAULT_KEYSIZE: u32 = 2048;
 const DEFAULT_COUNTRY: &str = "IE";
@@ -650,8 +646,6 @@ impl X509 {
 
     /// Returns the key length in bits (if possible)
     pub fn key_length(&self) -> Result<usize, X509Error> {
-        use crate::pkey::KeySize;
-
         let r = self.public_key();
         match r {
             Err(_) => Err(X509Error),

--- a/async-opcua-server/src/session/manager.rs
+++ b/async-opcua-server/src/session/manager.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use opcua_core::{comms::secure_channel::SecureChannel, trace_read_lock, trace_write_lock};
-use opcua_crypto::{random, security_policy::SecurityPolicy, CertificateStore};
+use opcua_crypto::{random, CertificateStore, SecurityPolicy};
 use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tracing::{error, info};


### PR DESCRIPTION
Also restricts what we export from the crypto crate to just what we need.

Once this and #182 are merged, I'd like to see if we can avoid directly referencing `AesKey`, `Pkey` etc. outside of the core crypto methods. Since ECC uses different types of keys and entirely different algorithms, I'd like to see if we can properly abstract security policies completely, perhaps ideally just store a `dyn SecurityPolicyImpl` or something like that, only ever using the `SecurityPolicy` enum to construct these.

The parts that are common to _all_ policies aren't entirely clear to me yet, so I expect this will take some iteration to get right, but I'd like to start by at least abstracting the current implementation. Ideally we'd pull some logic out of the `SecureChannel`, since I find that the boundaries between crypto algorithms and OPC-UA protocol are a little fuzzy at the moment.

There's technically breakage here, since we remove some exports, but I'd be surprised if the crypto primitives were seeing much direct use from here.