### PR TITLE
Fix ReferenceType::from_attributes setting symmetric from is_abstract

### DIFF
--- a/async-opcua-nodes/src/reference_type.rs
+++ b/async-opcua-nodes/src/reference_type.rs
@@ -192,7 +192,7 @@ impl ReferenceType {
                 node.set_is_abstract(attributes.is_abstract);
             }
             if mask.contains(AttributesMask::SYMMETRIC) {
-                node.set_symmetric(attributes.is_abstract);
+                node.set_symmetric(attributes.symmetric);
             }
             if mask.contains(AttributesMask::INVERSE_NAME) {
                 node.set_inverse_name(attributes.inverse_name);


### PR DESCRIPTION
`ReferenceType::from_attributes` copies `attributes.is_abstract` into the `symmetric` attribute when the SYMMETRIC mask bit is set, so any ReferenceType node created through the AddNodes service gets a wrong `Symmetric` value whenever it differs from `IsAbstract`.

One-line fix: use `attributes.symmetric`.

Found while reviewing the downstream fork at occamsshavingkit/async-opcua; the crate's existing tests pass with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)