### PR TITLE
Set is_for_events to true for history_read_events.

### DIFF
--- a/async-opcua-server/src/node_manager/memory/mod.rs
+++ b/async-opcua-server/src/node_manager/memory/mod.rs
@@ -997,7 +997,7 @@ impl<TImpl: InMemoryNodeManagerImpl> NodeManager for InMemoryNodeManager<TImpl> 
         nodes: &mut [&mut HistoryNode],
         timestamps_to_return: TimestampsToReturn,
     ) -> Result<(), StatusCode> {
-        let mut nodes = self.validate_history_read_nodes(context, nodes, false);
+        let mut nodes = self.validate_history_read_nodes(context, nodes, true);
         self.inner
             .history_read_events(context, details, &mut nodes, timestamps_to_return)
             .await


### PR DESCRIPTION
In `history_read_events` the call to `self.validate_history_read_nodes` should be done with `true` for the `is_for_events` parameter instead of `false`.