### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,75 @@ jobs:
   verify-clean-codegen:
     uses: ./.github/workflows/ci_verify_clean_codegen.yml
 
+  check_for_release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      tag_exists: ${{ steps.should-release.outputs.tag_exists }}
+      branch: ${{ steps.branch.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - name: Provision toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install jq
+        run: sudo apt-get install -y jq
+      - name: Get branch name
+        id: branch
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+      - name: Get version from Cargo.toml, and check that it is consistent.
+        id: get-version
+        run: echo "version=$(./tools/check_version_numbers.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if we should release a new version
+        id: should-release
+        run: echo "tag_exists=$(git tag --list '${{ steps.get-version.outputs.version }}' | wc -l | sed s/\ //g)" >> $GITHUB_OUTPUT
+
+      - name: Log release status
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (${{ steps.should-release.outputs.tag_exists }} == 0) {
+              core.warning('Will release async-opcua version ${{ steps.get-version.outputs.version }}')
+            } else {
+              core.notice('Will not create release for version ${{ steps.get-version.outputs.version }} because it already exists.')
+            }
+
+  release:
+    runs-on: ubuntu-latest
+    needs: check_for_release
+    environment: CD
+    if: ${{ needs.check_for_release.outputs.tag_exists == 0 && needs.check_for_release.outputs.branch == 'master'}}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - name: Provision toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo-release
+        run: cargo install cargo-release
+
+      - name: Create tag
+        uses: rickstaa/action-create-tag@v1
+        id: "tag_create"
+        with:
+          tag: ${{ needs.common.outputs.version }}
+          tag_exists_error: true
+          message: Async OPC-UA version ${{ needs.common.outputs.version }}
+
+      - name: Create github release
+        uses: softprops/action-gh-release@v3.0.0
+        with:
+          tag_name: ${{ needs.common.outputs.version }}
+          generate_release_notes: true
+
+      - name: Publish
+        run: cargo release $(./tools/release-package-args.sh) --execute
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/async-opcua-client/Cargo.toml
+++ b/async-opcua-client/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-client/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-codegen/Cargo.toml
+++ b/async-opcua-codegen/Cargo.toml
@@ -10,6 +10,7 @@ license = "MPL-2.0"
 keywords = ["opcua", "opc", "ua"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua/"
+publish = true
 
 [lib]
 name = "opcua_codegen"

--- a/async-opcua-core-namespace/Cargo.toml
+++ b/async-opcua-core-namespace/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-core-namespace/"
 edition = "2021"
+publish = true
 
 [lib]
 name = "opcua_core_namespace"

--- a/async-opcua-core/Cargo.toml
+++ b/async-opcua-core/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-core/"
 edition = "2021"
+publish = true
 
 [lib]
 name = "opcua_core"

--- a/async-opcua-crypto/Cargo.toml
+++ b/async-opcua-crypto/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-crypto/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-macros/Cargo.toml
+++ b/async-opcua-macros/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-macros/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-nodes/Cargo.toml
+++ b/async-opcua-nodes/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-nodes/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-server/Cargo.toml
+++ b/async-opcua-server/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-server/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-types/Cargo.toml
+++ b/async-opcua-types/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-types/"
 edition = "2021"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua-xml/Cargo.toml
+++ b/async-opcua-xml/Cargo.toml
@@ -10,6 +10,7 @@ license = "MPL-2.0"
 keywords = ["opcua", "opc", "ua"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua-xml/"
+publish = true
 
 [lints]
 workspace = true

--- a/async-opcua/Cargo.toml
+++ b/async-opcua/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["embedded", "network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/async-opcua/"
 edition = "2021"
+publish = true
 
 [lib]
 name = "opcua"

--- a/codegen-tests/Cargo.toml
+++ b/codegen-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codegen-tests"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [features]
 json = ["async-opcua/json"]

--- a/dotnet-tests/external-tests/Cargo.toml
+++ b/dotnet-tests/external-tests/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "OPC UA tests using an external .NET server"
 authors = ["Einar Omang <einar@omang.com>"]
 license = "MPL-2.0"
+publish = false
 
 [dependencies]
 tokio = { workspace = true }

--- a/samples/chess-server/Cargo.toml
+++ b/samples/chess-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-chess-server"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 tokio = { workspace = true }

--- a/samples/custom-codegen/Cargo.toml
+++ b/samples/custom-codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "custom-codegen"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [features]
 json = ["serde_json", "serde", "serde_with", "async-opcua/json"]

--- a/samples/custom-structures-client/Cargo.toml
+++ b/samples/custom-structures-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "opcua-structure-client"
 version = "0.13.0"
 authors = ["Rust-OpcUa contributors"]
 edition = "2021"
+publish = false
 
 [dependencies]
 pico-args = "0.5"

--- a/samples/demo-server/Cargo.toml
+++ b/samples/demo-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-demo-server"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 chrono = { workspace = true }

--- a/samples/discovery-client/Cargo.toml
+++ b/samples/discovery-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-discovery-client"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 pico-args = "0.5"

--- a/samples/event-client/Cargo.toml
+++ b/samples/event-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-event-client"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 pico-args = "0.5"

--- a/samples/mqtt-client/Cargo.toml
+++ b/samples/mqtt-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-mqtt-client"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 pico-args = "0.5"

--- a/samples/node-managers/Cargo.toml
+++ b/samples/node-managers/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-node-manager-sample"
 version = "0.13.0"
 authors = ["Einar Omang <einar@omang.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/samples/simple-client/Cargo.toml
+++ b/samples/simple-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "async-opcua-simple-client"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 log = { workspace = true }

--- a/samples/simple-server/Cargo.toml
+++ b/samples/simple-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-opcua-simple-server"
 version = "0.13.0"
 authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 chrono = { workspace = true }

--- a/tools/certificate-creator/Cargo.toml
+++ b/tools/certificate-creator/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 keywords = ["opcua", "opc", "ua"]
 categories = ["embedded", "network-programming"]
 edition = "2021"
+publish = false
 
 [dependencies]
 pico-args = "0.5"

--- a/tools/check_version_numbers.sh
+++ b/tools/check_version_numbers.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Check if all release targets have the same version number set, which we currently require. All releases
+# release every package, currently.
+packages=$(./tools/publish-targets.sh)
+
+items=""
+
+while IFS= read -r line; do
+    if [[ -n "$items" ]]; then
+        items+=", "
+    fi
+    items+="\"$line\""
+done <<< "$packages"
+
+versions=$(cargo metadata --format-version 1 | jq --raw-output '.packages[] | select(.name | IN($items[])) | .version' --argjson items "[$items]")
+
+unique=$(echo $versions | tr ' ' '\n' | sort -u | wc -l)
+
+if [[ "$unique" != "1" ]]; then
+    echo "At least one package has the wrong version. Versions:"
+    cargo metadata --format-version 1 | jq --raw-output '.packages[] | select(.name | IN($items[])) | "\(.name): \(.version)"' --argjson items "[$items]"
+    echo $version_info
+    exit 1
+fi
+
+echo $versions | tr ' ' '\n' | sort -u

--- a/tools/publish-targets.sh
+++ b/tools/publish-targets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Get the list of publish targets, for use in other scripts.
+ITEMS=(
+    'async-opcua-client'
+    'async-opcua-core'
+    'async-opcua-core-namespace'
+    'async-opcua-crypto'
+    'async-opcua-macros'
+    'async-opcua-nodes'
+    'async-opcua-server'
+    'async-opcua-types'
+    'async-opcua-xml'
+    'async-opcua-codegen'
+)
+
+for item in "${ITEMS[@]}"; do
+    echo "$item"
+done

--- a/tools/release-package-args.sh
+++ b/tools/release-package-args.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/env bash
-echo "--package async-opcua --package async-opcua-client --package async-opcua-core --package async-opcua-core-namespace --package async-opcua-crypto --package async-opcua-macros --package async-opcua-nodes --package async-opcua-server --package async-opcua-types --package async-opcua-xml --package async-opcua-codegen"
+
+# Get arguments for calls to `cargo release`, listing the packages we want to publish explicitly.
+
+packages=$(./tools/publish-targets.sh)
+
+while IFS= read -r line; do
+    echo -n "--package $line "
+done <<< "$packages"


### PR DESCRIPTION
Releases are triggered by just updating the version of all crates. Right now we also require them to be the same. To be safe, I made it so that releases run in a special "CD" environment, that is restricted to master and requires approval.