### PR TITLE
perf(core): allocation-free transmit path via streaming chunk encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,10 @@ dependencies = [
 [[package]]
 name = "async-opcua-safety"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "hex",
+]
 
 [[package]]
 name = "async-opcua-server"
@@ -564,6 +568,46 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "async-opcua-nodes",
  "async-opcua-types",
  "async-trait",
+ "bytes",
  "chrono",
  "futures",
  "hashbrown 0.15.5",
@@ -340,6 +341,10 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
 ]
+
+[[package]]
+name = "async-opcua-safety"
+version = "0.1.0"
 
 [[package]]
 name = "async-opcua-server"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,14 +343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-opcua-safety"
-version = "0.1.0"
-dependencies = [
- "clap",
- "hex",
-]
-
-[[package]]
 name = "async-opcua-server"
 version = "0.18.0"
 dependencies = [
@@ -568,46 +560,6 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
-
-[[package]]
-name = "clap"
-version = "4.5.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"

--- a/async-opcua-client/Cargo.toml
+++ b/async-opcua-client/Cargo.toml
@@ -21,6 +21,7 @@ name = "opcua_client"
 
 [dependencies]
 arc-swap = { workspace = true }
+bytes = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }

--- a/async-opcua-client/src/transport/core.rs
+++ b/async-opcua-client/src/transport/core.rs
@@ -21,7 +21,7 @@ use crate::transport::RequestRecv;
 #[derive(Debug)]
 struct MessageChunkWithChunkInfo {
     header: ChunkInfo,
-    data_with_header: Vec<u8>,
+    data_with_header: bytes::Bytes,
 }
 
 pub(crate) struct MessageState {

--- a/async-opcua-core/src/comms/buffer.rs
+++ b/async-opcua-core/src/comms/buffer.rs
@@ -38,6 +38,12 @@ enum PendingPayload {
 pub struct SendBuffer {
     /// The send buffer
     buffer: Cursor<Vec<u8>>,
+    /// Reusable storage for encoded chunk data. Chunks hold zero-copy
+    /// slices of this buffer, and its allocation is reclaimed once they
+    /// have been sent, so steady-state encoding does not allocate.
+    chunk_storage: bytes::BytesMut,
+    /// Reusable scratch for chunks produced by a single message.
+    chunk_scratch: Vec<MessageChunk>,
     /// Queued chunks
     chunks: VecDeque<PendingPayload>,
     /// The last request id
@@ -69,6 +75,8 @@ impl SendBuffer {
     ) -> Self {
         Self {
             buffer: Cursor::new(vec![0u8; buffer_size + 1024]),
+            chunk_storage: bytes::BytesMut::new(),
+            chunk_scratch: Vec::new(),
             chunks: VecDeque::with_capacity(max_chunk_count),
             last_request_id: 1000,
             sequence_numbers: SequenceNumberHandle::new(sequence_numbers_legacy),
@@ -136,34 +144,38 @@ impl SendBuffer {
     ) -> Result<u32, Error> {
         trace!("Writing request to buffer");
 
-        // Turn message to chunk(s)
-        let chunks = Chunker::encode(
+        // Turn message to chunk(s), reusing the connection-local chunk
+        // storage and scratch so this does not allocate at steady state.
+        self.chunk_scratch.clear();
+        let chunk_count = Chunker::encode_into(
             self.sequence_numbers.clone(),
             request_id,
             self.max_message_size,
             self.send_buffer_size,
             secure_channel,
             &message,
+            &mut self.chunk_storage,
+            &mut self.chunk_scratch,
         )
         .map_err(|e| e.with_context(Some(request_id), Some(message.request_handle())))?;
 
-        if self.max_chunk_count > 0 && chunks.len() > self.max_chunk_count {
+        if self.max_chunk_count > 0 && chunk_count > self.max_chunk_count {
+            self.chunk_scratch.clear();
             Err(Error::new(
                 StatusCode::BadCommunicationError,
                 format!(
-                    "Cannot write message since {} chunks exceeds {} chunk limit",
-                    chunks.len(),
+                    "Cannot write message since {chunk_count} chunks exceeds {} chunk limit",
                     self.max_chunk_count
                 ),
             )
             .with_context(Some(request_id), Some(message.request_handle())))
         } else {
             // Sequence number monotonically increases per chunk
-            self.sequence_numbers.increment(chunks.len() as u32);
+            self.sequence_numbers.increment(chunk_count as u32);
 
             // Send chunks
             self.chunks
-                .extend(chunks.into_iter().map(PendingPayload::Chunk));
+                .extend(self.chunk_scratch.drain(..).map(PendingPayload::Chunk));
             Ok(request_id)
         }
     }
@@ -335,6 +347,57 @@ mod tests {
         assert!(!buffer.should_encode_chunks());
         assert!(!buffer.can_read());
         assert!(cursor.get_ref().len() > 8196 * 2 && cursor.get_ref().len() < 8196 * 3);
+    }
+
+    #[tokio::test]
+    async fn test_buffer_chunk_storage_is_reused() {
+        let (mut buffer, channel) = get_buffer_and_channel();
+
+        let mut sink = Cursor::new(Vec::new());
+        let mut warmed_ptr = None;
+        let mut warmed_capacity = None;
+        for i in 0..5u32 {
+            let message = ReadRequest {
+                request_header: RequestHeader::new(&NodeId::null(), &DateTime::null(), 101),
+                max_age: 0.0,
+                timestamps_to_return: TimestampsToReturn::Both,
+                nodes_to_read: Some(
+                    (0..1000)
+                        .map(|r| ReadValueId {
+                            node_id: (1, r).into(),
+                            attribute_id: 1,
+                            ..Default::default()
+                        })
+                        .collect(),
+                ),
+            };
+            let m: RequestMessage = message.into();
+            buffer.write(i + 1, m, &channel).unwrap();
+
+            // After the first message the storage is warmed; subsequent
+            // writes must reclaim the same allocation rather than grow or
+            // reallocate.
+            if i >= 1 {
+                let ptr = buffer.chunk_storage.as_ptr();
+                let capacity = buffer.chunk_storage.capacity();
+                if let (Some(warmed_ptr), Some(warmed_capacity)) = (warmed_ptr, warmed_capacity) {
+                    assert_eq!(
+                        ptr, warmed_ptr,
+                        "chunk storage should be reclaimed, not reallocated"
+                    );
+                    assert_eq!(capacity, warmed_capacity, "chunk storage should not grow");
+                }
+                warmed_ptr = Some(ptr);
+                warmed_capacity = Some(capacity);
+            }
+
+            while buffer.should_encode_chunks() {
+                buffer.encode_next_chunk(&channel).unwrap();
+                while buffer.can_read() {
+                    buffer.read_into_async(&mut sink).await.unwrap();
+                }
+            }
+        }
     }
 
     #[test]

--- a/async-opcua-core/src/comms/chunker.rs
+++ b/async-opcua-core/src/comms/chunker.rs
@@ -18,11 +18,11 @@ use crate::{
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
     encoding::BinaryEncodable, node_id::NodeId, status_code::StatusCode, BinaryDecodable,
-    EncodingResult, Error, ObjectId,
+    EncodingResult, Error, ObjectId, SimpleBinaryEncodable,
 };
 use tracing::{debug, error, trace};
 
-use super::message_chunk::MessageChunkType;
+use super::{message_chunk::MessageChunkType, security_header::SequenceHeader};
 
 /// Read implementation for a sequence of message chunks.
 /// This lets us avoid allocating a buffer for the message.
@@ -102,13 +102,23 @@ impl<'a, T: Iterator<Item = &'a MessageChunk>> Read for ReceiveStream<'a, T> {
     }
 }
 
-struct ChunkingStream<'a> {
+/// Streaming chunk encoder that writes complete chunks (headers + body)
+/// contiguously into a caller-provided [`BytesMut`], emitting each chunk as a
+/// zero-copy [`Bytes`](bytes::Bytes) slice of that storage. With a reused
+/// connection-local storage buffer this makes steady-state transmit encoding
+/// allocation free: once the chunks from the previous message are dropped the
+/// storage allocation is reclaimed by `reserve`.
+struct ChunkingStream<'a, 'b> {
     secure_channel: &'a SecureChannel,
-    chunks: Vec<MessageChunk>,
+    storage: &'b mut bytes::BytesMut,
+    out: &'b mut Vec<MessageChunk>,
     expected_chunk_count: usize,
+    chunks_emitted: usize,
     max_body_per_chunk: usize,
-    next_buf: Vec<u8>,
-    buf_position: usize,
+    header_size: usize,
+    current_body_target: usize,
+    body_written: usize,
+    chunk_started: bool,
     is_closed: bool,
     sequence_number: SequenceNumberHandle,
     request_id: u32,
@@ -116,7 +126,8 @@ struct ChunkingStream<'a> {
     message_type: MessageChunkType,
 }
 
-impl<'a> ChunkingStream<'a> {
+impl<'a, 'b> ChunkingStream<'a, 'b> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         message_type: MessageChunkType,
         secure_channel: &'a SecureChannel,
@@ -125,8 +136,10 @@ impl<'a> ChunkingStream<'a> {
         request_id: u32,
         request_handle: u32,
         sequence_number: SequenceNumberHandle,
+        storage: &'b mut bytes::BytesMut,
+        out: &'b mut Vec<MessageChunk>,
     ) -> Result<Self, Error> {
-        if max_chunk_size > 0 {
+        let (expected_chunk_count, max_body_per_chunk) = if max_chunk_size > 0 {
             let max_body_per_chunk = MessageChunk::body_size_from_message_size(
                 message_type,
                 secure_channel,
@@ -142,112 +155,148 @@ impl<'a> ChunkingStream<'a> {
                     },
                 )
             })?;
-            let expected_chunk_count = message_size / max_body_per_chunk + 1;
-            let next_buf_size = if expected_chunk_count == 1 {
-                message_size
-            } else {
-                max_body_per_chunk
-            };
-
-            Ok(Self {
-                secure_channel,
-                chunks: Vec::with_capacity(expected_chunk_count),
-                expected_chunk_count,
+            (
+                message_size.div_ceil(max_body_per_chunk).max(1),
                 max_body_per_chunk,
-                next_buf: vec![0; next_buf_size],
-                buf_position: 0,
-                is_closed: false,
-                sequence_number,
-                request_id,
-                message_type,
-                message_size,
-            })
+            )
         } else {
-            let expected_chunk_count = 1;
-            let max_body_per_chunk = 0;
-            let next_buf_size = message_size;
-            Ok(Self {
-                secure_channel,
-                chunks: Vec::with_capacity(expected_chunk_count),
-                expected_chunk_count,
-                max_body_per_chunk,
-                next_buf: vec![0; next_buf_size],
-                buf_position: 0,
-                is_closed: false,
-                sequence_number,
-                request_id,
-                message_type,
-                message_size,
-            })
-        }
+            (1, 0)
+        };
+
+        let security_header = secure_channel.make_security_header(message_type);
+        let header_size = super::message_chunk::MESSAGE_CHUNK_HEADER_SIZE
+            + SimpleBinaryEncodable::byte_len(&security_header)
+            + SimpleBinaryEncodable::byte_len(&SequenceHeader {
+                sequence_number: 0,
+                request_id: 0,
+            });
+
+        // Any leftovers from a previously failed encode are dead; this only
+        // touches the unsplit tail, so chunks still in flight are unaffected.
+        storage.clear();
+        // On a warmed buffer whose previous chunks have been sent and
+        // dropped, this reclaims the existing allocation instead of
+        // allocating anew.
+        storage.reserve(message_size + expected_chunk_count * header_size);
+
+        Ok(Self {
+            secure_channel,
+            storage,
+            out,
+            expected_chunk_count,
+            chunks_emitted: 0,
+            max_body_per_chunk,
+            header_size,
+            current_body_target: 0,
+            body_written: 0,
+            chunk_started: false,
+            is_closed: false,
+            sequence_number,
+            request_id,
+            message_type,
+            message_size,
+        })
     }
 
-    fn flush_chunk(&mut self) -> EncodingResult<()> {
-        if self.is_closed {
-            return Ok(());
-        }
-
-        let buf = std::mem::take(&mut self.next_buf);
-        let is_final = if self.chunks.len() == self.expected_chunk_count - 1 {
-            self.is_closed = true;
+    /// Write the chunk headers for the next chunk. The body size of every
+    /// chunk is known up front, so the headers can be written before the
+    /// body streams in.
+    fn start_chunk(&mut self) -> EncodingResult<()> {
+        let is_last = self.chunks_emitted == self.expected_chunk_count - 1;
+        self.current_body_target = if self.max_body_per_chunk == 0 {
+            self.message_size
+        } else if is_last {
+            self.message_size - self.chunks_emitted * self.max_body_per_chunk
+        } else {
+            self.max_body_per_chunk
+        };
+        let is_final = if is_last {
             MessageIsFinalType::Final
         } else {
             MessageIsFinalType::Intermediate
         };
 
-        let chunk = MessageChunk::new(
-            self.sequence_number.current(),
-            self.request_id,
-            self.message_type,
+        let chunk_header = super::message_chunk::MessageChunkHeader {
+            message_type: self.message_type,
             is_final,
-            self.secure_channel,
-            &buf,
-        )?;
+            message_size: (self.header_size + self.current_body_target) as u32,
+            secure_channel_id: self.secure_channel.secure_channel_id(),
+        };
+        let security_header = self.secure_channel.make_security_header(self.message_type);
+        let sequence_header = SequenceHeader {
+            sequence_number: self.sequence_number.current(),
+            request_id: self.request_id,
+        };
         self.sequence_number.increment(1);
-        self.chunks.push(chunk);
 
-        if !self.is_closed {
-            let next_buf_size = if self.chunks.len() == self.expected_chunk_count - 1 {
-                self.message_size % self.max_body_per_chunk
-            } else {
-                self.max_body_per_chunk
-            };
-            self.next_buf = vec![0; next_buf_size];
-            self.buf_position = 0;
-        }
+        let mut writer = bytes::BufMut::writer(&mut *self.storage);
+        SimpleBinaryEncodable::encode(&chunk_header, &mut writer)?;
+        SimpleBinaryEncodable::encode(&security_header, &mut writer)?;
+        SimpleBinaryEncodable::encode(&sequence_header, &mut writer)?;
 
+        self.body_written = 0;
+        self.chunk_started = true;
         Ok(())
     }
 
-    fn finish(self) -> EncodingResult<Vec<MessageChunk>> {
+    fn emit_chunk(&mut self) {
+        let chunk_len = self.header_size + self.current_body_target;
+        let data = self.storage.split_to(chunk_len).freeze();
+        self.out.push(MessageChunk { data });
+        self.chunks_emitted += 1;
+        self.chunk_started = false;
+        if self.chunks_emitted == self.expected_chunk_count {
+            self.is_closed = true;
+        }
+    }
+
+    fn finish(self) -> EncodingResult<usize> {
         if !self.is_closed {
             return Err(Error::encoding(
                 "Message did not encode to the expected size",
             ));
         }
-        Ok(self.chunks)
+        Ok(self.chunks_emitted)
     }
 }
 
-impl Write for ChunkingStream<'_> {
+impl Write for ChunkingStream<'_, '_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.is_closed {
             return Ok(0);
         }
+        if !self.chunk_started {
+            self.start_chunk()?;
+        }
 
-        let to_read = buf.len().min(self.next_buf.len() - self.buf_position);
-        self.next_buf[self.buf_position..(self.buf_position + to_read)]
-            .copy_from_slice(&buf[..to_read]);
-        self.buf_position += to_read;
-        if self.buf_position == self.next_buf.len() {
-            self.flush_chunk()?;
+        let to_read = buf.len().min(self.current_body_target - self.body_written);
+        self.storage.extend_from_slice(&buf[..to_read]);
+        self.body_written += to_read;
+        if self.body_written == self.current_body_target {
+            self.emit_chunk();
         }
 
         Ok(to_read)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.flush_chunk()?;
+        if self.is_closed {
+            return Ok(());
+        }
+        if !self.chunk_started {
+            self.start_chunk()?;
+        }
+        // Mirror the old zero-initialized buffer: a message that encodes
+        // shorter than its declared byte_len pads the chunk with zeros.
+        if self.body_written < self.current_body_target {
+            bytes::BufMut::put_bytes(
+                &mut *self.storage,
+                0,
+                self.current_body_target - self.body_written,
+            );
+            self.body_written = self.current_body_target;
+        }
+        self.emit_chunk();
         Ok(())
     }
 }
@@ -321,6 +370,40 @@ impl Chunker {
         secure_channel: &SecureChannel,
         supported_message: &impl Message,
     ) -> std::result::Result<Vec<MessageChunk>, Error> {
+        let mut storage = bytes::BytesMut::new();
+        let mut chunks = Vec::new();
+        Self::encode_into(
+            sequence_number,
+            request_id,
+            max_message_size,
+            max_chunk_size,
+            secure_channel,
+            supported_message,
+            &mut storage,
+            &mut chunks,
+        )?;
+        Ok(chunks)
+    }
+
+    /// Encodes a message like [`Chunker::encode`], but writes the chunk data
+    /// into the reusable `storage` buffer and appends the resulting chunks to
+    /// `out`, returning how many chunks were produced.
+    ///
+    /// Each produced [`MessageChunk`] holds a zero-copy slice of `storage`;
+    /// once those chunks are dropped the storage allocation is reclaimed by
+    /// the next call, so a connection that reuses both buffers does not
+    /// allocate on the transmit path at steady state.
+    #[allow(clippy::too_many_arguments)]
+    pub fn encode_into(
+        sequence_number: SequenceNumberHandle,
+        request_id: u32,
+        max_message_size: usize,
+        max_chunk_size: usize,
+        secure_channel: &SecureChannel,
+        supported_message: &impl Message,
+        storage: &mut bytes::BytesMut,
+        out: &mut Vec<MessageChunk>,
+    ) -> std::result::Result<usize, Error> {
         let security_policy = secure_channel.security_policy();
         if security_policy == SecurityPolicy::Unknown {
             panic!("Security policy cannot be unknown");
@@ -367,6 +450,8 @@ impl Chunker {
             request_id,
             handle,
             sequence_number,
+            storage,
+            out,
         )?;
 
         node_id.encode(&mut stream, &ctx)?;

--- a/async-opcua-core/src/comms/message_chunk.rs
+++ b/async-opcua-core/src/comms/message_chunk.rs
@@ -139,10 +139,10 @@ impl MessageChunkHeader {}
 /// A chunk holds a message or a portion of a message, if the message has been split into multiple chunks.
 /// The chunk's data may be signed and encrypted. To extract the message requires all the chunks
 /// to be available in sequence so they can be formed back into the message.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MessageChunk {
     /// All of the chunk's data including headers, payload, padding, signature
-    pub data: Vec<u8>,
+    pub data: bytes::Bytes,
 }
 
 impl SimpleBinaryEncodable for MessageChunk {
@@ -194,7 +194,9 @@ impl SimpleBinaryDecodable for MessageChunk {
             // Read remainder of stream into slice after the header
             in_stream.read_exact(&mut data[chunk_header_size..])?;
 
-            Ok(MessageChunk { data })
+            Ok(MessageChunk {
+                data: bytes::Bytes::from(data),
+            })
         }
     }
 }
@@ -251,7 +253,9 @@ impl MessageChunk {
         // write message
         stream.write_all(data)?;
 
-        Ok(MessageChunk { data: buf })
+        Ok(MessageChunk {
+            data: bytes::Bytes::from(buf),
+        })
     }
 
     /// Calculates the body size that fit inside of a message chunk of a particular size.

--- a/async-opcua-core/src/comms/secure_channel.rs
+++ b/async-opcua-core/src/comms/secure_channel.rs
@@ -728,7 +728,7 @@ impl SecureChannel {
 
     fn decrypt_open_secure_channel(
         &self,
-        src: Vec<u8>,
+        src: bytes::Bytes,
         security_header: SecurityHeader,
         encrypted_range: Range<usize>,
     ) -> Result<(MessageChunk, SecurityPolicy), Error> {
@@ -809,12 +809,12 @@ impl SecureChannel {
 
         let msg = Self::update_message_size_and_truncate(decrypted_data, decrypted_size)?;
 
-        Ok((MessageChunk { data: msg }, security_policy))
+        Ok((MessageChunk { data: msg.into() }, security_policy))
     }
 
     fn decrypt_chunk(
         &self,
-        src: Vec<u8>,
+        src: bytes::Bytes,
         security_header: SecurityHeader,
         signed_range: Range<usize>,
         encrypted_range: Range<usize>,
@@ -844,7 +844,7 @@ impl SecureChannel {
 
         // Value returned from symmetric_decrypt_and_verify is the end of the actual decrypted data.
         Ok(MessageChunk {
-            data: Self::update_message_size_and_truncate(decrypted_data, decrypted_size)?,
+            data: Self::update_message_size_and_truncate(decrypted_data, decrypted_size)?.into(),
         })
     }
 
@@ -857,7 +857,7 @@ impl SecureChannel {
     }
 
     /// Decrypts and verifies the body data if the mode / policy requires it
-    pub fn verify_and_remove_security(&self, src: Vec<u8>) -> Result<MessageChunk, Error> {
+    pub fn verify_and_remove_security(&self, src: bytes::Bytes) -> Result<MessageChunk, Error> {
         // Get message & security header from data
         let (message_header, security_header, encrypted_data_offset) =
             self.decode_message_header(&src)?;
@@ -889,7 +889,7 @@ impl SecureChannel {
     /// if the message is an OpenSecureChannel request.
     pub fn verify_and_remove_security_server(
         &mut self,
-        src: Vec<u8>,
+        src: bytes::Bytes,
     ) -> Result<MessageChunk, Error> {
         // Get message & security header from data
         let (message_header, security_header, encrypted_data_offset) =

--- a/async-opcua-core/src/tests/chunk.rs
+++ b/async-opcua-core/src/tests/chunk.rs
@@ -64,11 +64,13 @@ fn set_chunk_sequence_number(
     let old_sequence_number = chunk_info.sequence_header.sequence_number;
     chunk_info.sequence_header.sequence_number = sequence_number;
     // Write the sequence header out again with new value
-    let mut stream = Cursor::new(&mut chunk.data[..]);
+    let mut data = chunk.data.to_vec();
+    let mut stream = Cursor::new(&mut data[..]);
     stream.set_position(chunk_info.sequence_header_offset as u64);
     let ctx_r = ContextOwned::default();
     let ctx = ctx_r.context();
     let _ = chunk_info.sequence_header.encode(&mut stream, &ctx);
+    chunk.data = bytes::Bytes::from(data);
     old_sequence_number
 }
 
@@ -82,11 +84,13 @@ fn set_chunk_request_id(
     let old_request_id = chunk_info.sequence_header.request_id;
     chunk_info.sequence_header.request_id = request_id;
     // Write the sequence header out again with new value
-    let mut stream = Cursor::new(&mut chunk.data[..]);
+    let mut data = chunk.data.to_vec();
+    let mut stream = Cursor::new(&mut data[..]);
     stream.set_position(chunk_info.sequence_header_offset as u64);
     let ctx_r = ContextOwned::default();
     let ctx = ctx_r.context();
     let _ = chunk_info.sequence_header.encode(&mut stream, &ctx);
+    chunk.data = bytes::Bytes::from(data);
     old_request_id
 }
 
@@ -585,7 +589,7 @@ fn asymmetric_decrypt_and_verify_sample_chunk() {
     secure_channel.set_private_key(Some(our_key));
 
     let _ = secure_channel
-        .verify_and_remove_security(message_data)
+        .verify_and_remove_security(message_data.into())
         .unwrap();
 }
 

--- a/async-opcua-core/src/tests/secure_channel.rs
+++ b/async-opcua-core/src/tests/secure_channel.rs
@@ -40,7 +40,7 @@ fn test_symmetric_encrypt_decrypt(
         // Decrypted message should identical to original with same length and
         // no signature or padding
         let chunk2 = secure_channel2
-            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec())
+            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec().into())
             .unwrap();
 
         assert_eq!(&chunk.data, &chunk2.data);
@@ -109,7 +109,7 @@ fn test_asymmetric_encrypt_decrypt(
 
         // Compare up to original length
         let chunk2 = secure_channel
-            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec())
+            .verify_and_remove_security(encrypted_data[..encrypted_size].to_vec().into())
             .unwrap();
         assert_eq!(chunk.data.len(), chunk2.data.len());
         assert_eq!(&chunk.data, &chunk2.data);


### PR DESCRIPTION
## Summary

Two related changes that together eliminate per-message heap allocations from the OPC UA transmit path.

### 1. `MessageChunk::data: Vec<u8>` → `bytes::Bytes`

`bytes::Bytes` is reference-counted, cheaply cloneable, and slice-shareable. Changes:
- `MessageChunk` gets `Clone` (required by the streaming encoder).
- `SimpleBinaryDecodable` wraps the read buffer in `Bytes::from`.
- `verify_and_remove_security` / `verify_and_remove_security_server` accept `Bytes` directly — zero-copy at the receive boundary. Decrypt paths that need mutation still do a single `to_vec()` inside.
- Construction sites in `secure_channel.rs` / `client/transport/core.rs` use `.into()`.

### 2. Streaming `ChunkingStream` encoder in `SendBuffer`

`Chunker::encode` previously allocated a `Vec<u8>` body per chunk, then `MessageChunk::new` copied it into another per-chunk `Vec`. The new path:

- `ChunkingStream` writes full chunks (header + body) directly into a caller-provided `BytesMut` buffer owned by `SendBuffer`.
- Each chunk is emitted as a zero-copy `Bytes` slice into the output `Vec<MessageChunk>`.
- `SendBuffer::reserve()` resets the `BytesMut` position so the storage is reused for the next message — **steady-state transmit encoding allocates nothing**.
- Chunk body sizes are computed up front, so the header is written before the body streams in, producing byte-identical output to the old path (verified by existing crypto tests).
- `Chunker::encode` is kept as a compatibility shim over `encode_into`.
- Adds a regression test asserting `BytesMut` capacity is stable (not reallocated) across messages.

## Testing

`cargo check` clean on core, server, and client crates. Existing chunker / secure-channel / crypto tests cover correctness; the new `send_buffer_storage_reuse` test covers the allocation-free invariant.