### PR TITLE
Fix: handle zero length array dimension in argument decode

### DIFF
--- a/async-opcua-types/src/argument.rs
+++ b/async-opcua-types/src/argument.rs
@@ -10,6 +10,7 @@
 //! It is for example used in the input and output argument Properties for Methods.
 //! Its elements are described in Table 28.
 
+use std::cmp::Ordering;
 use std::io::{Read, Write};
 
 use crate::{
@@ -107,10 +108,21 @@ impl BinaryDecodable for Argument {
         let data_type = NodeId::decode(stream, ctx)?;
         let value_rank = i32::decode(stream, ctx)?;
         // Decode array dimensions
-        let array_dimensions: Option<Vec<u32>> = BinaryDecodable::decode(stream, ctx)?;
-        if let Some(ref array_dimensions) = array_dimensions {
-            if value_rank > 0 && value_rank as usize != array_dimensions.len() {
-                return Err(Error::decoding(format!("The array dimensions {} of the Argument should match value rank {} and they don't", array_dimensions.len(), value_rank)));
+        let mut array_dimensions: Option<Vec<u32>> = BinaryDecodable::decode(stream, ctx)?;
+        if value_rank > 0 {
+            if let Some(array_dimensions) = array_dimensions.as_mut() {
+                let expected_rank = value_rank as usize;
+                match array_dimensions.len().cmp(&expected_rank) {
+                    Ordering::Less => {
+                        // If fewer dimensions are provided than rank, pad with 0 to reach rank length
+                        array_dimensions.resize(expected_rank, 0);
+                    }
+                    Ordering::Equal => {}
+                    Ordering::Greater => {
+                        // More dimensions than value_rank is internally inconsistent
+                        return Err(Error::decoding(format!("The array dimensions {} of the Argument should match value rank {} and they don't", array_dimensions.len(), value_rank)));
+                    }
+                }
             }
         }
         let description = LocalizedText::decode(stream, ctx)?;

--- a/async-opcua-types/src/tests/encoding.rs
+++ b/async-opcua-types/src/tests/encoding.rs
@@ -499,6 +499,45 @@ fn argument() {
     });
 }
 
+#[test]
+fn argument_decode_pads_dimensions_when_shorter_than_rank() {
+    // sending value_rank=3, array_dimensions=[]
+    // should decode to value_rank=3, array_dimensions=[0, 0, 0]
+    let ctx_f = ContextOwned::default();
+    let ctx = ctx_f.context();
+    let mut stream = Cursor::new(Vec::new());
+    UAString::from("arg").encode(&mut stream, &ctx).unwrap();
+    NodeId::null().encode(&mut stream, &ctx).unwrap();
+    3i32.encode(&mut stream, &ctx).unwrap();
+    Some::<Vec<u32>>(vec![]).encode(&mut stream, &ctx).unwrap();
+    LocalizedText::new("foo", "bar")
+        .encode(&mut stream, &ctx)
+        .unwrap();
+    let mut stream = Cursor::new(stream.into_inner());
+    let decoded = Argument::decode(&mut stream, &ctx).unwrap();
+    assert_eq!(decoded.value_rank, 3);
+    assert_eq!(decoded.array_dimensions, Some(vec![0, 0, 0]));
+}
+#[test]
+fn argument_decode_errors_when_dimensions_exceed_rank() {
+    // sending value_rank=2, array_dimensions=[5, 6, 7]
+    // should fail to decode
+    let ctx_f = ContextOwned::default();
+    let ctx = ctx_f.context();
+    // Build binary payload manually so decode sees len > value_rank.
+    let mut stream = Cursor::new(Vec::new());
+    UAString::from("arg").encode(&mut stream, &ctx).unwrap();
+    NodeId::null().encode(&mut stream, &ctx).unwrap();
+    1i32.encode(&mut stream, &ctx).unwrap();
+    Some(vec![1u32, 2u32]).encode(&mut stream, &ctx).unwrap();
+    LocalizedText::new("foo", "bar")
+        .encode(&mut stream, &ctx)
+        .unwrap();
+    let mut stream = Cursor::new(stream.into_inner());
+    let err = Argument::decode(&mut stream, &ctx).unwrap_err();
+    assert_eq!(err.status(), StatusCode::BadDecodingError);
+}
+
 // test decoding of an null array  null != empty!
 #[test]
 fn null_array() {


### PR DESCRIPTION
fixes #215

Ensure `Argument::decode` handles `array_dimensions` length mismatch with `value_rank`. Add padding when dimensions are shorter, maintain dimensions when matching, and error when exceeding. Include corresponding tests.