### PR TITLE
fix(types): bound Argument.value_rank against max_array_length

### DIFF
--- a/async-opcua-types/src/argument.rs
+++ b/async-opcua-types/src/argument.rs
@@ -112,6 +112,12 @@ impl BinaryDecodable for Argument {
         if value_rank > 0 {
             if let Some(array_dimensions) = array_dimensions.as_mut() {
                 let expected_rank = value_rank as usize;
+                if expected_rank > ctx.options().max_array_length {
+                    return Err(Error::decoding(format!(
+                        "Argument value_rank {value_rank} exceeds array length limit {}",
+                        ctx.options().max_array_length
+                    )));
+                }
                 match array_dimensions.len().cmp(&expected_rank) {
                     Ordering::Less => {
                         // If fewer dimensions are provided than rank, pad with 0 to reach rank length

--- a/async-opcua-types/src/tests/encoding.rs
+++ b/async-opcua-types/src/tests/encoding.rs
@@ -518,6 +518,62 @@ fn argument_decode_pads_dimensions_when_shorter_than_rank() {
     assert_eq!(decoded.value_rank, 3);
     assert_eq!(decoded.array_dimensions, Some(vec![0, 0, 0]));
 }
+
+fn encode_argument_payload(value_rank: i32, dimensions: Option<Vec<u32>>) -> Vec<u8> {
+    let ctx_f = ContextOwned::default();
+    let ctx = ctx_f.context();
+    let mut stream = Cursor::new(Vec::new());
+    UAString::from("arg").encode(&mut stream, &ctx).unwrap();
+    NodeId::null().encode(&mut stream, &ctx).unwrap();
+    value_rank.encode(&mut stream, &ctx).unwrap();
+    dimensions.encode(&mut stream, &ctx).unwrap();
+    LocalizedText::new("foo", "bar")
+        .encode(&mut stream, &ctx)
+        .unwrap();
+    stream.into_inner()
+}
+
+#[test]
+fn argument_decode_rejects_value_rank_above_array_limit() {
+    let decoding_options = DecodingOptions {
+        max_array_length: 2,
+        ..Default::default()
+    };
+    let ctx_f = ContextOwned::new_default(NamespaceMap::new(), decoding_options);
+    let ctx = ctx_f.context();
+    let mut stream = Cursor::new(encode_argument_payload(3, Some(Vec::new())));
+
+    let err = Argument::decode(&mut stream, &ctx).unwrap_err();
+
+    assert_eq!(err.status(), StatusCode::BadDecodingError);
+}
+
+#[test]
+fn variant_decode_rejects_oversized_argument_value_rank() {
+    let ctx_f = ContextOwned::default();
+    let ctx = ctx_f.context();
+    let mut stream = Cursor::new([
+        0x16, 0x01, 0x00, 0x2a, 0x01, 0x01, 0x84, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x7e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x81, 0x00, 0x00, 0x00, 0x01,
+    ]);
+
+    let err = Variant::decode(&mut stream, &ctx).unwrap_err();
+
+    assert_eq!(err.status(), StatusCode::BadDecodingError);
+}
+
+#[test]
+fn argument_decode_pads_valid_small_value_rank() {
+    let ctx_f = ContextOwned::default();
+    let ctx = ctx_f.context();
+    let mut stream = Cursor::new(encode_argument_payload(2, Some(Vec::new())));
+
+    let decoded = Argument::decode(&mut stream, &ctx).unwrap();
+
+    assert_eq!(decoded.value_rank, 2);
+    assert_eq!(decoded.array_dimensions, Some(vec![0, 0]));
+}
+
 #[test]
 fn argument_decode_errors_when_dimensions_exceed_rank() {
     // sending value_rank=2, array_dimensions=[5, 6, 7]


### PR DESCRIPTION
## Summary

Pre-authentication remote-DoS: `Argument::decode` did `array_dimensions.resize(value_rank as usize, 0)` with an attacker-controlled `i32 value_rank` read directly off the wire. A 30-byte crafted message with `value_rank ≈ 2.1e9` drives an ~8.45 GB allocation — reachable before any session/auth check, since `Argument` decodes as part of `Variant` and a `None`-security endpoint has no cryptographic gate in front of it.

Fix bounds `value_rank` by the connection's own negotiated `max_array_length` before the resize; ordinary `value_rank`s are unaffected.

Found via fuzzing on a downstream fork of this project ([occamsshavingkit/async-opcua](https://github.com/occamsshavingkit/async-opcua)). This patch was built and verified independently against this repository's own `master`, not carried over wholesale from the fork (which has diverged substantially). Privately disclosed to @einarmo ahead of this PR, at his request.

## Test plan

- [x] New regression tests decode the exact crafted artifact (and a minimal equivalent) and assert a clean decode error, not an allocation attempt
- [x] Existing `argument_decode_pads_dimensions_when_shorter_than_rank` and friends still pass — small, in-range `value_rank`s are unaffected
- [x] `cargo test -p async-opcua-types` — 0 failures
- [x] `cargo clippy -p async-opcua-types --all-targets` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)