### PR TITLE
fix: make the workspace warning-free under CI

### DIFF
--- a/async-opcua-core/src/config.rs
+++ b/async-opcua-core/src/config.rs
@@ -62,7 +62,7 @@ pub trait Config: serde::Serialize {
         f.read_to_string(&mut s)?;
         let mut value: serde_yaml::Value = serde_yaml::from_str(&s)?;
         expand_env_in_value(&mut value);
-        return Ok(serde_yaml::from_value(value)?);
+        Ok(serde_yaml::from_value(value)?)
     }
 
     /// Load the configuration object from the given path.

--- a/async-opcua-core/src/tests/chunk.rs
+++ b/async-opcua-core/src/tests/chunk.rs
@@ -224,7 +224,7 @@ fn validate_chunk_sequence_numbers(
     sequence_numbers: &mut SequenceNumberHandle,
 ) -> Result<(), StatusCode> {
     for chunk in chunks {
-        let chunk_info = chunk.chunk_info(&secure_channel)?;
+        let chunk_info = chunk.chunk_info(secure_channel)?;
         sequence_numbers.validate_and_increment(chunk_info.sequence_header.sequence_number)?;
     }
     Ok(())
@@ -255,7 +255,7 @@ fn validate_chunks_secure_channel_id() {
     validate_chunk_sequence_numbers(&secure_channel, &chunks, &mut sequence_number.clone())
         .unwrap();
     // Expect this to work
-    let _ = Chunker::validate_chunks(&secure_channel, &chunks).unwrap();
+    Chunker::validate_chunks(&secure_channel, &chunks).unwrap();
 
     // Test secure channel id mismatch
     let old_secure_channel_id = secure_channel.secure_channel_id();
@@ -350,7 +350,7 @@ fn validate_chunks_request_id() {
     assert!(chunks.len() > 1);
 
     // Expect this to work
-    let _ = Chunker::validate_chunks(&secure_channel, &chunks).unwrap();
+    Chunker::validate_chunks(&secure_channel, &chunks).unwrap();
 
     // Hack the request id so first chunk request id says 101 while the rest say 100
     let _ = set_chunk_request_id(&mut chunks[0], &secure_channel, 101);
@@ -441,8 +441,8 @@ fn open_secure_channel_response() {
     let chunks = vec![chunk];
 
     let decoded: Result<ResponseMessage, _> = Chunker::decode(&chunks, &secure_channel, None);
-    if decoded.is_err() {
-        panic!("Got error {:?}", decoded.unwrap_err());
+    if let Err(e) = decoded {
+        panic!("Got error {:?}", e);
     }
     let message = Chunker::decode(&chunks, &secure_channel, None).unwrap();
     //debug!("message = {:#?}", message);

--- a/async-opcua-core/src/tests/env_expansion.rs
+++ b/async-opcua-core/src/tests/env_expansion.rs
@@ -163,10 +163,10 @@ mod tests {
         fixture.write_yaml("value: $BOOLEAN_ENV_VAR");
         fixture.set_var("BOOLEAN_ENV_VAR", "true");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, true);
+        assert!(config.value);
         fixture.set_var("BOOLEAN_ENV_VAR", "false");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, false);
+        assert!(!config.value);
     }
 
     // Only lowercase "true" and "false" are parsed as booleans
@@ -177,16 +177,16 @@ mod tests {
         fixture.write_yaml("value: $BOOLEAN_ENV_VAR_2");
         fixture.set_var("BOOLEAN_ENV_VAR_2", "True");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, true);
+        assert!(config.value);
         fixture.set_var("BOOLEAN_ENV_VAR_2", "TRUE");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, true);
+        assert!(config.value);
         fixture.set_var("BOOLEAN_ENV_VAR_2", "False");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, false);
+        assert!(!config.value);
         fixture.set_var("BOOLEAN_ENV_VAR_2", "FALSE");
         let config: DummyConfig<bool> = DummyConfig::<bool>::load(fixture.path()).unwrap();
-        assert_eq!(config.value, false);
+        assert!(!config.value);
     }
 
     #[test]

