### PR TITLE
fix(server): populate ServerArray with the application URI

### DIFF
--- a/async-opcua-server/src/node_manager/memory/core.rs
+++ b/async-opcua-server/src/node_manager/memory/core.rs
@@ -474,6 +474,17 @@ impl CoreNodeManagerImpl {
                 (self.status.state() as i32).into()
             }
 
+            VariableId::Server_ServerArray => {
+                // Per OPC UA Part 5 (OPC 10000-5) 6.3.1, the ServerArray is a Mandatory
+                // String[] whose index 0 "shall be identical to" the server's
+                // ApplicationUri. Serving it from the static node (DataValue::null())
+                // makes spec-conformant clients reject the value with BadTypeMismatch.
+                // `ServerInfo::servers` is seeded with the application URI in
+                // `Server::new_from_builder`, mirroring how `Server_NamespaceArray`
+                // (whose index 1 is the same URI) is served below.
+                context.info.servers.clone().into()
+            }
+
             VariableId::Server_NamespaceArray => {
                 // This actually calls into other node managers to obtain the value, in fact
                 // it calls into _this_ node manager as well.

--- a/async-opcua/tests/integration/read.rs
+++ b/async-opcua/tests/integration/read.rs
@@ -23,21 +23,27 @@ use opcua_client::{services::Read, DefaultRetryPolicy, ExponentialBackoff, UAReq
 async fn read() {
     let (tester, _nm, session) = setup().await;
 
-    // Read the service level
+    // Read the service level, plus the ServerArray, which must contain this
+    // server's application URI at index 0 (OPC UA Part 5, 6.3.1).
     tester.handle.set_service_level(123);
     let r = session
         .read(
-            &[read_value_id(
-                AttributeId::Value,
-                VariableId::Server_ServiceLevel,
-            )],
+            &[
+                read_value_id(AttributeId::Value, VariableId::Server_ServiceLevel),
+                read_value_id(AttributeId::Value, VariableId::Server_ServerArray),
+            ],
             TimestampsToReturn::Both,
             0.0,
         )
         .await
         .unwrap();
-    assert_eq!(1, r.len());
-    assert_eq!(&Variant::Byte(123), r[0].value.as_ref().unwrap())
+    assert_eq!(2, r.len());
+    assert_eq!(&Variant::Byte(123), r[0].value.as_ref().unwrap());
+    assert_eq!(Some(StatusCode::Good), r[1].status);
+    assert_eq!(
+        array_value(&r[1]),
+        &vec![Variant::String("urn:integration_server".into())]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Hi, and thanks for async-opcua; it's been a pleasure to build on!

While exporting a NodeSet2 from a server built on async-opcua, I ran into a small server-side conformance gap where `ServerArray` is a `Null` value instead of the spec'd `String[]` type.

## identified root cause
`CoreNodeManager::read_server_value` has an arm for `Server_NamespaceArray` but none for `Server_ServerArray` (`i=2254`). Reads fall through to `_ => return None` and get served from the node's static value, which `nodeset_49.rs` creates as `DataValue::null()`. So the server reports `ServerArray = null`.

## relevant spec
Per OPC UA Part 5 (OPC 10000-5) §6.3.1 (ServerType):
- `ServerArray` is **Mandatory** and typed **`String[]`**.
- > "The ApplicationUri of an OPC UA Server **shall** be identical to the URI set in index 0 of the ServerArray and index 1 of the NamespaceArray."

A null/empty value trips up spec-conformant clients that read `ServerArray` during session setup. For instance, UA-.NETStandard's `FetchNamespaceTables` rejects the typeless `Variant` with `BadTypeMismatch`, so the session never finishes opening.

## proposed fix
Add the missing arm, returning `context.info.servers`, mirroring the existing `Server_NamespaceArray` handling:
```rust
VariableId::Server_ServerArray => {
    context.info.servers.clone().into()
}
```
Now the three URIs the spec wants to agree actually do: `ApplicationUri == ServerArray[0] == NamespaceArray[1]`.

## Reproducing with a stock sample
`samples/simple-server` plus any spec-conformant client (here the .NET `OpcUaNodesetExporter`, which calls `FetchNamespaceTables`):
```
# Terminal 1
cd samples/simple-server && cargo run     # None/anonymous endpoint at opc.tcp://localhost:4855/

# Terminal 2
opcua-nodeset-export --endpoint opc.tcp://localhost:4855/ --verbose
```

**Before**
```
fail: Cannot read ServerArray node. Validation of returned value failed.
      [80740000] (BadTypeMismatch)
```
(exit 1; session setup aborts before anything else can happen)

**After**
```
Successfully exported 2 namespace(s)  (urn:async-opcua-Sample-Server, urn:SimpleServer)
```
(exit 0). A direct read of `ServerArray` now returns `["urn:async-opcua-Sample-Server"]`.

## Tests
Extended the `read` integration test to also read `Server_ServerArray` and assert index 0 is the application URI. `cargo test --workspace --all-features` is green, and `cargo fmt` / clippy are clean.

I was a bit on the fence about including a test for such a small change, but went ahead after reading `docs/developer.md`, please let me know if this was the correct interpretation. Otherwise we can cherry-pick this out.

Disclosure: This work was assisted by GitHub Copilot (Claude Opus 4.8). I left in the rather verbatim comment it generated, as it seemed helpful to me as user of the library. If it's not useful at all or cringy form a maintainer perspective, I am more than happy to edit this.

Thanks so much for taking a look!