### PR TITLE
Fix race condition when creating monitored items

### DIFF
--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -159,7 +159,9 @@ pub mod services {
 
     /// Utilities for working with subscriptions.
     pub mod subscriptions {
-        pub use crate::session::{PublishLimits, SubscriptionCache, SubscriptionEventLoopState};
+        pub use crate::session::{
+            PreInsertMonitoredItems, PublishLimits, SubscriptionCache, SubscriptionEventLoopState,
+        };
     }
 }
 

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -63,9 +63,10 @@ use services::subscriptions::state::SubscriptionState;
 pub use services::subscriptions::{
     CreateMonitoredItems, CreateSubscription, DataChangeCallback, DeleteMonitoredItems,
     DeleteSubscriptions, EventCallback, ModifyMonitoredItems, ModifySubscription, MonitoredItem,
-    OnSubscriptionNotification, OnSubscriptionNotificationCore, Publish, PublishLimits, Republish,
-    SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription, SubscriptionActivity,
-    SubscriptionCache, SubscriptionCallbacks, SubscriptionEventLoopState, TransferSubscriptions,
+    OnSubscriptionNotification, OnSubscriptionNotificationCore, PreInsertMonitoredItems, Publish,
+    PublishLimits, Republish, SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription,
+    SubscriptionActivity, SubscriptionCache, SubscriptionCallbacks, SubscriptionEventLoopState,
+    TransferSubscriptions,
 };
 pub use services::view::{
     Browse, BrowseNext, RegisterNodes, TranslateBrowsePaths, UnregisterNodes,

--- a/async-opcua/tests/integration/subscriptions.rs
+++ b/async-opcua/tests/integration/subscriptions.rs
@@ -541,14 +541,9 @@ async fn transfer_subscriptions() {
     // Fetch the existing monitored item from the subscription.
     let old_item = {
         let state = session.subscription_state().lock();
-        state
-            .get(sub_id)
-            .unwrap()
-            .monitored_items()
-            .values()
-            .next()
-            .unwrap()
-            .clone()
+        let sub = state.get(sub_id).unwrap();
+        let mut items = sub.monitored_items();
+        items.next().unwrap().clone()
     };
 
     // Now, close the session without clearing subscriptions.


### PR DESCRIPTION
Described in #191. A race condition can occur when inserting monitored items where we get a publish response _before_ the items are inserted into the subscription state. This should fix that.

This was pretty hairy to do correctly. An issue is that we don't want to hold a lock on the subscription state while waiting for monitored item creation, so we need to insert them in a kind of "temporary" state, then remove them if insertion fails.

This also fixes a different bug, where monitored items that failed to create would be stored in the state as if they were created, which we should avoid.