### PR TITLE
fix(server): reclaim connection_map slot when a connection task panics

### DIFF
--- a/async-opcua-server/src/server.rs
+++ b/async-opcua-server/src/server.rs
@@ -53,6 +53,15 @@ struct ConnectionInfo {
     command_send: tokio::sync::mpsc::Sender<ControllerCommand>,
 }
 
+fn log_connection_panic(id: u32, payload: Box<dyn std::any::Any + Send>) {
+    let message = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload");
+    error!("Connection task {id} panicked: {message}");
+}
+
 /// The server struct. This is consumed when run, so you will typically not hold onto this for longer
 /// periods of time.
 pub struct Server {
@@ -381,7 +390,16 @@ impl Server {
                             );
 
                             let (send, recv) = tokio::sync::mpsc::channel(5);
-                            let handle = tokio::spawn(conn.run(recv, |_| {}).map(move |_| connection_counter));
+                            let handle = tokio::spawn(async move {
+                                if let Err(payload) =
+                                    std::panic::AssertUnwindSafe(conn.run(recv, |_| {}))
+                                        .catch_unwind()
+                                        .await
+                                {
+                                    log_connection_panic(connection_counter, payload);
+                                }
+                                connection_counter
+                            });
                             self.connections.push(handle);
                             self.connection_map.insert(connection_counter, ConnectionInfo {
                                 command_send: send
@@ -422,9 +440,14 @@ impl Server {
                     let (send, recv) = tokio::sync::mpsc::channel(5);
                     let rev_handle = rev_connect.handle;
                     let handle = tokio::spawn(async move {
-                        conn.run(recv, |status| {
+                        let run = conn.run(recv, |status| {
                             rev_handle.set_result(status);
-                        }).await;
+                        });
+                        if let Err(payload) =
+                            std::panic::AssertUnwindSafe(run).catch_unwind().await
+                        {
+                            log_connection_panic(connection_counter, payload);
+                        }
                         connection_counter
                     });
                     self.connections.push(handle);


### PR DESCRIPTION
## Problem

When a spawned connection task panics, `tokio::spawn` resolves the `JoinHandle` as `Err(JoinError)`. The select loop logs the error but **does not call `self.connection_map.remove(&id)`** because the panic path has no counter to match on:

```rust
Err(e) => error!("Connection panic! {e}")  // slot never freed
```

The connection counter slot stays in `connection_map` forever, permanently consuming one `max_connections` slot. Under sustained load with buggy node manager code, this eventually exhausts the connection limit and the server stops accepting new connections.

## Fix

Wrap both spawn sites (accept and reverse connect) with `AssertUnwindSafe` + `catch_unwind` so the task always returns its counter whether it exits normally or panics. The `Ok(id)` path in the select loop then handles cleanup in both cases.

A `log_connection_panic` helper extracts the message from the panic payload (covers both `&str` and `String` payloads).

## Testing

Verified with `cargo check -p async-opcua-server`. The existing `connection_limit_tests` suite covers the slot-reclamation path.