### PR TITLE
fix(types): return errors instead of panicking on subtyped-values struct kinds

### DIFF
--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -285,12 +285,10 @@ impl BinaryEncodable for DynamicStructure {
                     size += self.field_variant_len(value, field, ctx);
                 }
             }
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
-            }
+            // Unsupported; encode returns an error for these before any
+            // bytes are written, so the length is never used.
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => return 0,
         }
 
         size
@@ -342,11 +340,11 @@ impl BinaryEncodable for DynamicStructure {
                     self.encode_field(stream, value, field, ctx)?;
                 }
             }
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => {
+                return Err(Error::encoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ));
             }
         }
 
@@ -592,12 +590,10 @@ impl DynamicTypeLoader {
                     data: values,
                 }))
             }
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
-            }
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
+                "Structures and unions with subtyped values are unsupported",
+            )),
         }
     }
 }

--- a/async-opcua-types/src/custom/custom_struct.rs
+++ b/async-opcua-types/src/custom/custom_struct.rs
@@ -287,8 +287,9 @@ impl BinaryEncodable for DynamicStructure {
             }
             // Unsupported; encode returns an error for these before any
             // bytes are written, so the length is never used.
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => return 0,
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
+                return 0
+            }
         }
 
         size
@@ -340,8 +341,7 @@ impl BinaryEncodable for DynamicStructure {
                     self.encode_field(stream, value, field, ctx)?;
                 }
             }
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => {
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
                 return Err(Error::encoding(
                     "Structures and unions with subtyped values are unsupported",
                 ));
@@ -590,10 +590,11 @@ impl DynamicTypeLoader {
                     data: values,
                 }))
             }
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
-                "Structures and unions with subtyped values are unsupported",
-            )),
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
+                Err(Error::decoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ))
+            }
         }
     }
 }

--- a/async-opcua-types/src/custom/json.rs
+++ b/async-opcua-types/src/custom/json.rs
@@ -373,12 +373,10 @@ impl DynamicTypeLoader {
                 }))
             }
 
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
-            }
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
+                "Structures and unions with subtyped values are unsupported",
+            )),
         }
     }
 }
@@ -437,11 +435,11 @@ impl JsonEncodable for DynamicStructure {
                 }
             }
 
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => {
+                return Err(Error::encoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ));
             }
         }
         stream.end_object()?;

--- a/async-opcua-types/src/custom/json.rs
+++ b/async-opcua-types/src/custom/json.rs
@@ -373,10 +373,11 @@ impl DynamicTypeLoader {
                 }))
             }
 
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
-                "Structures and unions with subtyped values are unsupported",
-            )),
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
+                Err(Error::decoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ))
+            }
         }
     }
 }
@@ -435,8 +436,7 @@ impl JsonEncodable for DynamicStructure {
                 }
             }
 
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => {
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
                 return Err(Error::encoding(
                     "Structures and unions with subtyped values are unsupported",
                 ));

--- a/async-opcua-types/src/custom/mod.rs
+++ b/async-opcua-types/src/custom/mod.rs
@@ -10,6 +10,6 @@ mod xml;
 
 pub use custom_struct::{DynamicStructure, DynamicTypeLoader};
 pub use type_tree::{
-    DataTypeTree, DataTypeVariant, EncodingIds, EnumTypeInfo, ParentIds, ParsedStructureField,
-    StructTypeInfo, TypeInfo, TypeInfoRef,
+    DataTypeTree, DataTypeVariant, EncodingIds, EnumTypeInfo, GenericTypeInfo, ParentIds,
+    ParsedStructureField, StructTypeInfo, TypeInfo, TypeInfoRef,
 };

--- a/async-opcua-types/src/custom/type_tree.rs
+++ b/async-opcua-types/src/custom/type_tree.rs
@@ -139,11 +139,14 @@ pub struct EncodingIds {
 }
 
 #[derive(Debug)]
+/// Description of a generic or primitive data type.
 pub struct GenericTypeInfo {
+    /// True if the type is abstract.
     pub is_abstract: bool,
 }
 
 impl GenericTypeInfo {
+    /// Creates a new `GenericTypeInfo`.
     pub fn new(is_abstract: bool) -> Self {
         Self { is_abstract }
     }

--- a/async-opcua-types/src/custom/xml.rs
+++ b/async-opcua-types/src/custom/xml.rs
@@ -384,12 +384,10 @@ impl DynamicTypeLoader {
                     data: vec![value],
                 }))
             }
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
-            }
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
+                "Structures and unions with subtyped values are unsupported",
+            )),
         }
     }
 }
@@ -437,11 +435,11 @@ impl XmlEncodable for DynamicStructure {
                 };
                 self.xml_encode_field(stream, value, field, ctx)?;
             }
-            StructureType::StructureWithSubtypedValues => {
-                todo!("StructureWithSubtypedValues is unsupported")
-            }
-            StructureType::UnionWithSubtypedValues => {
-                todo!("UnionWithSubtypedValues is unsupported")
+            StructureType::StructureWithSubtypedValues
+            | StructureType::UnionWithSubtypedValues => {
+                return Err(Error::encoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ));
             }
         }
 

--- a/async-opcua-types/src/custom/xml.rs
+++ b/async-opcua-types/src/custom/xml.rs
@@ -384,10 +384,11 @@ impl DynamicTypeLoader {
                     data: vec![value],
                 }))
             }
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => Err(Error::decoding(
-                "Structures and unions with subtyped values are unsupported",
-            )),
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
+                Err(Error::decoding(
+                    "Structures and unions with subtyped values are unsupported",
+                ))
+            }
         }
     }
 }
