### PR TITLE
feat(client): SessionDropGuard for RAII session lifecycle (#143)

### DIFF
--- a/async-opcua-client/src/lib.rs
+++ b/async-opcua-client/src/lib.rs
@@ -127,8 +127,8 @@ pub use session::{
     Client, ConnectionSource, DataChangeCallback, DefaultRetryPolicy, DirectConnectionSource,
     EventCallback, HistoryReadAction, HistoryUpdateAction, MonitoredItem, MonitoredItemMap,
     OnSubscriptionNotification, OnSubscriptionNotificationCore, RequestRetryPolicy, Session,
-    SessionActivity, SessionBuilder, SessionConnectMode, SessionEventLoop, SessionPollResult,
-    Subscription, SubscriptionActivity, SubscriptionCallbacks, UARequest,
+    SessionActivity, SessionBuilder, SessionConnectMode, SessionDropGuard, SessionEventLoop,
+    SessionPollResult, Subscription, SubscriptionActivity, SubscriptionCallbacks, UARequest,
 };
 pub use transport::AsyncSecureChannel;
 

--- a/async-opcua-client/src/session/event_loop.rs
+++ b/async-opcua-client/src/session/event_loop.rs
@@ -68,6 +68,7 @@ enum SessionEventLoopState<T: Transport + Send + Sync + 'static> {
 pub struct SessionEventLoop<T: Connector + Send + Sync + 'static> {
     inner: Arc<Session>,
     trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
+    close_rx: tokio::sync::watch::Receiver<bool>,
     retry: SessionRetryPolicy,
     keep_alive_interval: Duration,
     max_failed_keep_alive_count: u64,
@@ -79,6 +80,7 @@ impl<T: Connector + Send + Sync + 'static> SessionEventLoop<T> {
         inner: Arc<Session>,
         retry: SessionRetryPolicy,
         trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
+        close_rx: tokio::sync::watch::Receiver<bool>,
         keep_alive_interval: Duration,
         max_failed_keep_alive_count: u64,
         connector: T,
@@ -87,6 +89,7 @@ impl<T: Connector + Send + Sync + 'static> SessionEventLoop<T> {
             inner,
             retry,
             trigger_publish_recv,
+            close_rx,
             keep_alive_interval,
             max_failed_keep_alive_count,
             connector,
@@ -134,7 +137,12 @@ impl<T: Connector + Send + Sync + 'static> SessionEventLoop<T> {
     pub fn enter(self) -> impl Stream<Item = Result<SessionPollResult, StatusCode>> {
         futures::stream::try_unfold(
             (self, SessionEventLoopState::Disconnected),
-            |(slf, state)| async move {
+            |(mut slf, state)| async move {
+                // If SessionDropGuard was dropped, stop the loop immediately.
+                if *slf.close_rx.borrow_and_update() {
+                    return Ok(None);
+                }
+
                 let (res, state) = match state {
                     SessionEventLoopState::Connected(mut state) => {
                         tokio::select! {
@@ -219,6 +227,19 @@ impl<T: Connector + Send + Sync + 'static> SessionEventLoop<T> {
                                 Ok((
                                     SessionPollResult::FinishedDisconnect,
                                     SessionEventLoopState::Connected(state)
+                                ))
+                            }
+                            _ = slf.close_rx.changed(), if !state.currently_closing => {
+                                if *slf.close_rx.borrow_and_update() {
+                                    state.currently_closing = true;
+                                    let s = slf.inner.clone();
+                                    state.disconnect_fut = async move {
+                                        s.disconnect_inner(true, false).await
+                                    }.boxed();
+                                }
+                                Ok((
+                                    SessionPollResult::FinishedDisconnect,
+                                    SessionEventLoopState::Connected(state),
                                 ))
                             }
                         }

--- a/async-opcua-client/src/session/mod.rs
+++ b/async-opcua-client/src/session/mod.rs
@@ -204,6 +204,7 @@ pub struct Session {
     pub(super) trigger_publish_tx: tokio::sync::watch::Sender<Instant>,
     pub(super) session_nonce_length: usize,
     decoding_options: DecodingOptions,
+    pub(crate) close_tx: tokio::sync::watch::Sender<bool>,
 }
 
 impl Session {
@@ -223,6 +224,7 @@ impl Session {
         let (state_watch_tx, state_watch_rx) =
             tokio::sync::watch::channel(SessionState::Disconnected);
         let (trigger_publish_tx, trigger_publish_rx) = tokio::sync::watch::channel(Instant::now());
+        let (close_tx, close_rx) = tokio::sync::watch::channel(false);
 
         let session = Arc::new(Session {
             channel,
@@ -248,6 +250,7 @@ impl Session {
             trigger_publish_tx,
             session_nonce_length: config.session_nonce_length,
             decoding_options,
+            close_tx,
         });
 
         (
@@ -256,6 +259,7 @@ impl Session {
                 session,
                 session_retry_policy,
                 trigger_publish_rx,
+                close_rx,
                 config.keep_alive_interval,
                 config.max_failed_keep_alive_count,
                 connector,
@@ -310,6 +314,14 @@ impl Session {
     /// You should also monitor the session event loop. If it ends, this method will never return.
     pub async fn wait_for_connection(&self) -> bool {
         self.wait_for_state(true).await
+    }
+
+    /// Returns a [`SessionDropGuard`] that will initiate a graceful disconnect
+    /// when dropped. Useful for RAII-style session lifetimes.
+    pub fn close_on_drop(self: &Arc<Self>) -> SessionDropGuard {
+        SessionDropGuard {
+            session: self.clone(),
+        }
     }
 
     /// Disable automatic reconnects.
@@ -474,5 +486,34 @@ impl Session {
             )
         })?;
         Ok(idx)
+    }
+}
+
+/// RAII guard that initiates a graceful disconnect when dropped.
+///
+/// Obtained via [`Session::close_on_drop`]. Implements [`std::ops::Deref`] to `Session`
+/// so all session methods are accessible directly.
+#[must_use = "SessionDropGuard disconnects on drop; assign it to a variable to control lifetime"]
+pub struct SessionDropGuard {
+    session: Arc<Session>,
+}
+
+impl SessionDropGuard {
+    /// Returns a clone of the underlying `Arc<Session>`.
+    pub fn arc(&self) -> Arc<Session> {
+        self.session.clone()
+    }
+}
+
+impl std::ops::Deref for SessionDropGuard {
+    type Target = Session;
+    fn deref(&self) -> &Session {
+        &self.session
+    }
+}
+
+impl Drop for SessionDropGuard {
+    fn drop(&mut self) {
+        let _ = self.session.close_tx.send(true);
     }
 }


### PR DESCRIPTION
## Summary

Closes #143.

Adds a `SessionDropGuard` that initiates a graceful server-side disconnect when dropped, enabling RAII-style session management without requiring an explicit `disconnect()` call.

### Design

- A `tokio::sync::watch` channel (sender in `Session`, receiver in `SessionEventLoop`) carries the close signal.
- `Session::close_on_drop()` returns a `SessionDropGuard` wrapping `Arc<Session>`.
- `Drop for SessionDropGuard` sends `true` on the watch channel.
- The event loop checks the channel at the top of every poll iteration (`borrow_and_update`) to handle the Disconnected/Connecting states, and adds a `close_rx.changed()` arm to the Connected-state `tokio::select!` for prompt response mid-connection.
- When the signal fires in the Connected state, `disconnect_inner(delete_subscriptions: true, …)` is queued just like a keep-alive failure.

### Usage

```rust
let (session, event_loop) = client.connect_to_matching_endpoint(endpoint, token).await?;
let _guard = session.close_on_drop(); // drop to disconnect
let handle = event_loop.spawn();
session.wait_for_connection().await;
// … use session …
drop(_guard); // sends CloseSession to server, event loop exits cleanly
handle.await;
```

### Notes

- `SessionDropGuard` is `#[must_use]` to prevent accidental immediate drop.
- `arc()` method gives access to the underlying `Arc<Session>` for sharing across tasks.
- The existing `disconnect()` / `disconnect_without_delete_subscriptions()` methods continue to work and are unaffected.

## Test plan

- [ ] Existing client test suite passes (`cargo test -p async-opcua-client`)
- [ ] Manual test: drop guard before event loop exits, verify server-side session is cleaned up
- [ ] `cargo clippy --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)