### PR TITLE
Run some services concurrently

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,5 +11,4 @@ This is a list of things that are known to be missing, or ideas that could be im
  - Write some "bad ideas" servers, it would be nice to showcase how flexible this is.
  - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
  - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.
- - Look into running certain services concurrently. Currently they are sequential because that makes everything much simpler, but the services that don't have any cross node-manager interaction could run on all node managers concurrently.
  - Tracing and detailed logging in the client.

--- a/async-opcua-server/src/node_manager/mod.rs
+++ b/async-opcua-server/src/node_manager/mod.rs
@@ -40,7 +40,10 @@ use super::{
 pub use {
     attributes::{ParsedReadValueId, ParsedWriteValue, ReadNode, WriteNode},
     build::NodeManagerBuilder,
-    context::{RequestContext, TypeTreeForUser, TypeTreeForUserStatic, TypeTreeReadContext},
+    context::{
+        RequestContext, RequestContextInner, TypeTreeForUser, TypeTreeForUserStatic,
+        TypeTreeReadContext,
+    },
     history::{HistoryNode, HistoryResult, HistoryUpdateDetails, HistoryUpdateNode},
     method::MethodCall,
     monitored_items::{MonitoredItemRef, MonitoredItemUpdateRef},

--- a/async-opcua-server/src/session/message_handler.rs
+++ b/async-opcua-server/src/session/message_handler.rs
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 use crate::{
     authenticator::UserToken,
     info::ServerInfo,
-    node_manager::{get_namespaces_for_user, NodeManagers, RequestContext},
+    node_manager::{get_namespaces_for_user, NodeManagers, RequestContext, RequestContextInner},
     session::services,
     subscriptions::{PendingPublish, SubscriptionCache},
 };
@@ -121,15 +121,17 @@ impl<T> Request<T> {
     /// Get a request context object from this request.
     pub(super) fn context(&self) -> RequestContext {
         RequestContext {
-            session: self.session.clone(),
-            authenticator: self.info.authenticator.clone(),
-            token: self.token.clone(),
             current_node_manager_index: 0,
-            type_tree: self.info.type_tree.clone(),
-            type_tree_getter: self.info.type_tree_getter.clone(),
-            subscriptions: self.subscriptions.clone(),
-            session_id: self.session_id,
-            info: self.info.clone(),
+            inner: Arc::new(RequestContextInner {
+                session: self.session.clone(),
+                authenticator: self.info.authenticator.clone(),
+                token: self.token.clone(),
+                type_tree: self.info.type_tree.clone(),
+                type_tree_getter: self.info.type_tree_getter.clone(),
+                subscriptions: self.subscriptions.clone(),
+                session_id: self.session_id,
+                info: self.info.clone(),
+            }),
         }
     }
 }
@@ -366,15 +368,17 @@ impl MessageHandler {
         }
 
         let mut context = RequestContext {
-            session,
-            session_id,
-            authenticator: self.info.authenticator.clone(),
-            token,
             current_node_manager_index: 0,
-            type_tree: self.info.type_tree.clone(),
-            subscriptions: self.subscriptions.clone(),
-            info: self.info.clone(),
-            type_tree_getter: self.info.type_tree_getter.clone(),
+            inner: Arc::new(RequestContextInner {
+                session,
+                session_id,
+                authenticator: self.info.authenticator.clone(),
+                token,
+                type_tree: self.info.type_tree.clone(),
+                subscriptions: self.subscriptions.clone(),
+                info: self.info.clone(),
+                type_tree_getter: self.info.type_tree_getter.clone(),
+            }),
         };
 
         // Ignore the result
@@ -397,15 +401,17 @@ impl MessageHandler {
         token: UserToken,
     ) -> NamespaceMap {
         let ctx = RequestContext {
-            session,
-            authenticator: self.info.authenticator.clone(),
-            token,
             current_node_manager_index: 0,
-            type_tree: self.info.type_tree.clone(),
-            type_tree_getter: self.info.type_tree_getter.clone(),
-            subscriptions: self.subscriptions.clone(),
-            session_id,
-            info: self.info.clone(),
+            inner: Arc::new(RequestContextInner {
+                session,
+                session_id,
+                authenticator: self.info.authenticator.clone(),
+                token,
+                type_tree: self.info.type_tree.clone(),
+                subscriptions: self.subscriptions.clone(),
+                info: self.info.clone(),
+                type_tree_getter: self.info.type_tree_getter.clone(),
+            }),
         };
         get_namespaces_for_user(&ctx, &self.node_managers)
     }

--- a/async-opcua-server/src/session/services/method.rs
+++ b/async-opcua-server/src/session/services/method.rs
@@ -1,13 +1,19 @@
+use std::sync::Arc;
+
 use crate::{
-    node_manager::{consume_results, MethodCall, NodeManagers},
-    session::{controller::Response, message_handler::Request},
+    node_manager::{consume_results, DynNodeManager, MethodCall, NodeManagers, RequestContext},
+    session::{
+        controller::Response,
+        message_handler::Request,
+        services::{invoke_service_concurrently_mut, ServiceCb},
+    },
 };
 use opcua_types::{CallRequest, CallResponse, ResponseHeader, StatusCode};
 use tracing::debug_span;
 use tracing_futures::Instrument;
 
 pub(crate) async fn call(node_managers: NodeManagers, request: Request<CallRequest>) -> Response {
-    let mut context = request.context();
+    let context = request.context();
     let method_calls = take_service_items!(
         request,
         request.request.methods_to_call,
@@ -19,29 +25,38 @@ pub(crate) async fn call(node_managers: NodeManagers, request: Request<CallReque
         .map(|c| MethodCall::new(c, request.request.request_header.return_diagnostics))
         .collect();
 
-    for (idx, node_manager) in node_managers.into_iter().enumerate() {
-        context.current_node_manager_index = idx;
-        let mut owned: Vec<_> = calls
-            .iter_mut()
-            .filter(|c| {
-                node_manager.owns_node(c.method_id()) && c.status() == StatusCode::BadMethodInvalid
-            })
-            .collect();
+    struct MethodServiceCb;
 
-        if owned.is_empty() {
-            continue;
-        }
-
-        if let Err(e) = node_manager
-            .call(&context, &mut owned)
-            .instrument(debug_span!("Call", node_manager = %node_manager.name()))
-            .await
-        {
-            for call in owned {
-                call.set_status(e);
+    impl ServiceCb<MethodCall> for MethodServiceCb {
+        async fn call(
+            &self,
+            items: &mut [&mut MethodCall],
+            node_manager: &Arc<DynNodeManager>,
+            context: RequestContext,
+        ) {
+            if let Err(e) = node_manager
+                .call(&context, &mut *items)
+                .instrument(debug_span!("Call", node_manager = %node_manager.name()))
+                .await
+            {
+                for call in items {
+                    call.set_status(e);
+                }
             }
         }
     }
+
+    invoke_service_concurrently_mut(
+        context,
+        &mut calls,
+        &node_managers,
+        MethodServiceCb,
+        |call, node_manager| {
+            node_manager.owns_node(call.method_id())
+                && call.status() == StatusCode::BadMethodInvalid
+        },
+    )
+    .await;
 
     let (results, diagnostic_infos) =
         consume_results(calls, request.request.request_header.return_diagnostics);

--- a/async-opcua-server/src/session/services/mod.rs
+++ b/async-opcua-server/src/session/services/mod.rs
@@ -21,6 +21,8 @@ mod query;
 mod subscriptions;
 mod view;
 
+use std::{future::Future, sync::Arc};
+
 pub(super) use attribute::*;
 pub(super) use method::*;
 pub(super) use monitored_items::*;
@@ -28,3 +30,107 @@ pub(super) use node_management::*;
 pub(super) use query::*;
 pub(super) use subscriptions::*;
 pub(super) use view::*;
+
+use crate::node_manager::{DynNodeManager, NodeManagers, RequestContext};
+
+trait ServiceCb<T> {
+    fn call(
+        &self,
+        items: &mut [&mut T],
+        node_manager: &Arc<DynNodeManager>,
+        context: RequestContext,
+    ) -> impl Future<Output = ()> + Send;
+}
+
+/// Invokes a service concurrently across multiple node managers.
+/// Note that this assumes that each item is owned by exactly one node manager.
+/// If multiple return true for `filter`, the first one will be used.
+/// You need to manually implement the `ServiceCb` trait. This is a workaround
+/// for the lack of return type notation on async closures, otherwise we could use
+/// AsyncFn instead.
+async fn invoke_service_concurrently_mut<T, F>(
+    context: RequestContext,
+    items: &mut [T],
+    node_managers: &NodeManagers,
+    service: F,
+    filter: impl Fn(&T, &Arc<DynNodeManager>) -> bool,
+) where
+    F: ServiceCb<T> + Send + Sync,
+{
+    // Reuse a slice of mutable references.
+    // For each node manager, move the items that match the filter to the front of the slice.
+    // Then split the refs slice into two parts: the matching items and the rest.
+    // This way we don't need to allocate a new vector for each node manager.
+    // We do still need to allocate a vector for the references, but
+    // since we need to preserve the original order of the items, this is unavoidable.
+    let mut refs = items.iter_mut().collect::<Vec<_>>();
+    let mut refs_ch = refs.as_mut_slice();
+    let mut futures = Vec::with_capacity(node_managers.len());
+    for (i, node_manager) in node_managers.iter().enumerate() {
+        let mut end_idx = 0;
+        for i in 0..refs_ch.len() {
+            if filter(refs_ch[i], node_manager) {
+                refs_ch.swap(end_idx, i);
+                end_idx += 1;
+            }
+        }
+
+        let (group, next_ch) = refs_ch.split_at_mut(end_idx);
+        refs_ch = next_ch;
+
+        if !group.is_empty() {
+            let mut ctx = context.clone();
+            ctx.current_node_manager_index = i;
+            futures.push(service.call(group, node_manager, ctx));
+        }
+    }
+    futures::future::join_all(futures).await;
+}
+
+trait ServiceCbRef<T> {
+    fn call(
+        &self,
+        items: &[&T],
+        node_manager: &Arc<DynNodeManager>,
+        context: RequestContext,
+    ) -> impl Future<Output = ()> + Send;
+}
+
+async fn invoke_service_concurrently<T, F>(
+    context: RequestContext,
+    items: &[T],
+    node_managers: &NodeManagers,
+    service: F,
+    filter: impl Fn(&T, &Arc<DynNodeManager>) -> bool,
+) where
+    F: ServiceCbRef<T> + Send + Sync,
+{
+    // Reuse a slice of references.
+    // For each node manager, move the items that match the filter to the front of the slice.
+    // Then split the refs slice into two parts: the matching items and the rest.
+    // This way we don't need to allocate a new vector for each node manager.
+    // We do still need to allocate a vector for the references, but
+    // since we need to preserve the original order of the items, this is unavoidable.
+    let mut refs = items.iter().collect::<Vec<_>>();
+    let mut refs_ch = refs.as_mut_slice();
+    let mut futures = Vec::with_capacity(node_managers.len());
+    for (i, node_manager) in node_managers.iter().enumerate() {
+        let mut end_idx = 0;
+        for i in 0..refs_ch.len() {
+            if filter(refs_ch[i], node_manager) {
+                refs_ch.swap(end_idx, i);
+                end_idx += 1;
+            }
+        }
+
+        let (group, next_ch) = refs_ch.split_at_mut(end_idx);
+        refs_ch = next_ch;
+
+        if !group.is_empty() {
+            let mut ctx = context.clone();
+            ctx.current_node_manager_index = i;
+            futures.push(service.call(group, node_manager, ctx));
+        }
+    }
+    futures::future::join_all(futures).await;
+}

--- a/async-opcua-server/src/subscriptions/mod.rs
+++ b/async-opcua-server/src/subscriptions/mod.rs
@@ -33,6 +33,8 @@ use opcua_types::{
     TransferSubscriptionsResponse,
 };
 
+use crate::node_manager::RequestContextInner;
+
 use super::{
     authenticator::UserToken,
     info::ServerInfo,
@@ -178,15 +180,17 @@ impl SubscriptionCache {
                 (lck.session_id_numeric(), token.clone())
             };
             let ctx = RequestContext {
-                session,
-                session_id: id,
-                authenticator: context.authenticator.clone(),
-                token,
                 current_node_manager_index: 0,
-                type_tree: context.type_tree.clone(),
-                subscriptions: context.subscriptions.clone(),
-                info: context.info.clone(),
-                type_tree_getter: context.type_tree_getter.clone(),
+                inner: Arc::new(RequestContextInner {
+                    session,
+                    session_id: id,
+                    authenticator: context.authenticator.clone(),
+                    token,
+                    type_tree: context.type_tree.clone(),
+                    subscriptions: context.subscriptions.clone(),
+                    info: context.info.clone(),
+                    type_tree_getter: context.type_tree_getter.clone(),
+                }),
             };
 
             for mgr in context.node_managers.iter() {


### PR DESCRIPTION
I've had this lying around for some time, and figured I'd finish it up. It's on the todo list.

This implements a general way to run some of our services concurrently, notably _just_ the ones that are supposed to be run on one node manager specifically, like `Read` and `Write`.

This involved some slightly fiddly async code, but the result isn't too bad, and allows us to generalize a few things that we're not very consistent about, like setting `current_node_manager_index` between calls.

Doing this properly required cloning the `RequestContext`. I'm concerned about the cost of this clone, which up until now we've been pretty lazy about, so I moved the shared part into an `inner` field behind an `Arc`. To avoid this breaking every server implementation I added a `Deref<RequestContextInner>` to `RequestContext` which is a bad practice, but does seem alright in this case. The alternative is to make the fields non-public and expose getters, but then every node manager implementation will have a hundred breaking changes.