### PR TITLE
corrects the sample server config to match the `Limits` struct fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "postcard",
  "regex",
  "serde",
+ "serde_yaml",
  "tokio",
  "tokio-util",
  "tracing",

--- a/async-opcua-codegen/src/ids/mod.rs
+++ b/async-opcua-codegen/src/ids/mod.rs
@@ -29,7 +29,7 @@ pub fn generate_node_ids(
     pairs.sort_by(|a, b| a.0.cmp(&b.0));
     let mut items = Vec::new();
     for (_, item) in pairs {
-        items.extend(render(item)?.into_iter());
+        items.extend(render(item)?);
     }
     Ok(syn::File {
         shebang: None,

--- a/async-opcua-codegen/src/lib.rs
+++ b/async-opcua-codegen/src/lib.rs
@@ -173,7 +173,7 @@ pub fn run_codegen(config: &CodeGenConfig, root_path: &str) -> Result<(), CodeGe
                 let mut module_file = create_module_file(modules);
                 module_file
                     .items
-                    .extend(type_loader_impl(&object_ids, &target_namespace).into_iter());
+                    .extend(type_loader_impl(&object_ids, &target_namespace));
 
                 write_module_file(&t.output_dir, root_path, &header, module_file)
                     .map_err(|e| e.in_file(&path))?;

--- a/async-opcua-codegen/src/types/mod.rs
+++ b/async-opcua-codegen/src/types/mod.rs
@@ -113,7 +113,7 @@ pub fn generate_types(
             .ignore
             .iter()
             .cloned()
-            .chain(base_ignored_types().into_iter())
+            .chain(base_ignored_types())
             .collect(),
         base_native_type_mappings(),
         &input.xml,

--- a/async-opcua-nodes/src/events/evaluate.rs
+++ b/async-opcua-nodes/src/events/evaluate.rs
@@ -416,13 +416,9 @@ fn like_to_regex(v: &str) -> Result<Regex, ()> {
                     }
                     pattern.push(*c);
                 }
-                '%' => {
-                    if i == 0 || v[i - 1] != '\\' {
-                        // A % is a match on zero or more chans unless it is escaped
-                        pattern.push_str(".*");
-                    } else {
-                        pattern.push(*c);
-                    }
+                // A % is a match on zero or more chans unless it is escaped
+                '%' if i == 0 || v[i - 1] != '\\' => {
+                    pattern.push_str(".*");
                 }
                 '_' => {
                     if i == 0 || v[i - 1] != '\\' {

--- a/async-opcua-nodes/src/type_tree.rs
+++ b/async-opcua-nodes/src/type_tree.rs
@@ -270,10 +270,7 @@ impl DefaultTypeTree {
     pub fn get_all_children<'a>(&'a self, root: &'a NodeId) -> Vec<&'a NodeId> {
         let mut res = Vec::new();
         let mut roots = vec![root];
-        loop {
-            let Some(root) = roots.pop() else {
-                break;
-            };
+        while let Some(root) = roots.pop() {
             res.push(root);
             let Some(children) = self.subtypes_by_source.get(root) else {
                 continue;

--- a/async-opcua-nodes/src/variable.rs
+++ b/async-opcua-nodes/src/variable.rs
@@ -516,14 +516,12 @@ impl Variable {
         // A special case is required here for when the variable is a single dimension
         // byte array and the value is a ByteString.
         match self.value_rank {
-            -3 | -2 | 1 => {
-                if self.data_type == DataTypeId::Byte {
-                    if let Variant::ByteString(_) = value {
-                        // Convert the value from a byte string to a byte array
-                        value = value
-                            .to_byte_array()
-                            .map_err(|_| StatusCode::BadUnexpectedError)?;
-                    }
+            -3 | -2 | 1 if self.data_type == DataTypeId::Byte => {
+                if let Variant::ByteString(_) = value {
+                    // Convert the value from a byte string to a byte array
+                    value = value
+                        .to_byte_array()
+                        .map_err(|_| StatusCode::BadUnexpectedError)?;
                 }
             }
             _ => { /* DO NOTHING */ }

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -58,6 +58,7 @@ async-opcua-server = { path = ".", features = [
   "discovery-server-registration",
   "json",
 ] }
+serde_yaml = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/async-opcua-server/src/config/limits.rs
+++ b/async-opcua-server/src/config/limits.rs
@@ -333,3 +333,71 @@ mod defaults {
         constants::MAX_SUBSCRIPTIONS_PER_CALL
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Ensures that the `limits` section of `samples/server.conf` stays in
+    /// sync with the `Limits` struct fields.
+    #[test]
+    fn server_conf_limits_match_struct_field_names() {
+        let conf_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../samples/server.conf");
+        let content = fs::read_to_string(&conf_path).unwrap();
+        let full_config: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let limits_value = full_config.get("limits").unwrap().clone();
+        let limits: Limits = serde_yaml::from_value(limits_value).unwrap();
+
+        assert_eq!(
+            limits,
+            Limits {
+                max_array_length: 100_000,
+                max_string_length: 65_535,
+                max_byte_string_length: 65_535,
+                max_message_size: 327_675,
+                max_chunk_count: 5,
+                send_buffer_size: 65_535,
+                receive_buffer_size: 65_535,
+                max_browse_continuation_points: 5_000,
+                max_history_continuation_points: 500,
+                max_query_continuation_points: 500,
+                max_sessions: 20,
+                subscriptions: SubscriptionLimits {
+                    max_subscriptions_per_session: 100,
+                    max_pending_publish_requests: 20,
+                    max_publish_requests_per_subscription: 4,
+                    min_sampling_interval_ms: 0.1,
+                    min_publishing_interval_ms: 0.1,
+                    max_keep_alive_count: 30_000,
+                    default_keep_alive_count: 10,
+                    max_monitored_items_per_sub: 0,
+                    max_monitored_item_queue_size: 10,
+                    max_lifetime_count: 90_000,
+                    max_notifications_per_publish: 0,
+                    max_queued_notifications: 20,
+                },
+                operational: OperationalLimits {
+                    max_nodes_per_translate_browse_paths_to_node_ids: 100,
+                    max_nodes_per_read: 10_000,
+                    max_nodes_per_write: 10_000,
+                    max_nodes_per_method_call: 100,
+                    max_nodes_per_browse: 1_000,
+                    max_nodes_per_register_nodes: 1_000,
+                    max_monitored_items_per_call: 1_000,
+                    max_nodes_per_history_read_data: 100,
+                    max_nodes_per_history_read_events: 100,
+                    max_nodes_per_history_update: 100,
+                    max_references_per_browse_node: 1_000,
+                    max_node_descs_per_query: 100,
+                    max_data_sets_query_return: 1_000,
+                    max_references_query_return: 100,
+                    max_nodes_per_node_management: 1_000,
+                    max_references_per_references_management: 1_000,
+                    max_subscriptions_per_call: 10,
+                },
+            }
+        );
+    }
+}

--- a/async-opcua-server/src/session/services/view.rs
+++ b/async-opcua-server/src/session/services/view.rs
@@ -312,7 +312,7 @@ pub(crate) async fn browse_next(
         {
             let mut session = request.session.write();
             let type_tree = context.get_type_tree_for_user();
-            for mut node in nodes.into_iter().chain(batch_nodes.into_iter()) {
+            for mut node in nodes.into_iter().chain(batch_nodes) {
                 node.resolve_external_references(type_tree.get(), &node_map);
 
                 let (result, input_index) =

--- a/async-opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/async-opcua-server/src/subscriptions/session_subscriptions.rs
@@ -588,7 +588,7 @@ impl SessionSubscriptions {
                 .values()
                 .map(|v| (v.id(), v.priority()))
                 .collect();
-            subscription_priority.sort_by(|s1, s2| s1.1.cmp(&s2.1));
+            subscription_priority.sort_by_key(|s1| s1.1);
             subscription_priority.into_iter().map(|s| s.0)
         };
 

--- a/async-opcua-types/src/relative_path.rs
+++ b/async-opcua-types/src/relative_path.rs
@@ -51,15 +51,13 @@ impl RelativePath {
                         // The next character is escaped and part of the token
                         escaped_char = true;
                     }
-                    '/' | '.' | '<' => {
-                        // We have reached the start of a token and need to process the previous one
-                        if !token.is_empty() {
-                            if elements.len() == Self::MAX_ELEMENTS {
-                                break;
-                            }
-                            elements.push(RelativePathElement::from_str(&token, node_resolver)?);
-                            token.clear();
+                    // We have reached the start of a token and need to process the previous one
+                    '/' | '.' | '<' if !token.is_empty() => {
+                        if elements.len() == Self::MAX_ELEMENTS {
+                            break;
                         }
+                        elements.push(RelativePathElement::from_str(&token, node_resolver)?);
+                        token.clear();
                     }
                     _ => {}
                 }

--- a/async-opcua-types/src/variant/mod.rs
+++ b/async-opcua-types/src/variant/mod.rs
@@ -1573,7 +1573,7 @@ impl Variant {
                     let v = self.range_of(range)?;
                     match v {
                         Variant::Array(a) => {
-                            res.extend(a.values.into_iter());
+                            res.extend(a.values);
                         }
                         r => res.push(r),
                     }

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -14,19 +14,48 @@ tcp_config:
   host: localhost
   port: 4855
 limits:
-  clients_can_modify_address_space: false
-  max_subscriptions: 100
-  max_monitored_items_per_sub: 0
-  max_monitored_item_queue_size: 10
   max_array_length: 100000
   max_string_length: 65535
   max_byte_string_length: 65535
-  min_sampling_interval: 0.1
-  min_publishing_interval: 0.1
   max_message_size: 327675
   max_chunk_count: 5
   send_buffer_size: 65535
   receive_buffer_size: 65535
+  max_browse_continuation_points: 5000
+  max_history_continuation_points: 500
+  max_query_continuation_points: 500
+  max_sessions: 20
+  subscriptions:
+    max_subscriptions_per_session: 100
+    max_pending_publish_requests: 20
+    max_publish_requests_per_subscription: 4
+    min_sampling_interval_ms: 0.1
+    min_publishing_interval_ms: 0.1
+    max_keep_alive_count: 30000
+    default_keep_alive_count: 10
+    max_monitored_items_per_sub: 0
+    max_monitored_item_queue_size: 10
+    max_lifetime_count: 90000
+    max_notifications_per_publish: 0
+    max_queued_notifications: 20
+  operational:
+    max_nodes_per_translate_browse_paths_to_node_ids: 100
+    max_nodes_per_read: 10000
+    max_nodes_per_write: 10000
+    max_nodes_per_method_call: 100
+    max_nodes_per_browse: 1000
+    max_nodes_per_register_nodes: 1000
+    max_monitored_items_per_call: 1000
+    max_nodes_per_history_read_data: 100
+    max_nodes_per_history_read_events: 100
+    max_nodes_per_history_update: 100
+    max_references_per_browse_node: 1000
+    max_node_descs_per_query: 100
+    max_data_sets_query_return: 1000
+    max_references_query_return: 100
+    max_nodes_per_node_management: 1000
+    max_references_per_references_management: 1000
+    max_subscriptions_per_call: 10
 locale_ids:
 - en
 user_tokens:


### PR DESCRIPTION
This PR corrects the `server.conf` to match the actual structure of the server config. Right now the incorrect keys were silently swallowed and replaced with the default values of the config. 

I also added a test that should prevent the config file going out of sync with the code.