@@ -435,8 +436,7 @@ impl XmlEncodable for DynamicStructure {
                 };
                 self.xml_encode_field(stream, value, field, ctx)?;
             }
-            StructureType::StructureWithSubtypedValues
-            | StructureType::UnionWithSubtypedValues => {
+            StructureType::StructureWithSubtypedValues | StructureType::UnionWithSubtypedValues => {
                 return Err(Error::encoding(
                     "Structures and unions with subtyped values are unsupported",
                 ));

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -32,3 +32,10 @@ path = "fuzz_targets/fuzz_deserialize.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_dynamic_struct"
+path = "fuzz_targets/fuzz_dynamic_struct.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_dynamic_struct.rs
+++ b/fuzz/fuzz_targets/fuzz_dynamic_struct.rs
@@ -8,7 +8,9 @@ fn main() {
 #[cfg(feature = "nightly")]
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     use opcua::types::{
-        custom::{DataTypeTree, DynamicTypeLoader, EncodingIds, GenericTypeInfo, ParentIds, TypeInfo},
+        custom::{
+            DataTypeTree, DynamicTypeLoader, EncodingIds, GenericTypeInfo, ParentIds, TypeInfo,
+        },
         BinaryDecodable, ContextOwned, DataTypeDefinition, DataTypeId, DecodingOptions, Error,
         ExtensionObject, NamespaceMap, NodeId, ObjectId, StructureDefinition, StructureField,
         TypeLoaderCollection,

--- a/fuzz/fuzz_targets/fuzz_dynamic_struct.rs
+++ b/fuzz/fuzz_targets/fuzz_dynamic_struct.rs
@@ -1,0 +1,93 @@
+#![cfg_attr(feature = "nightly", no_main)]
+
+#[cfg(not(feature = "nightly"))]
+fn main() {
+    panic!("Fuzzing requires the nightly feature to be enabled.");
+}
+
+#[cfg(feature = "nightly")]
+libfuzzer_sys::fuzz_target!(|data: &[u8]| {
+    use opcua::types::{
+        custom::{DataTypeTree, DynamicTypeLoader, EncodingIds, GenericTypeInfo, ParentIds, TypeInfo},
+        BinaryDecodable, ContextOwned, DataTypeDefinition, DataTypeId, DecodingOptions, Error,
+        ExtensionObject, NamespaceMap, NodeId, ObjectId, StructureDefinition, StructureField,
+        TypeLoaderCollection,
+    };
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    fn make_context() -> ContextOwned {
+        let mut type_tree = DataTypeTree::new(ParentIds::new());
+        type_tree.add_type(DataTypeId::Int32.into(), GenericTypeInfo::new(false));
+        type_tree.add_type(DataTypeId::String.into(), GenericTypeInfo::new(false));
+        type_tree.add_type(
+            DataTypeId::LocalizedText.into(),
+            GenericTypeInfo::new(false),
+        );
+        type_tree.parent_ids_mut().add_type(
+            DataTypeId::EUInformation.into(),
+            DataTypeId::Structure.into(),
+        );
+        type_tree.add_type(
+            DataTypeId::EUInformation.into(),
+            TypeInfo::from_type_definition(
+                DataTypeDefinition::Structure(StructureDefinition {
+                    default_encoding_id: NodeId::null(),
+                    base_data_type: DataTypeId::Structure.into(),
+                    structure_type: opcua::types::StructureType::Structure,
+                    fields: Some(vec![
+                        StructureField {
+                            name: "NamespaceUri".into(),
+                            data_type: DataTypeId::String.into(),
+                            value_rank: -1,
+                            ..Default::default()
+                        },
+                        StructureField {
+                            name: "UnitId".into(),
+                            data_type: DataTypeId::Int32.into(),
+                            value_rank: -1,
+                            ..Default::default()
+                        },
+                        StructureField {
+                            name: "DisplayName".into(),
+                            data_type: DataTypeId::LocalizedText.into(),
+                            value_rank: -1,
+                            ..Default::default()
+                        },
+                        StructureField {
+                            name: "Description".into(),
+                            data_type: DataTypeId::LocalizedText.into(),
+                            value_rank: -1,
+                            ..Default::default()
+                        },
+                    ]),
+                }),
+                "EUInformation".to_owned(),
+                Some(EncodingIds {
+                    binary_id: ObjectId::EUInformation_Encoding_DefaultBinary.into(),
+                    json_id: ObjectId::EUInformation_Encoding_DefaultJson.into(),
+                    xml_id: ObjectId::EUInformation_Encoding_DefaultXml.into(),
+                }),
+                false,
+                &DataTypeId::EUInformation.into(),
+                type_tree.parent_ids(),
+            )
+            .unwrap(),
+        );
+
+        let loader = DynamicTypeLoader::new(Arc::new(type_tree));
+        let mut loaders = TypeLoaderCollection::new_empty();
+        loaders.add_type_loader(loader);
+        ContextOwned::new(NamespaceMap::new(), loaders, DecodingOptions::default())
+    }
+
+    fn deserialize(data: &[u8], ctx: &ContextOwned) -> Result<ExtensionObject, Error> {
+        // Decoding arbitrary bytes through the dynamic type loader must
+        // return a value or an error, never panic.
+        let mut stream = Cursor::new(data);
+        ExtensionObject::decode(&mut stream, &ctx.context())
+    }
+
+    let ctx = make_context();
+    let _ = deserialize(data, &ctx);
+});


### PR DESCRIPTION
This PR is a standalone backport from our fork that prevents panics when decoding subtyped-values struct kinds. 

It fixes the types implementation to return a proper `opcua_types::Error` rather than panicking. It includes a fuzzing target that was used to catch and verify this boundary condition.