### PR TITLE
Client error improvements

### DIFF
--- a/async-opcua-client/src/browser/browse.rs
+++ b/async-opcua-client/src/browser/browse.rs
@@ -199,8 +199,7 @@ async fn run_browse<R: RequestRetryPolicy>(
                         .nodes_to_browse(items.iter().map(|r| r.request.clone()).collect()),
                     policy,
                 )
-                .await
-                .map_err(|e| Error::new(e, "Browse failed"))?;
+                .await?;
 
             let res = r.results.unwrap_or_default();
             if res.len() != items.len() {
@@ -238,8 +237,7 @@ async fn run_browse<R: RequestRetryPolicy>(
                         .continuation_points(items.iter().map(|r| r.cp.clone()).collect()),
                     policy,
                 )
-                .await
-                .map_err(|e| Error::new(e, "BrowseNext failed"))?;
+                .await?;
 
             let res = r.results.unwrap_or_default();
             if res.len() != items.len() {

--- a/async-opcua-client/src/custom_types/mod.rs
+++ b/async-opcua-client/src/custom_types/mod.rs
@@ -177,8 +177,7 @@ impl<T: FnMut(&NodeId) -> bool> DataTypeTreeBuilder<T> {
 
             let r = session
                 .read(chunk, TimestampsToReturn::Neither, 0.0)
-                .await
-                .map_err(|e| Error::new(e, "Failed to read type definitions"))?;
+                .await?;
 
             for (val, id) in r.into_iter().zip(chunk.iter()) {
                 let entry = type_data.entry(id.node_id.clone()).or_default();

--- a/async-opcua-client/src/session/client.rs
+++ b/async-opcua-client/src/session/client.rs
@@ -295,7 +295,7 @@ impl Client {
         channel: &AsyncSecureChannel,
         locale_ids: Option<Vec<UAString>>,
         profile_uris: Option<Vec<UAString>>,
-    ) -> Result<Vec<EndpointDescription>, StatusCode> {
+    ) -> Result<Vec<EndpointDescription>, Error> {
         let request = GetEndpointsRequest {
             request_header: channel.make_request_header(self.config.request_timeout),
             endpoint_url: endpoint.endpoint_url.clone(),
@@ -363,10 +363,7 @@ impl Client {
         };
         let channel = self.channel_from_endpoint_info(endpoint_info, self.config.channel_lifetime);
 
-        let mut evt_loop = channel
-            .connect(&server)
-            .await
-            .map_err(|e| Error::new(e, "Failed to connect to server"))?;
+        let mut evt_loop = channel.connect(&server).await?;
 
         let send_fut = self.get_server_endpoints_inner(
             &endpoint,
@@ -391,7 +388,7 @@ impl Client {
                         return Err(Error::new(e, "Transport closed unexpectedly"));
                     }
                 },
-                res = &mut send_fut => break res.map_err(|e| Error::new(e, "Failed to get endpoints")),
+                res = &mut send_fut => break res,
             }
         };
 
@@ -412,7 +409,7 @@ impl Client {
         channel: &AsyncSecureChannel,
         locale_ids: Option<Vec<UAString>>,
         server_uris: Option<Vec<UAString>>,
-    ) -> Result<Vec<ApplicationDescription>, StatusCode> {
+    ) -> Result<Vec<ApplicationDescription>, Error> {
         let request = FindServersRequest {
             request_header: channel.make_request_header(self.config.request_timeout),
             endpoint_url: endpoint_url.into(),
@@ -441,13 +438,13 @@ impl Client {
     /// # Returns
     ///
     /// * `Ok(Vec<ApplicationDescription>)` - List of descriptions for servers known to the discovery server.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     pub async fn find_servers(
         &self,
         discovery_endpoint: impl ConnectorBuilder,
         locale_ids: Option<Vec<UAString>>,
         server_uris: Option<Vec<UAString>>,
-    ) -> Result<Vec<ApplicationDescription>, StatusCode> {
+    ) -> Result<Vec<ApplicationDescription>, Error> {
         let discovery_endpoint = discovery_endpoint.build()?;
         let endpoint = discovery_endpoint.default_endpoint();
         let session_info = EndpointInfo {
@@ -471,7 +468,7 @@ impl Client {
             select! {
                 r = evt_loop.poll() => {
                     if let TransportPollResult::Closed(e) = r {
-                        return Err(e);
+                        return Err(Error::new(e, "Connection closed unexpectedly"));
                     }
                 },
                 res = &mut send_fut => break res
@@ -495,7 +492,7 @@ impl Client {
         max_records_to_return: u32,
         server_capability_filter: Option<Vec<UAString>>,
         channel: &AsyncSecureChannel,
-    ) -> Result<FindServersOnNetworkResponse, StatusCode> {
+    ) -> Result<FindServersOnNetworkResponse, Error> {
         let request = FindServersOnNetworkRequest {
             request_header: channel.make_request_header(self.config.request_timeout),
             starting_record_id,
@@ -536,7 +533,7 @@ impl Client {
         starting_record_id: u32,
         max_records_to_return: u32,
         server_capability_filter: Option<Vec<UAString>>,
-    ) -> Result<FindServersOnNetworkResponse, StatusCode> {
+    ) -> Result<FindServersOnNetworkResponse, Error> {
         let discovery_endpoint = discovery_endpoint.build()?;
         let endpoint = discovery_endpoint.default_endpoint();
         let session_info = EndpointInfo {
@@ -560,7 +557,7 @@ impl Client {
             select! {
                 r = evt_loop.poll() => {
                     if let TransportPollResult::Closed(e) = r {
-                        return Err(e);
+                        return Err(Error::new(e, "Connection closed unexpectedly"));
                     }
                 },
                 res = &mut send_fut => break res
@@ -643,7 +640,7 @@ impl Client {
         &self,
         server: RegisteredServer,
         channel: &AsyncSecureChannel,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         let request = RegisterServerRequest {
             request_header: channel.make_request_header(self.config.request_timeout),
             server,
@@ -712,14 +709,14 @@ impl Client {
     /// # Returns
     ///
     /// * `Ok(())` - Success
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn register_server(
         &self,
         connector: impl ConnectorBuilder,
         server_endpoint: &EndpointDescription,
         server: RegisteredServer,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         let endpoint_info = EndpointInfo {
             endpoint: server_endpoint.clone(),
             user_identity_token: IdentityToken::Anonymous,
@@ -737,7 +734,7 @@ impl Client {
             select! {
                 r = evt_loop.poll() => {
                     if let TransportPollResult::Closed(e) = r {
-                        return Err(e);
+                        return Err(Error::new(e, "Connection closed unexpectedly"));
                     }
                 },
                 res = &mut send_fut => break res

--- a/async-opcua-client/src/session/connect.rs
+++ b/async-opcua-client/src/session/connect.rs
@@ -4,7 +4,7 @@ use tokio::{pin, select};
 use tracing::{info, info_span, Instrument};
 
 use crate::transport::{Connector, SecureChannelEventLoop, TransportPollResult};
-use opcua_types::{NodeId, StatusCode};
+use opcua_types::{Error, NodeId};
 
 use super::Session;
 
@@ -32,14 +32,14 @@ impl SessionConnector {
     pub(super) async fn try_connect<T: Connector>(
         &self,
         connector: &T,
-    ) -> Result<(SecureChannelEventLoop<T::Transport>, SessionConnectMode), StatusCode> {
+    ) -> Result<(SecureChannelEventLoop<T::Transport>, SessionConnectMode), Error> {
         self.connect_and_activate(connector).await
     }
 
     async fn connect_and_activate<T: Connector>(
         &self,
         connector: &T,
-    ) -> Result<(SecureChannelEventLoop<T::Transport>, SessionConnectMode), StatusCode> {
+    ) -> Result<(SecureChannelEventLoop<T::Transport>, SessionConnectMode), Error> {
         let span = info_span!(
             "Attempting to create and activate session to server",
             endpoint_url = connector.default_endpoint().endpoint_url.as_ref()
@@ -58,7 +58,7 @@ impl SessionConnector {
             select! {
                 r = event_loop.poll() => {
                     if let TransportPollResult::Closed(c) = r {
-                        return Err(c);
+                        return Err(Error::new(c, "Transport closed while activating session"));
                     }
                 },
                 r = &mut activate_fut => break r,
@@ -83,7 +83,7 @@ impl SessionConnector {
         Ok((event_loop, id))
     }
 
-    async fn ensure_and_activate_session(&self) -> Result<SessionConnectMode, StatusCode> {
+    async fn ensure_and_activate_session(&self) -> Result<SessionConnectMode, Error> {
         let should_create_session = self.inner.session_id.load().is_null();
 
         if should_create_session {

--- a/async-opcua-client/src/session/event_loop.rs
+++ b/async-opcua-client/src/session/event_loop.rs
@@ -12,7 +12,7 @@ use crate::{
     transport::{Connector, SecureChannelEventLoop, Transport, TransportPollResult},
 };
 use opcua_types::{
-    AttributeId, QualifiedName, ReadValueId, StatusCode, TimestampsToReturn, VariableId,
+    AttributeId, Error, QualifiedName, ReadValueId, StatusCode, TimestampsToReturn, VariableId,
 };
 
 use super::{
@@ -51,7 +51,7 @@ struct ConnectedState<T: Transport + Send + Sync + 'static> {
     subscriptions: BoxStream<'static, SubscriptionActivity>,
     current_failed_keep_alive_count: u64,
     currently_closing: bool,
-    disconnect_fut: BoxFuture<'static, Result<(), StatusCode>>,
+    disconnect_fut: BoxFuture<'static, Result<(), Error>>,
 }
 
 // The way this is passed around, the Connected state being larger is
@@ -266,10 +266,10 @@ impl<T: Connector + Send + Sync + 'static> SessionEventLoop<T> {
                                 ))
                             }
                             Err(e) => {
-                                warn!("Failed to connect to server, status code: {e}");
+                                warn!("Failed to connect to server: {e}");
                                 match backoff.next() {
                                     Some(x) => Ok((
-                                        SessionPollResult::ReconnectFailed(e),
+                                        SessionPollResult::ReconnectFailed(e.status()),
                                         SessionEventLoopState::Connecting(
                                             connector,
                                             backoff,
@@ -371,7 +371,7 @@ impl SessionActivityLoop {
                                 slf,
                             ))
                         }
-                        Err(e) => return Some((SessionActivity::KeepAliveFailed(e), slf)),
+                        Err(e) => return Some((SessionActivity::KeepAliveFailed(e.status()), slf)),
                     };
 
                     match data_value.value.and_then(|v| v.try_cast_to().ok()) {

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -124,33 +124,45 @@ use super::IdentityToken;
 
 /// Process the service result, i.e. where the request "succeeded" but the response
 /// contains a failure status code.
-pub(crate) fn process_service_result(response_header: &ResponseHeader) -> Result<(), StatusCode> {
+pub(crate) fn process_service_result(response_header: &ResponseHeader) -> Result<(), Error> {
     if response_header.service_result.is_bad() {
         info!(
             "Received a bad service result {} from the request",
             response_header.service_result
         );
-        Err(response_header.service_result)
+        Err(Error::new(
+            response_header.service_result,
+            "Received a bad service result from the server",
+        ))
     } else {
         Ok(())
     }
 }
 
-pub(crate) fn process_unexpected_response(response: ResponseMessage) -> StatusCode {
+pub(crate) fn process_unexpected_response(response: ResponseMessage) -> Error {
     match response {
         ResponseMessage::ServiceFault(service_fault) => {
             error!(
                 "Received a service fault of {} for the request",
                 service_fault.response_header.service_result
             );
-            service_fault.response_header.service_result
+            Error::new(
+                service_fault.response_header.service_result,
+                "Request returned ServiceFault",
+            )
         }
         _ => {
             error!(
                 "Received an unexpected response to the request: {}",
                 response.type_name()
             );
-            StatusCode::BadUnknownResponse
+            Error::new(
+                StatusCode::BadUnknownResponse,
+                format!(
+                    "Received an unexpected response to the request: {}",
+                    response.type_name()
+                ),
+            )
         }
     }
 }
@@ -320,17 +332,17 @@ impl Session {
         &self,
         delete_subscriptions: bool,
         disable_reconnect: bool,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         if disable_reconnect {
             self.should_reconnect.store(false, Ordering::Relaxed);
         }
         let mut res = Ok(());
         if let Err(e) = self.close_session(delete_subscriptions).await {
-            res = Err(e);
             session_warn!(
                 self,
                 "Failed to close session, channel will be closed anyway: {e}"
             );
+            res = Err(e);
         }
         self.channel.close_channel().await;
 
@@ -343,12 +355,12 @@ impl Session {
     /// This will set the `should_reconnect` flag to false on the session, indicating
     /// that it should not attempt to reconnect to the server. You may clear this flag
     /// yourself to
-    pub async fn disconnect(&self) -> Result<(), StatusCode> {
+    pub async fn disconnect(&self) -> Result<(), Error> {
         self.disconnect_inner(true, true).await
     }
 
     /// Disconnect the server without deleting subscriptions, then wait until disconnected.
-    pub async fn disconnect_without_delete_subscriptions(&self) -> Result<(), StatusCode> {
+    pub async fn disconnect_without_delete_subscriptions(&self) -> Result<(), Error> {
         self.disconnect_inner(false, true).await
     }
 
@@ -425,10 +437,7 @@ impl Session {
                 TimestampsToReturn::Neither,
                 0.0,
             )
-            .await
-            .map_err(|status_code| {
-                Error::new(status_code, "Reading Server namespace array failed")
-            })?;
+            .await?;
         if let Some(Variant::Array(array)) = &result[0].value {
             let map = NamespaceMap::new_from_variant_array(&array.values)
                 .map_err(|e| Error::new(StatusCode::Bad, e))?;

--- a/async-opcua-client/src/session/request_builder.rs
+++ b/async-opcua-client/src/session/request_builder.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, time::Duration};
 
-use opcua_types::{DateTime, DiagnosticBits, IntegerId, NodeId, RequestHeader, StatusCode};
+use opcua_types::{DateTime, DiagnosticBits, Error, IntegerId, NodeId, RequestHeader};
 
 use crate::AsyncSecureChannel;
 
@@ -15,7 +15,7 @@ pub trait UARequest {
     fn send<'a>(
         self,
         channel: &'a AsyncSecureChannel,
-    ) -> impl Future<Output = Result<Self::Out, StatusCode>> + Send + 'a
+    ) -> impl Future<Output = Result<Self::Out, Error>> + Send + 'a
     where
         Self: 'a;
 }

--- a/async-opcua-client/src/session/retry.rs
+++ b/async-opcua-client/src/session/retry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use futures::FutureExt;
-use opcua_types::StatusCode;
+use opcua_types::{Error, StatusCode};
 
 use crate::retry::ExponentialBackoff;
 
@@ -136,7 +136,7 @@ impl Session {
         &self,
         request: T,
         mut policy: impl RequestRetryPolicy,
-    ) -> Result<T::Out, StatusCode> {
+    ) -> Result<T::Out, Error> {
         loop {
             let next_request = request.clone();
             // Removing `boxed` here causes any futures calling this to be non-send,
@@ -146,7 +146,7 @@ impl Session {
             match next_request.send(&self.channel).boxed().await {
                 Ok(r) => break Ok(r),
                 Err(e) => {
-                    if let Some(delay) = policy.get_next_delay(e) {
+                    if let Some(delay) = policy.get_next_delay(e.status()) {
                         session_debug!(self, "Request failed, retrying after {delay:?}");
                         tokio::time::sleep(delay).await;
                     } else {

--- a/async-opcua-client/src/session/services/attributes.rs
+++ b/async-opcua-client/src/session/services/attributes.rs
@@ -12,12 +12,13 @@ use crate::{
 };
 use opcua_core::ResponseMessage;
 use opcua_types::{
-    DataValue, DeleteAtTimeDetails, DeleteEventDetails, DeleteRawModifiedDetails, ExtensionObject,
-    HistoryReadRequest, HistoryReadResponse, HistoryReadResult, HistoryReadValueId,
-    HistoryUpdateRequest, HistoryUpdateResponse, HistoryUpdateResult, IntegerId, NodeId,
-    ReadAtTimeDetails, ReadEventDetails, ReadProcessedDetails, ReadRawModifiedDetails, ReadRequest,
-    ReadResponse, ReadValueId, StatusCode, TimestampsToReturn, UpdateDataDetails,
-    UpdateEventDetails, UpdateStructureDataDetails, WriteRequest, WriteResponse, WriteValue,
+    DataValue, DeleteAtTimeDetails, DeleteEventDetails, DeleteRawModifiedDetails, Error,
+    ExtensionObject, HistoryReadRequest, HistoryReadResponse, HistoryReadResult,
+    HistoryReadValueId, HistoryUpdateRequest, HistoryUpdateResponse, HistoryUpdateResult,
+    IntegerId, NodeId, ReadAtTimeDetails, ReadEventDetails, ReadProcessedDetails,
+    ReadRawModifiedDetails, ReadRequest, ReadResponse, ReadValueId, StatusCode, TimestampsToReturn,
+    UpdateDataDetails, UpdateEventDetails, UpdateStructureDataDetails, WriteRequest, WriteResponse,
+    WriteValue,
 };
 use tracing::{debug_span, Instrument};
 
@@ -174,7 +175,7 @@ builder_base!(Read);
 impl UARequest for Read {
     type Out = ReadResponse;
 
-    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'b,
     {
@@ -188,7 +189,10 @@ impl UARequest for Read {
             let _h = span.enter();
             if self.nodes_to_read.is_empty() {
                 builder_error!(self, "read(), was not supplied with any nodes to read");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "read was not supplied with any nodes to read",
+                ));
             }
             ReadRequest {
                 request_header: self.header.header,
@@ -296,7 +300,7 @@ impl HistoryRead {
 impl UARequest for HistoryRead {
     type Out = HistoryReadResponse;
 
-    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'b,
     {
@@ -395,7 +399,7 @@ impl Write {
 impl UARequest for Write {
     type Out = WriteResponse;
 
-    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -407,7 +411,10 @@ impl UARequest for Write {
             let _h = span.enter();
             if self.nodes_to_write.is_empty() {
                 builder_error!(self, "write(), was not supplied with any nodes to write");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "write was not supplied with any nodes to write",
+                ));
             }
             WriteRequest {
                 request_header: self.header.header,
@@ -489,7 +496,7 @@ impl HistoryUpdate {
 impl UARequest for HistoryUpdate {
     type Out = HistoryUpdateResponse;
 
-    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -504,7 +511,10 @@ impl UARequest for HistoryUpdate {
                     self,
                     "history_update(), was not supplied with any detail to update"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "history update was not supplied with any update details",
+                ));
             }
             let details = self
                 .details
@@ -550,14 +560,14 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<DataValue>)` - A list of [`DataValue`] corresponding to each read operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn read(
         &self,
         nodes_to_read: &[ReadValueId],
         timestamps_to_return: TimestampsToReturn,
         max_age: f64,
-    ) -> Result<Vec<DataValue>, StatusCode> {
+    ) -> Result<Vec<DataValue>, Error> {
         Ok(Read::new(self)
             .nodes_to_read(nodes_to_read.to_vec())
             .timestamps_to_return(timestamps_to_return)
@@ -588,7 +598,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<HistoryReadResult>)` - A list of [`HistoryReadResult`] results corresponding to history read operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn history_read(
         &self,
@@ -596,7 +606,7 @@ impl Session {
         timestamps_to_return: TimestampsToReturn,
         release_continuation_points: bool,
         nodes_to_read: &[HistoryReadValueId],
-    ) -> Result<Vec<HistoryReadResult>, StatusCode> {
+    ) -> Result<Vec<HistoryReadResult>, Error> {
         Ok(HistoryRead::new(history_read_details, self)
             .timestamps_to_return(timestamps_to_return)
             .release_continuation_points(release_continuation_points)
@@ -619,12 +629,9 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - A list of [`StatusCode`] results corresponding to each write operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub async fn write(
-        &self,
-        nodes_to_write: &[WriteValue],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    pub async fn write(&self, nodes_to_write: &[WriteValue]) -> Result<Vec<StatusCode>, Error> {
         Ok(Write::new(self)
             .nodes_to_write(nodes_to_write.to_vec())
             .send(&self.channel)
@@ -652,12 +659,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<HistoryUpdateResult>)` - A list of [`HistoryUpdateResult`] results corresponding to history update operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn history_update(
         &self,
         history_update_details: &[HistoryUpdateAction],
-    ) -> Result<Vec<HistoryUpdateResult>, StatusCode> {
+    ) -> Result<Vec<HistoryUpdateResult>, Error> {
         Ok(HistoryUpdate::new(self)
             .details(history_update_details.to_vec())
             .send(&self.channel)

--- a/async-opcua-client/src/session/services/method.rs
+++ b/async-opcua-client/src/session/services/method.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 use opcua_core::ResponseMessage;
 use opcua_types::{
-    CallMethodRequest, CallMethodResult, CallRequest, CallResponse, IntegerId, MethodId, NodeId,
-    ObjectId, StatusCode, TryFromVariant, Variant,
+    CallMethodRequest, CallMethodResult, CallRequest, CallResponse, Error, IntegerId, MethodId,
+    NodeId, ObjectId, StatusCode, TryFromVariant, Variant,
 };
 use tracing::{debug_span, Instrument};
 
@@ -65,7 +65,7 @@ impl Call {
 impl UARequest for Call {
     type Out = CallResponse;
 
-    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -78,7 +78,10 @@ impl UARequest for Call {
             let _h = span.enter();
             if self.methods.is_empty() {
                 builder_error!(self, "call(), was not supplied with any methods to call");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "call was not supplied with any methods to call",
+                ));
             }
 
             CallRequest {
@@ -100,7 +103,7 @@ impl UARequest for Call {
                         "call(), expecting {cnt} results from the call to the server, got {} results",
                         results.len()
                     );
-                    Err(StatusCode::BadUnexpectedError)
+                    Err(Error::new(StatusCode::BadUnexpectedError, format!("call(), expecting {cnt} results from the call to the server, got {} results", results.len())))
                 } else {
                     Ok(*response)
                 }
@@ -109,7 +112,10 @@ impl UARequest for Call {
                     self,
                     "call(), expecting a result from the call to the server, got nothing"
                 );
-                Err(StatusCode::BadUnexpectedError)
+                Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    "call(), expecting a result from the call to the server, got nothing",
+                ))
             }
         } else {
             Err(process_unexpected_response(response))
@@ -129,12 +135,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<CallMethodResult>)` - A [`CallMethodResult`] for the Method call.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn call(
         &self,
         methods: Vec<CallMethodRequest>,
-    ) -> Result<Vec<CallMethodResult>, StatusCode> {
+    ) -> Result<Vec<CallMethodResult>, Error> {
         Ok(Call::new(self)
             .methods_to_call(methods)
             .send(&self.channel)
@@ -156,12 +162,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(CallMethodResult)` - A [`CallMethodResult`] for the Method call.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn call_one(
         &self,
         method: impl Into<CallMethodRequest>,
-    ) -> Result<CallMethodResult, StatusCode> {
+    ) -> Result<CallMethodResult, Error> {
         Ok(self
             .call(vec![method.into()])
             .await?
@@ -179,12 +185,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok((Vec<u32>, Vec<u32>))` - Result for call, consisting a list of (monitored_item_id, client_handle)
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn call_get_monitored_items(
         &self,
         subscription_id: u32,
-    ) -> Result<(Vec<u32>, Vec<u32>), StatusCode> {
+    ) -> Result<(Vec<u32>, Vec<u32>), Error> {
         let args = Some(vec![Variant::from(subscription_id)]);
         let object_id: NodeId = ObjectId::Server.into();
         let method_id: NodeId = MethodId::Server_GetMonitoredItems.into();
@@ -192,10 +198,8 @@ impl Session {
         let response = self.call_one(request).await?;
         if let Some(mut result) = response.output_arguments {
             if result.len() == 2 {
-                let server_handles = <Vec<u32>>::try_from_variant(result.remove(0))
-                    .map_err(|_| StatusCode::BadUnexpectedError)?;
-                let client_handles = <Vec<u32>>::try_from_variant(result.remove(0))
-                    .map_err(|_| StatusCode::BadUnexpectedError)?;
+                let server_handles = <Vec<u32>>::try_from_variant(result.remove(0))?;
+                let client_handles = <Vec<u32>>::try_from_variant(result.remove(0))?;
                 Ok((server_handles, client_handles))
             } else {
                 session_error!(
@@ -203,11 +207,17 @@ impl Session {
                     "Expected a result with 2 args but got {}",
                     result.len()
                 );
-                Err(StatusCode::BadUnexpectedError)
+                Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!("Expected a result with 2 args but got {}", result.len()),
+                ))
             }
         } else {
-            session_error!(self, "Expected output arguments but got null");
-            Err(StatusCode::BadUnexpectedError)
+            session_error!(self, "Expected 2 output arguments but got null");
+            Err(Error::new(
+                StatusCode::BadUnexpectedError,
+                "Expected 2 output arguments but got null",
+            ))
         }
     }
 }

--- a/async-opcua-client/src/session/services/node_management.rs
+++ b/async-opcua-client/src/session/services/node_management.rs
@@ -13,7 +13,7 @@ use opcua_types::{
     AddNodesItem, AddNodesRequest, AddNodesResponse, AddNodesResult, AddReferencesItem,
     AddReferencesRequest, AddReferencesResponse, DeleteNodesItem, DeleteNodesRequest,
     DeleteNodesResponse, DeleteReferencesItem, DeleteReferencesRequest, DeleteReferencesResponse,
-    IntegerId, NodeId, StatusCode,
+    Error, IntegerId, NodeId, StatusCode,
 };
 use tracing::{debug_span, Instrument};
 
@@ -67,7 +67,7 @@ impl AddNodes {
 impl UARequest for AddNodes {
     type Out = AddNodesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -79,7 +79,10 @@ impl UARequest for AddNodes {
             let _h = span.enter();
             if self.nodes_to_add.is_empty() {
                 builder_error!(self, "add_nodes, called with no nodes to add");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "add_nodes called with no nodes to add",
+                ));
             }
             AddNodesRequest {
                 request_header: self.header.header,
@@ -153,7 +156,7 @@ impl AddReferences {
 impl UARequest for AddReferences {
     type Out = AddReferencesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -165,7 +168,10 @@ impl UARequest for AddReferences {
             let _h = span.enter();
             if self.references_to_add.is_empty() {
                 builder_error!(self, "add_references, called with no references to add");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "add_references called with no references to add",
+                ));
             }
             AddReferencesRequest {
                 request_header: self.header.header,
@@ -238,7 +244,7 @@ impl DeleteNodes {
 impl UARequest for DeleteNodes {
     type Out = DeleteNodesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -250,7 +256,10 @@ impl UARequest for DeleteNodes {
             let _h = span.enter();
             if self.nodes_to_delete.is_empty() {
                 builder_error!(self, "delete_nodes, called with no nodes to delete");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "delete_nodes called with no nodes to delete",
+                ));
             }
             DeleteNodesRequest {
                 request_header: self.header.header,
@@ -324,7 +333,7 @@ impl DeleteReferences {
 impl UARequest for DeleteReferences {
     type Out = DeleteReferencesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -339,7 +348,10 @@ impl UARequest for DeleteReferences {
                     self,
                     "delete_references, called with no references to delete"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "delete_references called with no references to delete",
+                ));
             }
             DeleteReferencesRequest {
                 request_header: self.header.header,
@@ -374,12 +386,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<AddNodesResult>)` - A list of [`AddNodesResult`] corresponding to each add node operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn add_nodes(
         &self,
         nodes_to_add: &[AddNodesItem],
-    ) -> Result<Vec<AddNodesResult>, StatusCode> {
+    ) -> Result<Vec<AddNodesResult>, Error> {
         Ok(AddNodes::new(self)
             .nodes_to_add(nodes_to_add.to_vec())
             .send(&self.channel)
@@ -399,12 +411,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - A list of `StatusCode` corresponding to each add reference operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn add_references(
         &self,
         references_to_add: &[AddReferencesItem],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         Ok(AddReferences::new(self)
             .references_to_add(references_to_add.to_vec())
             .send(&self.channel)
@@ -424,12 +436,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - A list of `StatusCode` corresponding to each delete node operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn delete_nodes(
         &self,
         nodes_to_delete: &[DeleteNodesItem],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         Ok(DeleteNodes::new(self)
             .nodes_to_delete(nodes_to_delete.to_vec())
             .send(&self.channel)
@@ -449,12 +461,12 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - A list of `StatusCode` corresponding to each delete node operation.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn delete_references(
         &self,
         references_to_delete: &[DeleteReferencesItem],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         Ok(DeleteReferences::new(self)
             .references_to_delete(references_to_delete.to_vec())
             .send(&self.channel)

--- a/async-opcua-client/src/session/services/session.rs
+++ b/async-opcua-client/src/session/services/session.rs
@@ -157,10 +157,12 @@ impl<'a> CreateSession<'a> {
 impl UARequest for CreateSession<'_> {
     type Out = CreateSessionResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
+        let security_policy = channel.security_policy();
+
         let span = info_span!(
             "Sending CreateSession request",
             endpoint = %self.endpoint_url,
@@ -202,49 +204,54 @@ impl UARequest for CreateSession<'_> {
             builder_debug!(self, "create_session, success");
             process_service_result(&response.response_header)?;
 
-            let security_policy = channel.security_policy();
-
             if security_policy != SecurityPolicy::None {
                 if self.endpoint.server_certificate != response.server_certificate {
                     error!("Server certificate in CreateSession response does not match channel certificate");
-                    return Err(StatusCode::BadCertificateInvalid);
+                    return Err(Error::new(StatusCode::BadCertificateInvalid, "Server certificate in CreateSession response does not match channel certificate"));
                 }
-                if let Ok(server_certificate) =
+                let server_certificate =
                     opcua_crypto::X509::from_byte_string(&response.server_certificate)
-                {
-                    // Validate server certificate against hostname and application_uri
-                    let hostname = hostname_from_url(self.endpoint.endpoint_url.as_ref())
-                        .map_err(|_| StatusCode::BadUnexpectedError)?;
-                    let application_uri = self.endpoint.server.application_uri.as_ref();
-
-                    let certificate_store = trace_write_lock!(self.certificate_store);
-                    certificate_store
-                        .validate_or_reject_application_instance_cert(
-                            &server_certificate,
-                            security_policy,
-                            Some(&hostname),
-                            Some(application_uri),
+                        .inspect_err(|e| error!("Failed to parse server certificate: {e}"))?;
+                // Validate server certificate against hostname and application_uri
+                let hostname =
+                    hostname_from_url(self.endpoint.endpoint_url.as_ref()).map_err(|e| {
+                        Error::new(
+                            StatusCode::BadUnexpectedError,
+                            format!(
+                                "Failed to extract hostname from endpoint URL ({}): {e}",
+                                self.endpoint.endpoint_url
+                            ),
                         )
-                        .inspect_err(|e| {
-                            error!("Rejected server certificate in create session response: {e}");
-                        })?;
+                    })?;
+                let application_uri = self.endpoint.server.application_uri.as_ref();
 
-                    opcua_crypto::verify_signature_data(
-                        &response.server_signature,
-                        security_policy,
+                let certificate_store = trace_write_lock!(self.certificate_store);
+                certificate_store
+                    .validate_or_reject_application_instance_cert(
                         &server_certificate,
-                        self.client_certificate
-                            .as_ref()
-                            .ok_or(StatusCode::BadCertificateInvalid)?,
-                        client_nonce.as_ref(),
+                        security_policy,
+                        Some(&hostname),
+                        Some(application_uri),
                     )
                     .inspect_err(|e| {
-                        error!("Failed to verify server signature in create session response: {e}");
+                        error!("Rejected server certificate in create session response: {e}");
                     })?;
-                } else {
-                    error!("Failed to parse server certificate in create session response");
-                    return Err(StatusCode::BadCertificateInvalid);
-                }
+
+                opcua_crypto::verify_signature_data(
+                    &response.server_signature,
+                    security_policy,
+                    &server_certificate,
+                    self.client_certificate.as_ref().ok_or_else(|| {
+                        Error::new(
+                            StatusCode::BadCertificateInvalid,
+                            "Missing client certificate in request",
+                        )
+                    })?,
+                    client_nonce.as_ref(),
+                )
+                .inspect_err(|e| {
+                    error!("Failed to verify server signature in create session response: {e}");
+                })?;
             }
 
             tracing::debug!(
@@ -453,8 +460,7 @@ impl ActivateSession {
                     security_policy,
                     &server_cert.as_byte_string(),
                     &ByteString::from(&nonce),
-                )
-                .map_err(|s| Error::new(s, "Failed to create token signature"))?;
+                )?;
 
                 // Create identity token
                 let identity_token = X509IdentityToken {
@@ -495,7 +501,7 @@ impl ActivateSession {
     async fn build_request(
         self,
         channel: &AsyncSecureChannel,
-    ) -> Result<ActivateSessionRequest, StatusCode> {
+    ) -> Result<ActivateSessionRequest, Error> {
         let (remote_cert, remote_nonce, security_policy, message_security_mode) = {
             let secure_channel = trace_read_lock!(channel.secure_channel);
             (
@@ -519,18 +525,27 @@ impl ActivateSession {
             _ => {
                 let Some(client_pkey) = self.private_key else {
                     error!("Cannot create client signature - no pkey!");
-                    return Err(StatusCode::BadUnexpectedError);
+                    return Err(Error::new(
+                        StatusCode::BadUnexpectedError,
+                        "Cannot sign request, no private key provided",
+                    ));
                 };
 
                 let Some(server_cert) = remote_cert else {
                     error!("Cannot sign server certificate because server cert is null");
-                    return Err(StatusCode::BadUnexpectedError);
+                    return Err(Error::new(
+                        StatusCode::BadUnexpectedError,
+                        "Cannot sign request, missing server certificate",
+                    ));
                 };
 
                 let server_nonce = remote_nonce;
                 if server_nonce.is_null_or_empty() {
                     error!("Cannot sign server certificate because server nonce is empty");
-                    return Err(StatusCode::BadUnexpectedError);
+                    return Err(Error::new(
+                        StatusCode::BadUnexpectedError,
+                        "Cannot sign request, empty remote nonce",
+                    ));
                 }
 
                 let server_cert = server_cert.as_byte_string();
@@ -565,7 +580,7 @@ impl ActivateSession {
 impl UARequest for ActivateSession {
     type Out = ActivateSessionResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -642,7 +657,7 @@ impl CloseSession {
 impl UARequest for CloseSession {
     type Out = CloseSessionResponse;
 
-    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -708,7 +723,7 @@ impl Cancel {
 impl UARequest for Cancel {
     type Out = CancelResponse;
 
-    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -746,9 +761,9 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(NodeId)` - Success, session id
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub(crate) async fn create_session(&self) -> Result<NodeId, StatusCode> {
+    pub(crate) async fn create_session(&self) -> Result<NodeId, Error> {
         let response = CreateSession::new(self).send(&self.channel).await?;
 
         let session_id = {
@@ -766,9 +781,9 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(())` - Success
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub(crate) async fn activate_session(&self) -> Result<(), StatusCode> {
+    pub(crate) async fn activate_session(&self) -> Result<(), Error> {
         ActivateSession::new(self).send(&self.channel).await?;
         Ok(())
     }
@@ -776,7 +791,7 @@ impl Session {
     /// Close the session by sending a [`CloseSessionRequest`] to the server.
     ///
     /// This is not accessible by users, they must instead call `disconnect` to properly close the session.
-    pub(crate) async fn close_session(&self, delete_subscriptions: bool) -> Result<(), StatusCode> {
+    pub(crate) async fn close_session(&self, delete_subscriptions: bool) -> Result<(), Error> {
         CloseSession::new(self)
             .delete_subscriptions(delete_subscriptions)
             .send(&self.channel)
@@ -795,9 +810,9 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(u32)` - Success, number of cancelled requests
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub async fn cancel(&self, request_handle: IntegerId) -> Result<u32, StatusCode> {
+    pub async fn cancel(&self, request_handle: IntegerId) -> Result<u32, Error> {
         Ok(Cancel::new(request_handle, self)
             .send(&self.channel)
             .await?

--- a/async-opcua-client/src/session/services/subscriptions/event_loop_state.rs
+++ b/async-opcua-client/src/session/services/subscriptions/event_loop_state.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, time::Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
-use opcua_types::StatusCode;
+use opcua_types::{Error, StatusCode};
 use tokio::{select, sync::watch::Receiver};
 use tracing::debug;
 
@@ -53,7 +53,7 @@ enum ActivityOrNext {
     Next(Option<Instant>),
 }
 
-impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: SubscriptionCache>
+impl<T: Future<Output = Result<bool, Error>>, R: Fn() -> T, S: SubscriptionCache>
     SubscriptionEventLoopState<T, R, S>
 {
     /// Construct a new subscription cache.
@@ -105,14 +105,16 @@ impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: Subscription
         }
     }
 
-    async fn wait_for_next_publish(&mut self) -> Result<bool, StatusCode> {
+    async fn wait_for_next_publish(&mut self) -> Result<bool, Error> {
         if self.futures.is_empty() {
             futures::future::pending().await
         } else {
-            self.futures
-                .next()
-                .await
-                .unwrap_or(Err(StatusCode::BadInvalidState))
+            self.futures.next().await.unwrap_or_else(|| {
+                Err(Error::new(
+                    StatusCode::BadInvalidState,
+                    "Invalid state, polling for publish completion returned None",
+                ))
+            })
         }
     }
 
@@ -196,7 +198,7 @@ impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: Subscription
                         ActivityOrNext::Activity(SubscriptionActivity::Publish)
                     }
                     Err(e) => {
-                        match e {
+                        match e.status() {
                             StatusCode::BadTimeout => {
                                 session_debug!(self, "Publish request timed out");
                             }
@@ -211,7 +213,7 @@ impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: Subscription
                             | StatusCode::BadSessionIdInvalid => {
                                 // If this happens we will probably eventually fail keep-alive, defer to that.
                                 session_error!(self, "Publish response indicates session is dead");
-                                return ActivityOrNext::Activity(SubscriptionActivity::FatalFailure(e))
+                                return ActivityOrNext::Activity(SubscriptionActivity::FatalFailure(e.status()))
                             }
                             StatusCode::BadNoSubscription => {
                                 session_debug!(
@@ -222,7 +224,7 @@ impl<T: Future<Output = Result<bool, StatusCode>>, R: Fn() -> T, S: Subscription
                             },
                             _ => ()
                         }
-                        ActivityOrNext::Activity(SubscriptionActivity::PublishFailed(e))
+                        ActivityOrNext::Activity(SubscriptionActivity::PublishFailed(e.status()))
                     }
                 }
             },

--- a/async-opcua-client/src/session/services/subscriptions/service.rs
+++ b/async-opcua-client/src/session/services/subscriptions/service.rs
@@ -19,8 +19,8 @@ use opcua_core::{handle::AtomicHandle, sync::Mutex, trace_lock, ResponseMessage}
 use opcua_types::{
     AttributeId, CreateMonitoredItemsRequest, CreateSubscriptionRequest,
     CreateSubscriptionResponse, DeleteMonitoredItemsRequest, DeleteMonitoredItemsResponse,
-    DeleteSubscriptionsRequest, DeleteSubscriptionsResponse, DiagnosticInfo, ExtensionObject,
-    IntegerId, ModifyMonitoredItemsRequest, ModifyMonitoredItemsResponse,
+    DeleteSubscriptionsRequest, DeleteSubscriptionsResponse, DiagnosticInfo, Error,
+    ExtensionObject, IntegerId, ModifyMonitoredItemsRequest, ModifyMonitoredItemsResponse,
     ModifySubscriptionRequest, ModifySubscriptionResponse, MonitoredItemCreateRequest,
     MonitoredItemCreateResult, MonitoredItemModifyRequest, MonitoredItemModifyResult,
     MonitoringMode, MonitoringParameters, NodeId, NotificationMessage, PublishRequest,
@@ -144,7 +144,7 @@ impl CreateSubscription {
 impl UARequest for CreateSubscription {
     type Out = CreateSubscriptionResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -291,7 +291,7 @@ impl ModifySubscription {
 impl UARequest for ModifySubscription {
     type Out = ModifySubscriptionResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -311,7 +311,10 @@ impl UARequest for ModifySubscription {
                     self,
                     "modify_subscription, subscription id must be non-zero"
                 );
-                return Err(StatusCode::BadInvalidArgument);
+                return Err(Error::new(
+                    StatusCode::BadInvalidArgument,
+                    "modify_subscription, subscription id must be non-zero",
+                ));
             }
 
             ModifySubscriptionRequest {
@@ -400,7 +403,7 @@ impl SetPublishingMode {
 impl UARequest for SetPublishingMode {
     type Out = SetPublishingModeResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -416,7 +419,10 @@ impl UARequest for SetPublishingMode {
                     self,
                     "set_publishing_mode, no subscription ids were provided"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "set_publishing_mode, no subscription ids were provided",
+                ));
             }
 
             SetPublishingModeRequest {
@@ -446,7 +452,10 @@ impl UARequest for SetPublishingMode {
                     self.subscription_ids.len(),
                     num_results
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(StatusCode::BadUnexpectedError, format!("set_publishing_mode returned an incorrect number of results. Expected {}, got {}",
+                    self.subscription_ids.len(),
+                    num_results)
+                ));
             }
 
             builder_debug!(self, "set_publishing_mode success");
@@ -511,7 +520,7 @@ impl Publish {
 impl UARequest for Publish {
     type Out = PublishResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -598,7 +607,7 @@ impl Republish {
 
 impl UARequest for Republish {
     type Out = RepublishResponse;
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -699,7 +708,7 @@ impl TransferSubscriptions {
 impl UARequest for TransferSubscriptions {
     type Out = TransferSubscriptionsResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -715,7 +724,10 @@ impl UARequest for TransferSubscriptions {
                     self,
                     "transfer_subscriptions, no subscription ids were provided"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "transfer_subscriptions, no subscription ids were provided",
+                ));
             }
             TransferSubscriptionsRequest {
                 request_header: self.header.header,
@@ -790,7 +802,7 @@ impl DeleteSubscriptions {
 impl UARequest for DeleteSubscriptions {
     type Out = DeleteSubscriptionsResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -802,7 +814,10 @@ impl UARequest for DeleteSubscriptions {
             let _h = span.enter();
             if self.subscription_ids.is_empty() {
                 builder_error!(self, "delete_subscriptions called with no subscription IDs");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "delete_subscriptions called with no subscription IDs",
+                ));
             }
             DeleteSubscriptionsRequest {
                 request_header: self.header.header,
@@ -940,10 +955,7 @@ pub struct CreateMonitoredItemsResult {
 impl UARequest for CreateMonitoredItems<'_> {
     type Out = CreateMonitoredItemsResult;
 
-    async fn send<'a>(
-        mut self,
-        channel: &'a crate::AsyncSecureChannel,
-    ) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(mut self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -959,7 +971,10 @@ impl UARequest for CreateMonitoredItems<'_> {
             let _h = span.enter();
             if self.subscription_id == 0 {
                 builder_error!(self, "create_monitored_items, subscription id 0 is invalid");
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    "create_monitored_items, subscription id 0 is invalid",
+                ));
             }
 
             if self.items_to_create.is_empty() {
@@ -967,7 +982,10 @@ impl UARequest for CreateMonitoredItems<'_> {
                     self,
                     "create_monitored_items, called with no items to create"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "create_monitored_items, called with no items to create",
+                ));
             }
             for item in &mut self.items_to_create {
                 if item.requested_parameters.client_handle == 0 {
@@ -999,7 +1017,10 @@ impl UARequest for CreateMonitoredItems<'_> {
                         results.len(),
                         num_items
                     );
-                    return Err(StatusCode::BadUnexpectedError);
+                    return Err(Error::new(StatusCode::BadUnexpectedError, format!("create_monitored_items, unexpected number of results. Got {}, expected {}",
+                        results.len(),
+                        num_items)
+                    ));
                 }
                 builder_debug!(self, "create_monitored_items, {} items created", num_items);
             } else {
@@ -1007,7 +1028,10 @@ impl UARequest for CreateMonitoredItems<'_> {
                     self,
                     "create_monitored_items, success but no monitored items were created"
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    "create_monitored_items, success but no monitored items were created",
+                ));
             }
 
             let created = response
@@ -1098,7 +1122,7 @@ impl ModifyMonitoredItems {
 impl UARequest for ModifyMonitoredItems {
     type Out = ModifyMonitoredItemsResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -1113,14 +1137,20 @@ impl UARequest for ModifyMonitoredItems {
             let _h = span.enter();
             if self.subscription_id == 0 {
                 builder_error!(self, "modify_monitored_items, subscription id 0 is invalid");
-                return Err(StatusCode::BadInvalidArgument);
+                return Err(Error::new(
+                    StatusCode::BadInvalidArgument,
+                    "modify_monitored_items, subscription id 0 is invalid",
+                ));
             }
             if self.items_to_modify.is_empty() {
                 builder_error!(
                     self,
                     "modify_monitored_items, called with no items to modify"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "modify_monitored_items, called with no items to modify",
+                ));
             }
             ModifyMonitoredItemsRequest {
                 request_header: self.header.header,
@@ -1138,7 +1168,10 @@ impl UARequest for ModifyMonitoredItems {
             process_service_result(&response.response_header)?;
             let Some(results) = &response.results else {
                 builder_error!(self, "modify_monitored_items, got empty response");
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    "modify_monitored_items, got empty response",
+                ));
             };
             if results.len() != num_items {
                 builder_error!(
@@ -1147,7 +1180,14 @@ impl UARequest for ModifyMonitoredItems {
                     num_items,
                     results.len()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "modify_monitored_items, unexpected number of results. Expected {}, got {}",
+                        num_items,
+                        results.len()
+                    ),
+                ));
             }
 
             builder_debug!(self, "modify_monitored_items, success");
@@ -1218,7 +1258,7 @@ impl SetMonitoringMode {
 impl UARequest for SetMonitoringMode {
     type Out = SetMonitoringModeResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -1234,11 +1274,17 @@ impl UARequest for SetMonitoringMode {
             let _h = span.enter();
             if self.subscription_id == 0 {
                 builder_error!(self, "set_monitoring_mode, subscription id 0 is invalid");
-                return Err(StatusCode::BadInvalidArgument);
+                return Err(Error::new(
+                    StatusCode::BadInvalidArgument,
+                    "set_monitoring_mode, subscription id 0 is invalid",
+                ));
             }
             if self.monitored_item_ids.is_empty() {
                 builder_error!(self, "set_monitoring_mode, called with no items to modify");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "set_monitoring_mode, subscription id 0 is invalid",
+                ));
             }
 
             SetMonitoringModeRequest {
@@ -1253,7 +1299,10 @@ impl UARequest for SetMonitoringMode {
         if let ResponseMessage::SetMonitoringMode(response) = response {
             let Some(results) = &response.results else {
                 builder_error!(self, "set_monitoring_mode, got empty response");
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    "set_monitoring_mode, got empty response",
+                ));
             };
             if results.len() != num_items {
                 builder_error!(
@@ -1262,7 +1311,14 @@ impl UARequest for SetMonitoringMode {
                     num_items,
                     results.len()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "set_monitoring_mode, unexpected number of results. Expected {}, got {}",
+                        num_items,
+                        results.len()
+                    ),
+                ));
             }
 
             Ok(*response)
@@ -1348,7 +1404,7 @@ impl SetTriggering {
 impl UARequest for SetTriggering {
     type Out = SetTriggeringResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -1363,12 +1419,18 @@ impl UARequest for SetTriggering {
             let _h = span.enter();
             if self.subscription_id == 0 {
                 builder_error!(self, "set_triggering, subscription id 0 is invalid");
-                return Err(StatusCode::BadInvalidArgument);
+                return Err(Error::new(
+                    StatusCode::BadInvalidArgument,
+                    "set_triggering, subscription id 0 is invalid",
+                ));
             }
 
             if self.links_to_add.is_empty() && self.links_to_remove.is_empty() {
                 builder_error!(self, "set_triggering, called with nothing to add or remove");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "set_triggering, subscription id 0 is invalid",
+                ));
             }
             SetTriggeringRequest {
                 request_header: self.header.header,
@@ -1402,7 +1464,14 @@ impl UARequest for SetTriggering {
                     to_add_res.len(),
                     self.links_to_add.len()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "set_triggering, got unexpected number of add results: {}, expected {}",
+                        to_add_res.len(),
+                        self.links_to_add.len()
+                    ),
+                ));
             }
             if to_remove_res.len() != self.links_to_remove.len() {
                 builder_error!(
@@ -1411,7 +1480,14 @@ impl UARequest for SetTriggering {
                     to_remove_res.len(),
                     self.links_to_add.len()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "set_triggering, got unexpected number of remove results: {}, expected {}",
+                        to_remove_res.len(),
+                        self.links_to_add.len()
+                    ),
+                ));
             }
 
             Ok(*response)
@@ -1476,7 +1552,7 @@ impl DeleteMonitoredItems {
 impl UARequest for DeleteMonitoredItems {
     type Out = DeleteMonitoredItemsResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -1489,14 +1565,20 @@ impl UARequest for DeleteMonitoredItems {
             let _h = span.enter();
             if self.subscription_id == 0 {
                 builder_error!(self, "delete_monitored_items, subscription id 0 is invalid");
-                return Err(StatusCode::BadInvalidArgument);
+                return Err(Error::new(
+                    StatusCode::BadInvalidArgument,
+                    "delete_monitored_items, subscription id 0 is invalid",
+                ));
             }
             if self.items_to_delete.is_empty() {
                 builder_error!(
                     self,
                     "delete_monitored_items, called with no items to delete"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "delete_monitored_items, called with no items to delete",
+                ));
             }
 
             DeleteMonitoredItemsRequest {
@@ -1543,7 +1625,7 @@ impl Session {
         publishing_enabled: bool,
         priority: u8,
         callback: Box<dyn OnSubscriptionNotificationCore>,
-    ) -> Result<u32, StatusCode> {
+    ) -> Result<u32, Error> {
         let response = CreateSubscription::new(self)
             .publishing_interval(publishing_interval)
             .max_lifetime_count(lifetime_count)
@@ -1618,7 +1700,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(u32)` - identifier for new subscription
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     #[allow(clippy::too_many_arguments)]
     pub async fn create_subscription(
@@ -1630,7 +1712,7 @@ impl Session {
         priority: u8,
         publishing_enabled: bool,
         callback: impl OnSubscriptionNotificationCore + 'static,
-    ) -> Result<u32, StatusCode> {
+    ) -> Result<u32, Error> {
         self.create_subscription_inner(
             publishing_interval,
             lifetime_count,
@@ -1684,7 +1766,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(())` - Success
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn modify_subscription(
         &self,
@@ -1694,10 +1776,13 @@ impl Session {
         max_keep_alive_count: u32,
         max_notifications_per_publish: u32,
         priority: u8,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         if !self.subscription_exists(subscription_id) {
             session_error!(self, "modify_subscription, subscription id does not exist");
-            return Err(StatusCode::BadInvalidArgument);
+            return Err(Error::new(
+                StatusCode::BadInvalidArgument,
+                "modify_subscription, subscription id does not exist",
+            ));
         }
 
         let response = ModifySubscription::new(subscription_id, self)
@@ -1737,13 +1822,13 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - Service return code for the action for each id, `Good` or `BadSubscriptionIdInvalid`
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn set_publishing_mode(
         &self,
         subscription_ids: &[u32],
         publishing_enabled: bool,
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         let results = SetPublishingMode::new(publishing_enabled, self)
             .subscription_ids(subscription_ids.to_vec())
             .send(&self.channel)
@@ -1789,13 +1874,13 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<TransferResult>)` - The [`TransferResult`] for each transfer subscription.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn transfer_subscriptions(
         &self,
         subscription_ids: &[u32],
         send_initial_values: bool,
-    ) -> Result<Vec<TransferResult>, StatusCode> {
+    ) -> Result<Vec<TransferResult>, Error> {
         let r = TransferSubscriptions::new(self)
             .send_initial_values(send_initial_values)
             .subscription_ids(subscription_ids.to_vec())
@@ -1820,22 +1905,28 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(StatusCode)` - Service return code for the delete action, `Good` or `BadSubscriptionIdInvalid`
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub async fn delete_subscription(
-        &self,
-        subscription_id: u32,
-    ) -> Result<StatusCode, StatusCode> {
+    pub async fn delete_subscription(&self, subscription_id: u32) -> Result<StatusCode, Error> {
         if subscription_id == 0 {
             session_error!(self, "delete_subscription, subscription id 0 is invalid");
-            Err(StatusCode::BadInvalidArgument)
+            Err(Error::new(
+                StatusCode::BadInvalidArgument,
+                "delete_subscription, subscription id 0 is invalid",
+            ))
         } else if !self.subscription_exists(subscription_id) {
             session_error!(
                 self,
                 "delete_subscription, subscription id {} does not exist",
                 subscription_id
             );
-            Err(StatusCode::BadInvalidArgument)
+            Err(Error::new(
+                StatusCode::BadInvalidArgument,
+                format!(
+                    "delete_subscription, subscription id {} does not exist",
+                    subscription_id
+                ),
+            ))
         } else {
             let result = self.delete_subscriptions(&[subscription_id]).await?;
             Ok(result[0])
@@ -1855,12 +1946,12 @@ impl Session {
     ///
     /// * `Ok(Vec<StatusCode>)` - List of result for delete action on each id, `Good` or `BadSubscriptionIdInvalid`
     ///   The size and order of the list matches the size and order of the input.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn delete_subscriptions(
         &self,
         subscription_ids: &[u32],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         let result = DeleteSubscriptions::new(self)
             .subscription_ids(subscription_ids.to_vec())
             .send(&self.channel)
@@ -1892,14 +1983,14 @@ impl Session {
     ///
     /// * `Ok(Vec<MonitoredItemCreateResult>)` - A list of [`MonitoredItemCreateResult`] corresponding to the items to create.
     ///   The size and order of the list matches the size and order of the `items_to_create` request parameter.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn create_monitored_items(
         &self,
         subscription_id: u32,
         timestamps_to_return: TimestampsToReturn,
         mut items_to_create: Vec<MonitoredItemCreateRequest>,
-    ) -> Result<Vec<CreatedMonitoredItem>, StatusCode> {
+    ) -> Result<Vec<CreatedMonitoredItem>, Error> {
         {
             let state = trace_lock!(self.subscription_state);
             if !state.subscription_exists(subscription_id) {
@@ -1908,7 +1999,13 @@ impl Session {
                     "create_monitored_items, subscription id {} does not exist",
                     subscription_id
                 );
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    format!(
+                        "create_monitored_items, subscription id {} does not exist",
+                        subscription_id
+                    ),
+                ));
             }
         }
 
@@ -1953,14 +2050,14 @@ impl Session {
     ///
     /// * `Ok(Vec<MonitoredItemModifyResult>)` - A list of [`MonitoredItemModifyResult`] corresponding to the MonitoredItems to modify.
     ///   The size and order of the list matches the size and order of the `items_to_modify` request parameter.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn modify_monitored_items(
         &self,
         subscription_id: u32,
         timestamps_to_return: TimestampsToReturn,
         items_to_modify: &[MonitoredItemModifyRequest],
-    ) -> Result<Vec<MonitoredItemModifyResult>, StatusCode> {
+    ) -> Result<Vec<MonitoredItemModifyResult>, Error> {
         {
             let state = trace_lock!(self.subscription_state);
             if !state.subscription_exists(subscription_id) {
@@ -1969,7 +2066,13 @@ impl Session {
                     "modify_monitored_items, subscription id {} does not exist",
                     subscription_id
                 );
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    format!(
+                        "modify_monitored_items, subscription id {} does not exist",
+                        subscription_id
+                    ),
+                ));
             }
         }
         let id_and_filter: Vec<(u32, ExtensionObject)> = items_to_modify
@@ -2023,14 +2126,14 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(Vec<StatusCode>)` - Individual result for each monitored item.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn set_monitoring_mode(
         &self,
         subscription_id: u32,
         monitoring_mode: MonitoringMode,
         monitored_item_ids: &[u32],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         {
             let state = trace_lock!(self.subscription_state);
             if !state.subscription_exists(subscription_id) {
@@ -2039,7 +2142,13 @@ impl Session {
                     "set_monitoring_mode, subscription id {} does not exist",
                     subscription_id
                 );
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    format!(
+                        "set_monitoring_mode, subscription id {} does not exist",
+                        subscription_id
+                    ),
+                ));
             }
         }
         let results = SetMonitoringMode::new(subscription_id, monitoring_mode, self)
@@ -2079,7 +2188,7 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok((Option<Vec<StatusCode>>, Option<Vec<StatusCode>>))` - Individual result for each item added / removed for the SetTriggering call.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn set_triggering(
         &self,
@@ -2087,7 +2196,7 @@ impl Session {
         triggering_item_id: u32,
         links_to_add: &[u32],
         links_to_remove: &[u32],
-    ) -> Result<(Option<Vec<StatusCode>>, Option<Vec<StatusCode>>), StatusCode> {
+    ) -> Result<(Option<Vec<StatusCode>>, Option<Vec<StatusCode>>), Error> {
         {
             let state = trace_lock!(self.subscription_state);
             if !state.subscription_exists(subscription_id) {
@@ -2096,7 +2205,13 @@ impl Session {
                     "set_triggering, subscription id {} does not exist",
                     subscription_id
                 );
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    format!(
+                        "set_triggering, subscription id {} does not exist",
+                        subscription_id
+                    ),
+                ));
             }
         }
         let response = SetTriggering::new(subscription_id, triggering_item_id, self)
@@ -2147,13 +2262,13 @@ impl Session {
     ///
     /// * `Ok(Vec<StatusCode>)` - List of StatusCodes for the MonitoredItems to delete. The size and
     ///   order of the list matches the size and order of the `items_to_delete` request parameter.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn delete_monitored_items(
         &self,
         subscription_id: u32,
         items_to_delete: &[u32],
-    ) -> Result<Vec<StatusCode>, StatusCode> {
+    ) -> Result<Vec<StatusCode>, Error> {
         {
             let state = trace_lock!(self.subscription_state);
             if !state.subscription_exists(subscription_id) {
@@ -2162,7 +2277,13 @@ impl Session {
                     "delete_monitored_items, subscription id {} does not exist",
                     subscription_id
                 );
-                return Err(StatusCode::BadSubscriptionIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSubscriptionIdInvalid,
+                    format!(
+                        "delete_monitored_items, subscription id {} does not exist",
+                        subscription_id
+                    ),
+                ));
             }
         }
         let response = DeleteMonitoredItems::new(subscription_id, self)
@@ -2186,7 +2307,7 @@ impl Session {
 
     /// Send a publish request, returning `true` if the session should send a new request
     /// immediately.
-    pub(crate) async fn publish(&self) -> Result<bool, StatusCode> {
+    pub(crate) async fn publish(&self) -> Result<bool, Error> {
         let acks = {
             let mut subscription_state = trace_lock!(self.subscription_state);
             let acks = subscription_state.take_acknowledgements();
@@ -2240,13 +2361,13 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(NotificationMessage)` - Re-published notification message.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn republish(
         &self,
         subscription_id: u32,
         sequence_number: u32,
-    ) -> Result<NotificationMessage, StatusCode> {
+    ) -> Result<NotificationMessage, Error> {
         let res = Republish::new(subscription_id, sequence_number, self)
             .send(&self.channel)
             .await?;

--- a/async-opcua-client/src/session/services/view.rs
+++ b/async-opcua-client/src/session/services/view.rs
@@ -10,7 +10,7 @@ use crate::{
 use opcua_core::ResponseMessage;
 use opcua_types::{
     BrowseDescription, BrowseNextRequest, BrowseNextResponse, BrowsePath, BrowsePathResult,
-    BrowseRequest, BrowseResponse, BrowseResult, ByteString, IntegerId, NodeId,
+    BrowseRequest, BrowseResponse, BrowseResult, ByteString, Error, IntegerId, NodeId,
     RegisterNodesRequest, RegisterNodesResponse, StatusCode, TranslateBrowsePathsToNodeIdsRequest,
     TranslateBrowsePathsToNodeIdsResponse, UnregisterNodesRequest, UnregisterNodesResponse,
     ViewDescription,
@@ -87,7 +87,7 @@ impl Browse {
 impl UARequest for Browse {
     type Out = BrowseResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -99,7 +99,10 @@ impl UARequest for Browse {
             let _h = span.enter();
             if self.nodes_to_browse.is_empty() {
                 builder_error!(self, "browse was not supplied with any nodes to browse");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "browse was not supplied with any nodes to browse",
+                ));
             }
             BrowseRequest {
                 request_header: self.header.header,
@@ -187,7 +190,7 @@ impl BrowseNext {
 impl UARequest for BrowseNext {
     type Out = BrowseNextResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -203,7 +206,10 @@ impl UARequest for BrowseNext {
                     self,
                     "browse_next was not supplied with any continuation points"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "browse_next was not supplied with any continuation points",
+                ));
             }
             BrowseNextRequest {
                 request_header: self.header.header,
@@ -282,7 +288,7 @@ impl TranslateBrowsePaths {
 impl UARequest for TranslateBrowsePaths {
     type Out = TranslateBrowsePathsToNodeIdsResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -297,7 +303,10 @@ impl UARequest for TranslateBrowsePaths {
                     self,
                     "translate_browse_paths_to_node_ids was not supplied with any browse paths"
                 );
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "translate_browse_paths_to_node_ids was not supplied with any browse paths",
+                ));
             }
             TranslateBrowsePathsToNodeIdsRequest {
                 request_header: self.header.header,
@@ -374,7 +383,7 @@ impl RegisterNodes {
 impl UARequest for RegisterNodes {
     type Out = RegisterNodesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -386,7 +395,10 @@ impl UARequest for RegisterNodes {
             let _h = span.enter();
             if self.nodes_to_register.is_empty() {
                 builder_error!(self, "register_nodes was not supplied with any node IDs");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "register_nodes was not supplied with any node IDs",
+                ));
             }
             RegisterNodesRequest {
                 request_header: self.header.header,
@@ -463,7 +475,7 @@ impl UnregisterNodes {
 impl UARequest for UnregisterNodes {
     type Out = UnregisterNodesResponse;
 
-    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, Error>
     where
         Self: 'a,
     {
@@ -475,7 +487,10 @@ impl UARequest for UnregisterNodes {
             let _h = span.enter();
             if self.nodes_to_unregister.is_empty() {
                 builder_error!(self, "unregister_nodes was not supplied with any node IDs");
-                return Err(StatusCode::BadNothingToDo);
+                return Err(Error::new(
+                    StatusCode::BadNothingToDo,
+                    "unregister_nodes was not supplied with any node IDs",
+                ));
             }
             UnregisterNodesRequest {
                 request_header: self.header.header,
@@ -511,14 +526,14 @@ impl Session {
     ///
     /// * `Ok(Vec<BrowseResult>)` - A list [`BrowseResult`] corresponding to each node to browse. A browse result
     ///   may contain a continuation point, for use with `browse_next()`.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn browse(
         &self,
         nodes_to_browse: &[BrowseDescription],
         max_references_per_node: u32,
         view: Option<ViewDescription>,
-    ) -> Result<Vec<BrowseResult>, StatusCode> {
+    ) -> Result<Vec<BrowseResult>, Error> {
         Ok(Browse::new(self)
             .nodes_to_browse(nodes_to_browse.to_vec())
             .view(view.unwrap_or_default())
@@ -543,13 +558,13 @@ impl Session {
     ///
     /// * `Ok(Option<Vec<BrowseResult>)` - A list [`BrowseResult`] corresponding to each node to browse. A browse result
     ///   may contain a continuation point, for use with `browse_next()`.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn browse_next(
         &self,
         release_continuation_points: bool,
         continuation_points: &[ByteString],
-    ) -> Result<Vec<BrowseResult>, StatusCode> {
+    ) -> Result<Vec<BrowseResult>, Error> {
         Ok(BrowseNext::new(self)
             .continuation_points(continuation_points.to_vec())
             .release_continuation_points(release_continuation_points)
@@ -575,12 +590,12 @@ impl Session {
     /// * `Ok(Vec<BrowsePathResult>>)` - List of [`BrowsePathResult`] for the list of browse
     ///   paths. The size and order of the list matches the size and order of the `browse_paths`
     ///   parameter.
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn translate_browse_paths_to_node_ids(
         &self,
         browse_paths: &[BrowsePath],
-    ) -> Result<Vec<BrowsePathResult>, StatusCode> {
+    ) -> Result<Vec<BrowsePathResult>, Error> {
         Ok(TranslateBrowsePaths::new(self)
             .browse_paths(browse_paths.to_vec())
             .send(&self.channel)
@@ -603,12 +618,9 @@ impl Session {
     ///
     /// * `Ok(Vec<NodeId>)` - A list of [`NodeId`] corresponding to size and order of the input. The
     ///   server may return an alias for the input `NodeId`
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub async fn register_nodes(
-        &self,
-        nodes_to_register: &[NodeId],
-    ) -> Result<Vec<NodeId>, StatusCode> {
+    pub async fn register_nodes(&self, nodes_to_register: &[NodeId]) -> Result<Vec<NodeId>, Error> {
         Ok(RegisterNodes::new(self)
             .nodes_to_register(nodes_to_register.to_vec())
             .send(&self.channel)
@@ -630,9 +642,9 @@ impl Session {
     /// # Returns
     ///
     /// * `Ok(())` - Request succeeded, server ignores invalid nodes
-    /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
+    /// * `Err(Error)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
-    pub async fn unregister_nodes(&self, nodes_to_unregister: &[NodeId]) -> Result<(), StatusCode> {
+    pub async fn unregister_nodes(&self, nodes_to_unregister: &[NodeId]) -> Result<(), Error> {
         UnregisterNodes::new(self)
             .nodes_to_unregister(nodes_to_unregister.to_vec())
             .send(&self.channel)

--- a/async-opcua-client/src/transport/channel.rs
+++ b/async-opcua-client/src/transport/channel.rs
@@ -12,7 +12,7 @@ use opcua_core::{
 };
 use opcua_crypto::{CertificateStore, PrivateKey, SecurityPolicy, X509};
 use opcua_types::{
-    ByteString, CloseSecureChannelRequest, ContextOwned, IntegerId, NodeId, RequestHeader,
+    ByteString, CloseSecureChannelRequest, ContextOwned, Error, IntegerId, NodeId, RequestHeader,
     SecurityTokenRequestType, StatusCode,
 };
 use tokio::sync::mpsc::Sender;
@@ -83,7 +83,7 @@ impl AsyncSecureChannel {
         nonce: &ByteString,
         certificate: &ByteString,
         auth_token: &NodeId,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         let mut secure_channel = trace_write_lock!(self.secure_channel);
         secure_channel.set_remote_nonce_from_byte_string(nonce)?;
         secure_channel.set_remote_cert_from_byte_string(certificate)?;
@@ -94,7 +94,7 @@ impl AsyncSecureChannel {
     pub(crate) fn update_from_activated_session(
         &self,
         server_nonce: &ByteString,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         let mut secure_channel = trace_write_lock!(self.secure_channel);
         secure_channel.set_remote_nonce_from_byte_string(server_nonce)
     }
@@ -171,7 +171,7 @@ impl AsyncSecureChannel {
         }
     }
 
-    async fn renew_secure_channel(&self, send: Sender<OutgoingMessage>) -> Result<(), StatusCode> {
+    async fn renew_secure_channel(&self, send: Sender<OutgoingMessage>) -> Result<(), Error> {
         // Grab the lock, then check again whether we should renew the secure channel,
         // this avoids renewing it multiple times if the client sends many requests in quick
         // succession.
@@ -204,10 +204,13 @@ impl AsyncSecureChannel {
         &self,
         request: impl Into<RequestMessage>,
         timeout: Duration,
-    ) -> Result<ResponseMessage, StatusCode> {
+    ) -> Result<ResponseMessage, Error> {
         let sender = self.request_send.load().as_deref().cloned();
         let Some(send) = sender else {
-            return Err(StatusCode::BadNotConnected);
+            return Err(Error::new(
+                StatusCode::BadNotConnected,
+                "Unable to send request, transport is not connected",
+            ));
         };
 
         let should_renew_security_token = {
@@ -232,7 +235,7 @@ impl AsyncSecureChannel {
     pub async fn connect<T: Connector>(
         &self,
         connector: &T,
-    ) -> Result<SecureChannelEventLoop<T::Transport>, StatusCode> {
+    ) -> Result<SecureChannelEventLoop<T::Transport>, Error> {
         self.request_send.store(None);
         let mut backoff = self.session_retry_policy.new_backoff();
         loop {
@@ -255,7 +258,7 @@ impl AsyncSecureChannel {
     pub async fn connect_no_retry<T: Connector>(
         &self,
         connector: &T,
-    ) -> Result<SecureChannelEventLoop<T::Transport>, StatusCode> {
+    ) -> Result<SecureChannelEventLoop<T::Transport>, Error> {
         {
             let mut secure_channel = trace_write_lock!(self.secure_channel);
             secure_channel.clear_security_token();
@@ -281,7 +284,7 @@ impl AsyncSecureChannel {
                 r = &mut request_fut => break r?,
                 r = transport.poll() => {
                     if let TransportPollResult::Closed(e) = r {
-                        return Err(e);
+                        return Err(Error::new(e, "Transport closed unexpectedly"));
                     }
                 }
             }
@@ -298,18 +301,29 @@ impl AsyncSecureChannel {
     async fn create_transport<T: Connector>(
         &self,
         connector: &T,
-    ) -> Result<(T::Transport, tokio::sync::mpsc::Sender<OutgoingMessage>), StatusCode> {
+    ) -> Result<(T::Transport, tokio::sync::mpsc::Sender<OutgoingMessage>), Error> {
         debug!("Connect");
         let security_policy =
             SecurityPolicy::from_str(self.endpoint_info.endpoint.security_policy_uri.as_ref())
-                .map_err(|_| StatusCode::BadSecurityPolicyRejected)?;
+                .map_err(|_| {
+                    Error::new(
+                        StatusCode::BadSecurityPolicyRejected,
+                        "Unknown security policy",
+                    )
+                })?;
 
         if security_policy == SecurityPolicy::Unknown {
             error!(
                 "connect, security policy \"{}\" is unknown",
                 self.endpoint_info.endpoint.security_policy_uri.as_ref()
             );
-            Err(StatusCode::BadSecurityPolicyRejected)
+            Err(Error::new(
+                StatusCode::BadSecurityPolicyRejected,
+                format!(
+                    "security policy \"{}\" is unknown",
+                    self.endpoint_info.endpoint.security_policy_uri
+                ),
+            ))
         } else {
             let (cert, key) = {
                 let certificate_store = trace_write_lock!(self.certificate_store);

--- a/async-opcua-client/src/transport/connect.rs
+++ b/async-opcua-client/src/transport/connect.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, sync::Arc};
 
-use opcua_types::{EndpointDescription, Error, StatusCode};
+use opcua_types::{EndpointDescription, Error};
 
 use crate::transport::{state::SecureChannelState, RequestRecv};
 
@@ -28,7 +28,7 @@ pub trait Connector: Send + Sync {
         channel: Arc<SecureChannelState>,
         outgoing_recv: RequestRecv,
         config: TransportConfiguration,
-    ) -> impl Future<Output = Result<Self::Transport, StatusCode>> + Send + Sync;
+    ) -> impl Future<Output = Result<Self::Transport, Error>> + Send + Sync;
 
     /// Get the default endpoint for this connector.
     fn default_endpoint(&self) -> EndpointDescription;

--- a/async-opcua-client/src/transport/core.rs
+++ b/async-opcua-client/src/transport/core.rs
@@ -25,7 +25,7 @@ struct MessageChunkWithChunkInfo {
 }
 
 pub(crate) struct MessageState {
-    callback: tokio::sync::oneshot::Sender<Result<ResponseMessage, StatusCode>>,
+    callback: tokio::sync::oneshot::Sender<Result<ResponseMessage, Error>>,
     chunks: Vec<MessageChunkWithChunkInfo>,
     deadline: Instant,
     span: tracing::Span,
@@ -77,7 +77,7 @@ pub struct OutgoingMessage {
     /// The actual request message to send.
     pub request: RequestMessage,
     /// A callback that should be called when a response is received.
-    pub callback: Option<tokio::sync::oneshot::Sender<Result<ResponseMessage, StatusCode>>>,
+    pub callback: Option<tokio::sync::oneshot::Sender<Result<ResponseMessage, Error>>>,
     /// Deadline for the request.
     pub deadline: Instant,
     /// An optional tracing span to attach to the request.
@@ -142,36 +142,42 @@ impl TransportState {
     }
 
     /// Store incoming messages in the message state.
-    pub fn handle_incoming_message(&mut self, message: Message) -> Result<(), StatusCode> {
-        let status = match message {
+    pub fn handle_incoming_message(&mut self, message: Message) -> Result<(), Error> {
+        match message {
             Message::Acknowledge(ack) => {
                 debug!("Reader got an unexpected ack {:?}", ack);
-                StatusCode::BadUnexpectedError
+                Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    "Received an unexpected ACK from the server",
+                ))
             }
-            Message::Chunk(chunk) => self.process_chunk(chunk).err().unwrap_or(StatusCode::Good),
+            Message::Chunk(chunk) => {
+                self.process_chunk(chunk)?;
+                Ok(())
+            }
             Message::Error(error) => {
                 error!(
                     "Received error {} from server. Reason: {}",
                     error.error, error.reason
                 );
-                error.error
+                Err(Error::new(
+                    error.error,
+                    format!("Received error from server. Reason: {}", error.reason),
+                ))
             }
             m => {
                 error!("Expected a recognized message, got {:?}", m);
-                StatusCode::BadUnexpectedError
+                Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!("Expected a chunk or error, got {:?}", m),
+                ))
             }
-        };
-
-        if status.is_good() {
-            Ok(())
-        } else {
-            Err(status)
         }
     }
 
     /// Call this if sending a message fails. This will notify the waiting request
     /// that the message could not be sent.
-    pub fn message_send_failed(&mut self, request_id: u32, err: StatusCode) {
+    pub fn message_send_failed(&mut self, request_id: u32, err: Error) {
         if let Some(message_state) = self.message_states.remove(&request_id) {
             message_state.span.in_scope(|| {
                 debug!(
@@ -203,13 +209,17 @@ impl TransportState {
                 state.span.in_scope(|| {
                     debug!("Message timed out, request_id = {id}");
                 });
-                let _ = state.callback.send(Err(StatusCode::BadTimeout));
+                let _ = state.callback.send(Err(Error::new(
+                    StatusCode::BadTimeout,
+                    "Message timed out",
+                )
+                .with_request_id(id)));
             }
         }
         next_timeout
     }
 
-    fn process_chunk(&mut self, chunk: MessageChunk) -> Result<(), StatusCode> {
+    fn process_chunk(&mut self, chunk: MessageChunk) -> Result<(), Error> {
         let (chunk, chunk_info, decoding_options) = {
             let secure_channel = trace_read_lock!(self.channel_state.secure_channel());
             let chunk = secure_channel.verify_and_remove_security(chunk.data)?;
@@ -257,9 +267,11 @@ impl TransportState {
                     let message_state = self.message_states.remove(&req_id).unwrap();
                     message_state.span.in_scope(|| {
                         error!("Message {} exceeded max chunk count", req_id);
-                        let _ = message_state
-                            .callback
-                            .send(Err(StatusCode::BadEncodingLimitsExceeded));
+                        let _ = message_state.callback.send(Err(Error::new(
+                            StatusCode::BadEncodingLimitsExceeded,
+                            "Message exceeded max chunk count",
+                        )
+                        .with_request_id(req_id)));
                     });
                 }
             }
@@ -271,7 +283,7 @@ impl TransportState {
                     warn!(
                         "Message marked as final error, request_id = {req_id}, status = {status}, reason = {reason}"
                     );
-                    let _ = message_state.callback.send(Err(status));
+                    let _ = message_state.callback.send(Err(Error::new(status, format!("Message marked final error: {reason}")).with_request_id(req_id)));
                 });
             }
             MessageIsFinalType::Final => {
@@ -305,7 +317,10 @@ impl TransportState {
                     let service_result = msg.response_header.service_result;
                     if !service_result.is_good() {
                         error!("OpenSecureChannel response failed, request_id = {req_id}: {service_result}");
-                        return Err(service_result);
+                        return Err(Error::new(
+                            service_result,
+                            "OpenSecureChannel received service fault from server",
+                        ));
                     }
                     self.channel_state.end_issue_or_renew_secure_channel(msg).inspect_err(|e| {
                         error!("Failed to process OpenSecureChannel response, request_id = {req_id}: {e}");
@@ -331,7 +346,7 @@ impl TransportState {
 
     fn merge_chunks(
         mut chunks: Vec<MessageChunkWithChunkInfo>,
-    ) -> Result<Vec<MessageChunk>, StatusCode> {
+    ) -> Result<Vec<MessageChunk>, Error> {
         if chunks.len() == 1 {
             return Ok(vec![MessageChunk {
                 data: chunks.pop().unwrap().data_with_header,
@@ -382,7 +397,9 @@ impl TransportState {
             pending.span.in_scope(|| {
                 debug!("Transport is closing, failing pending request");
             });
-            let _ = pending.callback.send(Err(request_status));
+            let _ = pending
+                .callback
+                .send(Err(Error::new(request_status, "Transport is closing")));
         }
 
         // Make sure we also send a bad status for any remaining messages in the queue
@@ -392,7 +409,7 @@ impl TransportState {
         // recv is no longer blocking.
         while let Some(msg) = self.outgoing_recv.recv().await {
             if let Some(cb) = msg.callback {
-                let _ = cb.send(Err(request_status));
+                let _ = cb.send(Err(Error::new(request_status, "Transport is closing")));
             }
         }
 

--- a/async-opcua-client/src/transport/core.rs
+++ b/async-opcua-client/src/transport/core.rs
@@ -8,12 +8,12 @@ use opcua_core::{trace_read_lock, RequestMessage, ResponseMessage};
 use tracing::{debug, error, trace, warn};
 
 use opcua_core::comms::buffer::SendBuffer;
-use opcua_core::comms::message_chunk::MessageIsFinalType;
+use opcua_core::comms::message_chunk::{MessageFinalError, MessageIsFinalType};
 use opcua_core::comms::{
     chunker::Chunker, message_chunk::MessageChunk, message_chunk_info::ChunkInfo,
     tcp_codec::Message,
 };
-use opcua_types::{DecodingOptions, Error, SimpleBinaryDecodable, StatusCode, UAString};
+use opcua_types::{Error, StatusCode, UAString};
 
 use crate::transport::state::SecureChannelState;
 use crate::transport::RequestRecv;
@@ -276,14 +276,19 @@ impl TransportState {
                 }
             }
             MessageIsFinalType::FinalError => {
-                let (status, reason) = decode_abort_body(&chunk, &chunk_info, &decoding_options)
-                    .unwrap_or((StatusCode::BadCommunicationError, UAString::null()));
+                let err = match chunk.final_error_body(&chunk_info, &decoding_options) {
+                    Ok(err) => err,
+                    Err(_) => MessageFinalError {
+                        status: StatusCode::BadCommunicationError,
+                        reason: UAString::null(),
+                    },
+                };
                 let message_state = self.message_states.remove(&req_id).unwrap();
                 message_state.span.in_scope(|| {
                     warn!(
-                        "Message marked as final error, request_id = {req_id}, status = {status}, reason = {reason}"
+                        "Message marked as final error, request_id = {req_id}, status = {}, reason = {}", err.status, err.reason
                     );
-                    let _ = message_state.callback.send(Err(Error::new(status, format!("Message marked final error: {reason}")).with_request_id(req_id)));
+                    let _ = message_state.callback.send(Err(Error::new(err.status, format!("Message marked final error: {}", err.reason)).with_request_id(req_id)));
                 });
             }
             MessageIsFinalType::Final => {
@@ -415,18 +420,4 @@ impl TransportState {
 
         status
     }
-}
-
-fn decode_abort_body(
-    chunk: &MessageChunk,
-    chunk_info: &ChunkInfo,
-    decoding_options: &DecodingOptions,
-) -> Option<(StatusCode, UAString)> {
-    let start = chunk_info.body_offset;
-    let end = start.checked_add(chunk_info.body_length)?;
-    let body = chunk.data.get(start..end)?;
-    let mut cursor = std::io::Cursor::new(body);
-    let status = StatusCode::decode(&mut cursor, decoding_options).ok()?;
-    let reason = UAString::decode(&mut cursor, decoding_options).ok()?;
-    Some((status, reason))
 }

--- a/async-opcua-client/src/transport/state.rs
+++ b/async-opcua-client/src/transport/state.rs
@@ -14,8 +14,9 @@ use opcua_core::{
 };
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
-    DateTime, DiagnosticBits, IntegerId, MessageSecurityMode, NodeId, OpenSecureChannelRequest,
-    OpenSecureChannelResponse, RequestHeader, SecurityTokenRequestType, StatusCode,
+    DateTime, DiagnosticBits, Error, IntegerId, MessageSecurityMode, NodeId,
+    OpenSecureChannelRequest, OpenSecureChannelResponse, RequestHeader, SecurityTokenRequestType,
+    StatusCode,
 };
 
 /// Tokio channel for sending requests to the transport.
@@ -71,7 +72,7 @@ impl Request {
         }
     }
 
-    pub(super) async fn send(self) -> Result<ResponseMessage, StatusCode> {
+    pub(super) async fn send(self) -> Result<ResponseMessage, Error> {
         let (cb_send, cb_recv) = tokio::sync::oneshot::channel();
 
         let message = OutgoingMessage {
@@ -83,14 +84,25 @@ impl Request {
 
         match self.sender.send_timeout(message, self.timeout).await {
             Ok(()) => (),
-            Err(SendTimeoutError::Closed(_)) => return Err(StatusCode::BadConnectionClosed),
-            Err(SendTimeoutError::Timeout(_)) => return Err(StatusCode::BadTimeout),
+            Err(SendTimeoutError::Closed(_)) => {
+                return Err(Error::new(
+                    StatusCode::BadConnectionClosed,
+                    "Request failed due to the client suhtting down",
+                ))
+            }
+            Err(SendTimeoutError::Timeout(_)) => return Err(Error::new(
+                    StatusCode::BadTimeout,
+                    "Request failed to send within timeout, likely because the request queue is backed up",
+                )),
         }
 
         match cb_recv.await {
             Ok(r) => r,
             // Should not really happen, would mean something panicked.
-            Err(_) => Err(StatusCode::BadConnectionClosed),
+            Err(_) => Err(Error::new(
+                StatusCode::BadConnectionClosed,
+                "Fatal error, connection closed",
+            )),
         }
     }
 }
@@ -159,7 +171,7 @@ impl SecureChannelState {
     pub(super) fn end_issue_or_renew_secure_channel(
         &self,
         response: &OpenSecureChannelResponse,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         // Extract the security token from the response.
         let mut security_token = response.security_token.clone();
 
@@ -186,7 +198,13 @@ impl SecureChannelState {
                     "OpenSecureChannel response changed channel_id from {} to {}",
                     existing_channel_id, security_token.channel_id
                 );
-                return Err(StatusCode::BadSecureChannelIdInvalid);
+                return Err(Error::new(
+                    StatusCode::BadSecureChannelIdInvalid,
+                    format!(
+                        "OpenSecureChannel response changed channel_id from {} to {}",
+                        existing_channel_id, security_token.channel_id
+                    ),
+                ));
             }
             secure_channel.set_client_offset(**self.client_offset.load());
             secure_channel.set_security_token(security_token);

--- a/async-opcua-client/src/transport/stream.rs
+++ b/async-opcua-client/src/transport/stream.rs
@@ -189,11 +189,10 @@ where
         channel: Arc<SecureChannelState>,
         outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
         config: TransportConfiguration,
-    ) -> Result<StreamTransport<R, W>, StatusCode> {
+    ) -> Result<StreamTransport<R, W>, Error> {
         let (connection, ack, policy) = self
             .connect_inner(channel.secure_channel(), &config)
-            .await
-            .map_err(|e| e.status())?;
+            .await?;
         let mut buffer = SendBuffer::new(
             config.send_buffer_size,
             config.max_message_size,
@@ -256,7 +255,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> StreamTransport<R, W> {
                         "Failed to handle incoming message, closing transport: {}",
                         e
                     );
-                    TransportPollResult::Closed(e)
+                    TransportPollResult::Closed(e.status())
                 } else {
                     TransportPollResult::IncomingMessage
                 }
@@ -321,8 +320,9 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> StreamTransport<R, W> {
                         drop(secure_channel);
                         if let Some((request_id, request_handle)) = e.full_context() {
                             error!("Failed to send message with request handle {}: {}", request_handle, e);
-                            self.state.message_send_failed(request_id, e.status());
-                            TransportPollResult::RecoverableError(e.status())
+                            let status = e.status();
+                            self.state.message_send_failed(request_id, e);
+                            TransportPollResult::RecoverableError(status)
                         } else {
                             error!("Failed to write outgoing message to send buffer, closing transport: {}", e);
                             TransportPollResult::Closed(e.status())

--- a/async-opcua-client/src/transport/tcp.rs
+++ b/async-opcua-client/src/transport/tcp.rs
@@ -118,7 +118,7 @@ impl Connector for TcpConnector {
         channel: Arc<SecureChannelState>,
         outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
         config: TransportConfiguration,
-    ) -> Result<TcpTransport, StatusCode> {
+    ) -> Result<TcpTransport, Error> {
         let inner = StreamConnector::new(Self::connect_tcp, self.endpoint_url.clone());
         inner.connect(channel, outgoing_recv, config).await
     }
@@ -281,7 +281,7 @@ impl Connector for ReverseTcpConnector {
         channel: Arc<SecureChannelState>,
         outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
         config: TransportConfiguration,
-    ) -> Result<TcpTransport, StatusCode> {
+    ) -> Result<TcpTransport, Error> {
         match &self.listener {
             TcpConnectorReceiver::Listener(listener) => {
                 let verifier = self.verifier.as_ref();
@@ -301,7 +301,10 @@ impl Connector for ReverseTcpConnector {
             TcpConnectorReceiver::Address(addr) => {
                 let listener = TcpListener::bind(addr).await.map_err(|err| {
                     error!("Could not bind to address {}, {:?}", addr, err);
-                    StatusCode::BadCommunicationError
+                    Error::new(
+                        StatusCode::BadCommunicationError,
+                        format!("Could not bind to address {}, {:?}", addr, err),
+                    )
                 })?;
                 let verifier = self.verifier.as_ref();
                 let inner = StreamConnector::new(

--- a/async-opcua-core/src/comms/message_chunk.rs
+++ b/async-opcua-core/src/comms/message_chunk.rs
@@ -10,7 +10,7 @@ use std::io::{Cursor, Read, Write};
 use opcua_types::{
     process_decode_io_result, process_encode_io_result, read_u32, read_u8, status_code::StatusCode,
     write_u32, write_u8, DecodingOptions, EncodingResult, Error, SimpleBinaryDecodable,
-    SimpleBinaryEncodable,
+    SimpleBinaryEncodable, UAString,
 };
 use tracing::trace;
 
@@ -342,6 +342,29 @@ impl MessageChunk {
         ChunkInfo::new(self, secure_channel)
     }
 
+    /// Decode the body of this message as a `MessageFinalError`.
+    pub fn final_error_body(
+        &self,
+        chunk_info: &ChunkInfo,
+        decoding_options: &DecodingOptions,
+    ) -> Result<MessageFinalError, Error> {
+        let start = chunk_info.body_offset;
+        let end = start.checked_add(chunk_info.body_length).ok_or_else(|| {
+            Error::new(
+                StatusCode::BadCommunicationError,
+                "Invalid error body length",
+            )
+        })?;
+        let body = self.data.get(start..end).ok_or_else(|| {
+            Error::new(
+                StatusCode::BadCommunicationError,
+                "Invalid error body length",
+            )
+        })?;
+        let mut cursor = std::io::Cursor::new(body);
+        MessageFinalError::decode(&mut cursor, decoding_options)
+    }
+
     pub(crate) fn encrypted_data_offset(
         &self,
         decoding_options: &DecodingOptions,
@@ -356,5 +379,27 @@ impl MessageChunk {
             decoding_options,
         )?;
         Ok(stream.position() as usize)
+    }
+}
+
+#[derive(Debug)]
+/// Body of a message chunk with status FinalError.
+///
+/// See OPC-UA part 6, 6.7.3.
+pub struct MessageFinalError {
+    /// Numeric status code for the error.
+    pub status: StatusCode,
+    /// A more verbose description of the error.
+    pub reason: UAString,
+}
+
+impl SimpleBinaryDecodable for MessageFinalError {
+    fn decode<S: Read + ?Sized>(
+        stream: &mut S,
+        decoding_options: &DecodingOptions,
+    ) -> EncodingResult<Self> {
+        let status = StatusCode::decode(stream, decoding_options)?;
+        let reason = UAString::decode(stream, decoding_options)?;
+        Ok(Self { status, reason })
     }
 }

--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -345,7 +345,7 @@ impl SecureChannel {
     pub fn set_remote_cert_from_byte_string(
         &mut self,
         remote_cert: &ByteString,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         self.remote_cert = if remote_cert.is_null_or_empty() {
             None
         } else {
@@ -364,10 +364,7 @@ impl SecureChannel {
     }
 
     /// For secure channel requests, validate that the nonce has the correct length.
-    pub fn validate_secure_channel_nonce_length(
-        &self,
-        nonce: &ByteString,
-    ) -> Result<(), StatusCode> {
+    pub fn validate_secure_channel_nonce_length(&self, nonce: &ByteString) -> Result<(), Error> {
         if self.security_policy != SecurityPolicy::None
             && nonce.len() != self.security_policy.secure_channel_nonce_length()
         {
@@ -377,7 +374,15 @@ impl SecureChannel {
                 self.security_policy.secure_channel_nonce_length(),
                 nonce
             );
-            Err(StatusCode::BadNonceInvalid)
+            Err(Error::new(
+                StatusCode::BadNonceInvalid,
+                format!(
+                    "Nonce is invalid length {}, expecting {}. {:?}",
+                    nonce.len(),
+                    self.security_policy.secure_channel_nonce_length(),
+                    nonce
+                ),
+            ))
         } else {
             Ok(())
         }
@@ -387,13 +392,16 @@ impl SecureChannel {
     pub fn set_remote_nonce_from_byte_string(
         &mut self,
         remote_nonce: &ByteString,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         if let Some(ref remote_nonce) = remote_nonce.value {
             self.remote_nonce = remote_nonce.to_vec();
             Ok(())
         } else if self.security_policy != SecurityPolicy::None {
             error!("Remote nonce is invalid {:?}", remote_nonce);
-            Err(StatusCode::BadNonceInvalid)
+            Err(Error::new(
+                StatusCode::BadNonceInvalid,
+                "Remote nonce is invalid",
+            ))
         } else {
             Ok(())
         }

--- a/async-opcua-core/src/comms/url.rs
+++ b/async-opcua-core/src/comms/url.rs
@@ -4,6 +4,8 @@
 
 //! Provides functions for parsing Urls from strings.
 
+use std::fmt::Display;
+
 use tracing::error;
 use url::Url;
 
@@ -88,6 +90,17 @@ pub enum HostnameFromUrlError {
     Parse(url::ParseError),
     /// Host is not present in URL.
     MissingHost,
+}
+
+impl Display for HostnameFromUrlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HostnameFromUrlError::Parse(parse_error) => {
+                write!(f, "Failed to parse URL: {parse_error}")
+            }
+            HostnameFromUrlError::MissingHost => write!(f, "URL missing host"),
+        }
+    }
 }
 
 impl From<url::ParseError> for HostnameFromUrlError {

--- a/async-opcua-crypto/src/certificate_store.rs
+++ b/async-opcua-crypto/src/certificate_store.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use opcua_types::Error;
 use tracing::{debug, error, info, trace, warn};
 
 use opcua_types::status_code::StatusCode;
@@ -215,7 +216,7 @@ impl CertificateStore {
         security_policy: SecurityPolicy,
         hostname: Option<&str>,
         application_uri: Option<&str>,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         self.validate_application_instance_cert(cert, security_policy, hostname, application_uri)
     }
 
@@ -277,7 +278,7 @@ impl CertificateStore {
         security_policy: SecurityPolicy,
         hostname: Option<&str>,
         application_uri: Option<&str>,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), Error> {
         let cert_file_name = CertificateStore::cert_file_name(cert);
         debug!("Validating cert with name on disk {}", cert_file_name);
 
@@ -290,7 +291,13 @@ impl CertificateStore {
                     "Path for rejected certificates {} does not exist",
                     cert_path.display()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "Path for rejected certificates {} does not exist",
+                        cert_path.display()
+                    ),
+                ));
             }
             cert_path.push(&cert_file_name);
             if cert_path.exists() {
@@ -298,7 +305,13 @@ impl CertificateStore {
                     "Certificate {} is untrusted because it resides in the rejected directory",
                     cert_file_name
                 );
-                return Err(StatusCode::BadSecurityChecksFailed);
+                return Err(Error::new(
+                    StatusCode::BadSecurityChecksFailed,
+                    format!(
+                        "Certificate {} is untrusted because it resides in the rejected directory",
+                        cert_file_name
+                    ),
+                ));
             }
         }
 
@@ -309,10 +322,16 @@ impl CertificateStore {
             let mut cert_path = self.trusted_certs_dir();
             if !cert_path.exists() {
                 error!(
-                    "Path for rejected certificates {} does not exist",
+                    "Path for trusted certificates {} does not exist",
                     cert_path.display()
                 );
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(
+                    StatusCode::BadUnexpectedError,
+                    format!(
+                        "Path for trusted certificates {} does not exist",
+                        cert_path.display()
+                    ),
+                ));
             }
             cert_path.push(&cert_file_name);
 
@@ -327,21 +346,27 @@ impl CertificateStore {
                 } else {
                     warn!("Certificate {} is unknown and untrusted so it will be stored in rejected directory", cert_file_name);
                     let _ = self.store_rejected_cert(cert);
-                    return Err(StatusCode::BadCertificateUntrusted);
+                    return Err(Error::new(
+                        StatusCode::BadCertificateUntrusted,
+                        format!("Certificate {} is unknown and untrusted", cert_file_name),
+                    ));
                 }
             }
 
             // Read the cert from the trusted folder to make sure it matches the one supplied
             if !CertificateStore::ensure_cert_and_file_are_the_same(cert, &cert_path) {
                 error!("Certificate in memory does not match the one on disk {} so cert will automatically be treated as untrusted", cert_path.display());
-                return Err(StatusCode::BadUnexpectedError);
+                return Err(Error::new(StatusCode::BadUnexpectedError, format!("Certificate in memory does not match the one on disk {} so cert will automatically be treated as untrusted", cert_path.display())));
             }
 
             // Check that the certificate is the right length for the security policy
             match cert.key_length() {
                 Err(_) => {
                     error!("Cannot read key length from certificate {}", cert_file_name);
-                    return Err(StatusCode::BadSecurityChecksFailed);
+                    return Err(Error::new(
+                        StatusCode::BadSecurityChecksFailed,
+                        format!("Cannot read key length from certificate {}", cert_file_name),
+                    ));
                 }
                 Ok(key_length) => {
                     if !security_policy.is_valid_keylength(key_length) {
@@ -349,7 +374,13 @@ impl CertificateStore {
                             "Certificate {} has an invalid key length {} for the policy {}",
                             cert_file_name, key_length, security_policy
                         );
-                        return Err(StatusCode::BadSecurityChecksFailed);
+                        return Err(Error::new(
+                            StatusCode::BadSecurityChecksFailed,
+                            format!(
+                                "Certificate {} has an invalid key length {} for the policy {}",
+                                cert_file_name, key_length, security_policy
+                            ),
+                        ));
                     }
                 }
             }

--- a/async-opcua-crypto/src/lib.rs
+++ b/async-opcua-crypto/src/lib.rs
@@ -105,18 +105,29 @@ pub fn create_signature_data(
     security_policy: SecurityPolicy,
     contained_cert: &ByteString,
     nonce: &ByteString,
-) -> Result<SignatureData, StatusCode> {
+) -> Result<SignatureData, Error> {
     let (algorithm, signature) = match security_policy {
-        SecurityPolicy::Unknown => return Err(StatusCode::BadSecurityPolicyRejected),
+        SecurityPolicy::Unknown => {
+            return Err(Error::new(
+                StatusCode::BadSecurityPolicyRejected,
+                "Cannot create signature for Unknown security policy",
+            ))
+        }
         SecurityPolicy::None => (UAString::null(), ByteString::null()),
         security_policy => {
             if contained_cert.is_null_or_empty() {
                 error!("Null certificate passed to create_signature_data");
-                return Err(StatusCode::BadCertificateInvalid);
+                return Err(Error::new(
+                    StatusCode::BadCertificateInvalid,
+                    "Cannot create signature, missing signing certificate",
+                ));
             }
             if nonce.is_null_or_empty() {
                 error!("Null nonce passed to create_signature_data");
-                return Err(StatusCode::BadNonceInvalid);
+                return Err(Error::new(
+                    StatusCode::BadNonceInvalid,
+                    "Cannot create signature, missing nonce",
+                ));
             }
 
             let data = concat_data_and_nonce(contained_cert.as_ref(), nonce.as_ref());

--- a/async-opcua-crypto/src/tests/crypto.rs
+++ b/async-opcua-crypto/src/tests/crypto.rs
@@ -408,7 +408,7 @@ fn certificate_with_hostname_mismatch() {
     // Create a certificate and ensure that when the hostname does not match, the verification fails
     // with the correct error
     let result = cert.is_hostname_valid(&wrong_host_name).unwrap_err();
-    assert_eq!(result, StatusCode::BadCertificateHostNameInvalid);
+    assert_eq!(result.status(), StatusCode::BadCertificateHostNameInvalid);
 
     // Create a certificate and ensure that when the hostname does  match, the verification succeeds
     cert.is_hostname_valid(APPLICATION_HOSTNAME).unwrap();
@@ -426,7 +426,7 @@ fn certificate_with_application_uri_mismatch() {
 
     // Compare the certificate to the wrong application uri in the description, expect error
     let result = cert.is_application_uri_valid("urn:WrongURI").unwrap_err();
-    assert_eq!(result, StatusCode::BadCertificateUriInvalid);
+    assert_eq!(result.status(), StatusCode::BadCertificateUriInvalid);
 
     // Compare the certificate to the correct application uri in the description, expect success
     cert.is_application_uri_valid(APPLICATION_URI).unwrap();

--- a/async-opcua-crypto/src/x509.rs
+++ b/async-opcua-crypto/src/x509.rs
@@ -676,18 +676,26 @@ impl X509 {
 
     /// Tests if the certificate is valid for the supplied time using the not before and not
     /// after values on the cert.
-    pub fn is_time_valid(&self, now: &DateTime<Utc>) -> Result<(), StatusCode> {
+    pub fn is_time_valid(&self, now: &DateTime<Utc>) -> Result<(), Error> {
         // Issuer time
         let not_before = self.not_before();
         if let Ok(not_before) = not_before {
             if now.lt(&not_before) {
                 error!("Certificate < before date)");
-                return Err(StatusCode::BadCertificateTimeInvalid);
+                return Err(Error::new(
+                    StatusCode::BadCertificateTimeInvalid,
+                    format!(
+                        "Certificate not yet valid (valid from {not_before}, current time {now})",
+                    ),
+                ));
             }
         } else {
             // No before time
             error!("Certificate has no before date");
-            return Err(StatusCode::BadCertificateInvalid);
+            return Err(Error::new(
+                StatusCode::BadCertificateInvalid,
+                "Certificate has no not_before date",
+            ));
         }
 
         // Expiration time
@@ -695,12 +703,18 @@ impl X509 {
         if let Ok(not_after) = not_after {
             if now.gt(&not_after) {
                 error!("Certificate has expired (> after date)");
-                return Err(StatusCode::BadCertificateTimeInvalid);
+                return Err(Error::new(
+                    StatusCode::BadCertificateTimeInvalid,
+                    format!("Certificate has expired (valid to {not_after}, current time {now})"),
+                ));
             }
         } else {
             // No after time
             error!("Certificate has no after date");
-            return Err(StatusCode::BadCertificateInvalid);
+            return Err(Error::new(
+                StatusCode::BadCertificateInvalid,
+                "Certificate has no not_after date",
+            ));
         }
 
         trace!("Certificate is valid for this time");
@@ -723,12 +737,15 @@ impl X509 {
     }
 
     /// Tests if the supplied hostname matches any of the dns alt subject name entries on the cert
-    pub fn is_hostname_valid(&self, hostname: &str) -> Result<(), StatusCode> {
+    pub fn is_hostname_valid(&self, hostname: &str) -> Result<(), Error> {
         trace!("is_hostname_valid against {} on cert", hostname);
         // Look through alt subject names for a matching entry
         if hostname.is_empty() {
             error!("Hostname is empty");
-            Err(StatusCode::BadCertificateHostNameInvalid)
+            Err(Error::new(
+                StatusCode::BadCertificateHostNameInvalid,
+                "Certificate hostname is empty",
+            ))
         } else if let Some(subject_alt_names) = self.get_alternate_names() {
             let found = subject_alt_names
                 .iter()
@@ -745,17 +762,20 @@ impl X509 {
                 Ok(())
             } else {
                 warn!("Did not find hostname {hostname} in alt names {subject_alt_names:?}");
-                Err(StatusCode::BadCertificateHostNameInvalid)
+                Err(Error::new(StatusCode::BadCertificateHostNameInvalid, format!("Certificate hostname ({hostname}) not found in alt names ({subject_alt_names:?})")))
             }
         } else {
             // No alt names
             error!("Cert has no subject alt names at all");
-            Err(StatusCode::BadCertificateHostNameInvalid)
+            Err(Error::new(
+                StatusCode::BadCertificateHostNameInvalid,
+                "Certificate has no subject alt names",
+            ))
         }
     }
 
     /// Tests if the supplied application uri matches the uri alt subject name entry on the cert
-    pub fn is_application_uri_valid(&self, application_uri: &str) -> Result<(), StatusCode> {
+    pub fn is_application_uri_valid(&self, application_uri: &str) -> Result<(), Error> {
         // Expecting the first subject alternative name to be a uri that matches with the supplied
         // application uri
         if let Some(alt_names) = self.get_alternate_names() {
@@ -769,23 +789,35 @@ impl X509 {
                                 "Application uri {} does not match first alt name {}",
                                 application_uri, val
                             );
-                            Err(StatusCode::BadCertificateUriInvalid)
+                            Err(Error::new(StatusCode::BadCertificateUriInvalid, format!("Application uri {application_uri} does not match first alt name {val}")))
                         }
                     }
 
                     _ => {
                         error!("Alternate name {:?} cannot be converted", alt_names[0]);
-                        Err(StatusCode::BadCertificateUriInvalid)
+                        Err(Error::new(
+                            StatusCode::BadCertificateUriInvalid,
+                            format!(
+                                "Failed to convert certificate alt name {:?} to string",
+                                alt_names[0]
+                            ),
+                        ))
                     }
                 }
             } else {
                 error!("Cert has zero subject alt names");
-                Err(StatusCode::BadCertificateUriInvalid)
+                Err(Error::new(
+                    StatusCode::BadCertificateUriInvalid,
+                    "Certificate has no subject alt names",
+                ))
             }
         } else {
             error!("Cert has no subject alt names at all");
             // No alt names
-            Err(StatusCode::BadCertificateUriInvalid)
+            Err(Error::new(
+                StatusCode::BadCertificateUriInvalid,
+                "Certificate has no subject alt names",
+            ))
         }
     }
 

--- a/async-opcua/tests/integration/browse.rs
+++ b/async-opcua/tests/integration/browse.rs
@@ -363,25 +363,25 @@ async fn browse_limits() {
 
     // Browse zero
     let r = session.browse(&[], 1000, None).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     // Too many operations
     let ops: Vec<_> = (0..(browse_limit + 1))
         .map(|r| hierarchical_desc(NodeId::new(2, r as u32)))
         .collect();
     let r = session.browse(&ops, 1000, None).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 
     // Browse next zero
     let r = session.browse_next(false, &[]).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     // Too many operations
     let ops: Vec<_> = (0..(browse_limit + 1))
         .map(|_| ByteString::from(vec![1u8]))
         .collect();
     let r = session.browse_next(false, &ops).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 }
 
 #[tokio::test]
@@ -506,7 +506,7 @@ async fn translate_browse_paths_limits() {
         .translate_browse_paths_to_node_ids(&[])
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     // Translate too many
     let ops: Vec<_> = (0..(limit + 1))
@@ -519,7 +519,7 @@ async fn translate_browse_paths_limits() {
         .translate_browse_paths_to_node_ids(&ops)
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 }
 
 #[tokio::test]

--- a/async-opcua/tests/integration/core_tests.rs
+++ b/async-opcua/tests/integration/core_tests.rs
@@ -388,7 +388,7 @@ async fn recoverable_error_test_server() {
         .read(&ids, TimestampsToReturn::Both, 0.0)
         .await
         .unwrap_err();
-    assert_eq!(res, StatusCode::BadDecodingError);
+    assert_eq!(res.status(), StatusCode::BadDecodingError);
 
     session
         .read(

--- a/async-opcua/tests/integration/methods.rs
+++ b/async-opcua/tests/integration/methods.rs
@@ -239,7 +239,7 @@ async fn call_limits() {
 
     // Call none
     let e = session.call(Vec::new()).await.unwrap_err();
-    assert_eq!(e, StatusCode::BadNothingToDo);
+    assert_eq!(e.status(), StatusCode::BadNothingToDo);
 
     // Call too many
     let e = session
@@ -254,7 +254,7 @@ async fn call_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(e, StatusCode::BadTooManyOperations);
+    assert_eq!(e.status(), StatusCode::BadTooManyOperations);
 }
 
 #[tokio::test]

--- a/async-opcua/tests/integration/node_management.rs
+++ b/async-opcua/tests/integration/node_management.rs
@@ -147,7 +147,7 @@ async fn add_delete_node_limits() {
 
     // Add zero
     let e = session.add_nodes(&[]).await.unwrap_err();
-    assert_eq!(e, StatusCode::BadNothingToDo);
+    assert_eq!(e.status(), StatusCode::BadNothingToDo);
 
     // Add too many
     let e = session
@@ -176,7 +176,7 @@ async fn add_delete_node_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(e, StatusCode::BadTooManyOperations);
+    assert_eq!(e.status(), StatusCode::BadTooManyOperations);
 }
 
 #[tokio::test]
@@ -192,7 +192,7 @@ async fn add_delete_reference_limits() {
 
     // Add zero
     let e = session.add_references(&[]).await.unwrap_err();
-    assert_eq!(e, StatusCode::BadNothingToDo);
+    assert_eq!(e.status(), StatusCode::BadNothingToDo);
 
     // Add too many
     let e = session
@@ -210,5 +210,5 @@ async fn add_delete_reference_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(e, StatusCode::BadTooManyOperations);
+    assert_eq!(e.status(), StatusCode::BadTooManyOperations);
 }

--- a/async-opcua/tests/integration/read.rs
+++ b/async-opcua/tests/integration/read.rs
@@ -699,7 +699,7 @@ async fn read_limits() {
         .read(&[], TimestampsToReturn::Both, 0.0)
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     // Invalid max age
     let r = session
@@ -710,7 +710,7 @@ async fn read_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadMaxAgeInvalid);
+    assert_eq!(r.status(), StatusCode::BadMaxAgeInvalid);
 
     // Invalid timestamps to return
     let r = session
@@ -721,7 +721,7 @@ async fn read_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadTimestampsToReturnInvalid);
+    assert_eq!(r.status(), StatusCode::BadTimestampsToReturnInvalid);
 
     // Too many operations
     let ops: Vec<_> = (0..(read_limit + 1))
@@ -731,7 +731,7 @@ async fn read_limits() {
         .read(&ops, TimestampsToReturn::Both, 0.0)
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 
     // Exact number of operations, should not fail, though the reads will probably fail, mostly.
     let ops: Vec<_> = (0..read_limit)
@@ -1010,7 +1010,7 @@ async fn history_read_fail() {
         .history_read(action.clone(), TimestampsToReturn::Both, false, &[])
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     let history_read_limit = tester
         .handle
@@ -1037,7 +1037,7 @@ async fn history_read_fail() {
         )
         .await
         .unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 
     // Read without access
     let r = session
@@ -1114,7 +1114,7 @@ async fn read_retry() {
         )
         .await
         .unwrap_err();
-    assert_eq!(e, StatusCode::BadInternalError);
+    assert_eq!(e.status(), StatusCode::BadInternalError);
 
     // Use the retry method to send the remaining requests, two more will fail, then
     // the request will succeed.
@@ -1237,7 +1237,7 @@ async fn test_read_timeout() {
         .send(session.channel())
         .await
         .unwrap_err();
-    assert!(matches!(r, StatusCode::BadTimeout));
+    assert!(matches!(r.status(), StatusCode::BadTimeout));
 
     // Now, wait for a bit, so that the client receives the late response from the server.
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/async-opcua/tests/integration/subscriptions.rs
+++ b/async-opcua/tests/integration/subscriptions.rs
@@ -403,7 +403,7 @@ async fn subscription_limits() {
         .create_subscription(Duration::from_secs(1), 100, 20, 1000, 0, true, notifs)
         .await
         .unwrap_err();
-    assert_eq!(StatusCode::BadTooManySubscriptions, e);
+    assert_eq!(StatusCode::BadTooManySubscriptions, e.status());
     for sub in subs.iter().skip(1) {
         session.delete_subscription(*sub).await.unwrap();
     }
@@ -424,7 +424,7 @@ async fn subscription_limits() {
         .create_monitored_items(sub, TimestampsToReturn::Both, vec![])
         .await
         .unwrap_err();
-    assert_eq!(StatusCode::BadNothingToDo, e);
+    assert_eq!(StatusCode::BadNothingToDo, e.status());
 
     // Create too many
     let e = session
@@ -449,7 +449,7 @@ async fn subscription_limits() {
         )
         .await
         .unwrap_err();
-    assert_eq!(e, StatusCode::BadTooManyOperations);
+    assert_eq!(e.status(), StatusCode::BadTooManyOperations);
 }
 
 #[tokio::test]
@@ -990,7 +990,7 @@ async fn test_keep_alive_sequence_not_retransmitted() {
         .send(session.channel())
         .await;
     assert_eq!(
-        republish_keep_alive.unwrap_err(),
+        republish_keep_alive.unwrap_err().status(),
         StatusCode::BadMessageNotAvailable
     );
 }

--- a/async-opcua/tests/integration/write.rs
+++ b/async-opcua/tests/integration/write.rs
@@ -552,7 +552,7 @@ async fn write_limits() {
     // Write zero. This doesn't actually reach the server, since we intercept it in the client.
     // we still protect against it on the server, but we don't have a way to bypass that check here.
     let r = session.write(&[]).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     // Too many operations
     let ops: Vec<_> = (0..(write_limit + 1))
@@ -560,7 +560,7 @@ async fn write_limits() {
         .collect();
 
     let r = session.write(&ops).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 
     // Exact number of operations
     let ops: Vec<_> = (0..write_limit)
@@ -825,7 +825,7 @@ async fn history_update_fail() {
 
     // Write nothing
     let r = session.history_update(&[]).await.unwrap_err();
-    assert_eq!(r, StatusCode::BadNothingToDo);
+    assert_eq!(r.status(), StatusCode::BadNothingToDo);
 
     let history_update_limit = tester
         .handle
@@ -851,7 +851,7 @@ async fn history_update_fail() {
         .await
         .unwrap_err();
 
-    assert_eq!(r, StatusCode::BadTooManyOperations);
+    assert_eq!(r.status(), StatusCode::BadTooManyOperations);
 
     // Write without access
     let r = session


### PR DESCRIPTION
In general, I strongly prefer using `Error` where possible, for a few reasons:
    
 - It lets us pass structured context. OPC-UA status codes can be very opaque.
 - It's extensible. It's very possible we'll be able to include some clever extensions in the future, like opt-in stack-traces which is _very useful for debugging.

This makes more or less everything in the client return `Error`, which is somewhat breaking. Note that Error implements `Into<StatusCode>`, so clients using `?` to return `StatusCode` will continue to work. I do expect some breakage, however. It really should not be too difficult to fix for most users.