--- a/async-opcua-nodes/src/xml.rs
+++ b/async-opcua-nodes/src/xml.rs
@@ -771,7 +771,7 @@ mod tests {
     /// Struct DataType with:
     ///  - inward HasSubtype  → i=22  (OPC UA "Structure" base type)
     ///  - forward HasEncoding → ns=1;i=11 (a "Default Binary" encoding object)
-    /// Expected: base_data_type = i=22, default_encoding_id = ns=1;i=11
+    ///    Expected: base_data_type = i=22, default_encoding_id = ns=1;i=11
     const TEST_STRUCT_WITH_BASE_AND_BINARY_ENCODING: &str = r#"
 <UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/async-opcua-server/src/subscriptions/subscription.rs
+++ b/async-opcua-server/src/subscriptions/subscription.rs
@@ -1013,7 +1013,7 @@ mod tests {
         assert!(sub.take_notification().is_none());
 
         // Notify the first item
-        sub.notify_data_value(&1, DataValue::new_at(1, time.into()), &time);
+        sub.notify_data_value(&1, DataValue::new_at(1, time), &time);
         let (time, time_inst) = offset(start_dt, start, 200);
         sub.tick(&time, time_inst, TickReason::TickTimerFired, true);
         let notif = sub.take_notification().unwrap();

--- a/async-opcua-types/src/tests/variant.rs
+++ b/async-opcua-types/src/tests/variant.rs
@@ -166,8 +166,7 @@ fn variant_u32_array() {
         Variant::Array(array) => {
             let values = array.values;
             assert_eq!(values.len(), 3);
-            let mut i = 1u32;
-            for v in values {
+            for (i, v) in (1u32..).zip(values) {
                 assert!(v.is_numeric());
                 match v {
                     Variant::UInt32(v) => {
@@ -175,7 +174,6 @@ fn variant_u32_array() {
                     }
                     _ => panic!("Not the expected type"),
                 }
-                i += 1;
             }
         }
         _ => panic!("Not an array"),
@@ -206,8 +204,7 @@ fn variant_i32_array() {
         Variant::Array(array) => {
             let values = array.values;
             assert_eq!(values.len(), 3);
-            let mut i = 1;
-            for v in values {
+            for (i, v) in (1..).zip(values) {
                 assert!(v.is_numeric());
                 match v {
                     Variant::Int32(v) => {
@@ -215,7 +212,6 @@ fn variant_i32_array() {
                     }
                     _ => panic!("Not the expected type"),
                 }
-                i += 1;
             }
         }
         _ => panic!("Not an array"),

--- a/async-opcua/tests/integration/browse.rs
+++ b/async-opcua/tests/integration/browse.rs
@@ -341,7 +341,10 @@ async fn browse_release_continuation_point() {
     assert!(!it.continuation_point.is_null());
 
     let cp = it.continuation_point.clone();
-    let r = session.browse_next(true, std::slice::from_ref(&cp)).await.unwrap();
+    let r = session
+        .browse_next(true, std::slice::from_ref(&cp))
+        .await
+        .unwrap();
     assert_eq!(1, r.len());
     let it = &r[0];
     assert_eq!(StatusCode::Good, it.status_code);

--- a/async-opcua/tests/integration/browse.rs
+++ b/async-opcua/tests/integration/browse.rs
@@ -341,7 +341,7 @@ async fn browse_release_continuation_point() {
     assert!(!it.continuation_point.is_null());
 
     let cp = it.continuation_point.clone();
-    let r = session.browse_next(true, &[cp.clone()]).await.unwrap();
+    let r = session.browse_next(true, std::slice::from_ref(&cp)).await.unwrap();
     assert_eq!(1, r.len());
     let it = &r[0];
     assert_eq!(StatusCode::Good, it.status_code);

--- a/async-opcua/tests/integration/subscriptions.rs
+++ b/async-opcua/tests/integration/subscriptions.rs
@@ -1065,13 +1065,13 @@ async fn test_event_subscriptions() {
         ProgressEventType::event_type_id(),
         random::byte_string(6),
         "Hello",
-        &tester.handle.type_tree().read().namespaces(),
+        tester.handle.type_tree().read().namespaces(),
     );
     let miss_evt_2 = AuditSecurityEventType::new_event_now(
         AuditSecurityEventType::event_type_id(),
         random::byte_string(6),
         "Hello 2",
-        &tester.handle.type_tree().read().namespaces(),
+        tester.handle.type_tree().read().namespaces(),
     );
     let mut hit_evt = AuditHistoryBulkInsertEventType::new_event_now(
         AuditHistoryBulkInsertEventType::event_type_id(),

--- a/async-opcua/tests/utils/node_manager.rs
+++ b/async-opcua/tests/utils/node_manager.rs
@@ -894,7 +894,7 @@ impl TestNodeManagerImpl {
                 results[idx] = StatusCode::BadInvalidTimestamp;
             }
         }
-        to_update.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        to_update.sort_by_key(|a| a.timestamp);
 
         let now = DateTime::now();
         let mut index = 0;

--- a/codegen-tests/src/tests/types.rs
+++ b/codegen-tests/src/tests/types.rs
@@ -32,8 +32,8 @@ fn ctx() -> ContextOwned {
     let mut loaders = TypeLoaderCollection::new();
     loaders.add_type_loader(crate::generated::base::GeneratedTypeLoader);
     loaders.add_type_loader(crate::generated::ext::GeneratedTypeLoader);
-    let ctx_owned = ContextOwned::new(namespaces, loaders, DecodingOptions::default());
-    ctx_owned
+    
+    ContextOwned::new(namespaces, loaders, DecodingOptions::default())
 }
 
 fn all_encoding_roundtrip<
@@ -64,7 +64,7 @@ fn all_encoding_roundtrip<
     let mut stream = JsonStreamWriter::new(&mut cursor as &mut dyn Write);
     JsonEncodable::encode(ty, &mut stream, &ctx).unwrap();
     stream.finish_document().unwrap();
-    println!("JSON: {}", String::from_utf8_lossy(&cursor.get_ref()));
+    println!("JSON: {}", String::from_utf8_lossy(cursor.get_ref()));
     cursor.set_position(0);
     let mut stream = JsonStreamReader::new(&mut cursor as &mut dyn Read);
     let rf: T = JsonDecodable::decode(&mut stream, &ctx).unwrap();
@@ -74,7 +74,7 @@ fn all_encoding_roundtrip<
     let mut cursor = Cursor::new(Vec::new());
     let mut stream = XmlStreamWriter::new(&mut cursor as &mut dyn Write);
     XmlEncodable::encode(ty, &mut stream, &ctx).unwrap();
-    println!("XML: {}", String::from_utf8_lossy(&cursor.get_ref()));
+    println!("XML: {}", String::from_utf8_lossy(cursor.get_ref()));
     cursor.set_position(0);
     let mut stream = XmlStreamReader::new(&mut cursor as &mut dyn Read);
     let rf: T = XmlDecodable::decode(&mut stream, &ctx).unwrap();

--- a/codegen-tests/src/tests/types.rs
+++ b/codegen-tests/src/tests/types.rs
@@ -32,7 +32,7 @@ fn ctx() -> ContextOwned {
     let mut loaders = TypeLoaderCollection::new();
     loaders.add_type_loader(crate::generated::base::GeneratedTypeLoader);
     loaders.add_type_loader(crate::generated::ext::GeneratedTypeLoader);
-    
+
     ContextOwned::new(namespaces, loaders, DecodingOptions::default())
 }
 


### PR DESCRIPTION
CI sets `RUSTFLAGS=-D warnings` which caused newer clippy versions to fail on accumulated warnings. This PR fixes all warnings across the workspace without resorting to `#[allow(...)]` attributes in generated code, ensuring a clean and reliable build.

- Replaced obsolete `for` loop patterns and needless borrows
- Fixed unidiomatic uses of `assert_eq!` with booleans
- Added missing indentations in doc comments
- Scoped redundant matches and returns