### PR TITLE
fix(core): enforce max_message_size on incoming TCP message headers

### DIFF
--- a/async-opcua-core/src/comms/tcp_types.rs
+++ b/async-opcua-core/src/comms/tcp_types.rs
@@ -95,10 +95,28 @@ impl SimpleBinaryEncodable for MessageHeader {
 }
 
 impl SimpleBinaryDecodable for MessageHeader {
-    fn decode<S: Read + ?Sized>(stream: &mut S, _: &DecodingOptions) -> EncodingResult<Self> {
+    fn decode<S: Read + ?Sized>(
+        stream: &mut S,
+        decoding_options: &DecodingOptions,
+    ) -> EncodingResult<Self> {
         let mut message_type = [0u8; 4];
         process_decode_io_result(stream.read_exact(&mut message_type))?;
         let message_size = read_u32(stream)?;
+        // Reject a declared message size larger than the negotiated maximum before the rest of
+        // the frame is buffered. message_size is an attacker-controlled u32 (up to 4 GB); without
+        // this a peer willing to stream bytes can grow a connection's read buffer toward that
+        // declared size. A max_message_size of 0 means "unlimited" (no negotiated cap).
+        if decoding_options.max_message_size > 0
+            && message_size as usize > decoding_options.max_message_size
+        {
+            return Err(opcua_types::Error::new(
+                StatusCode::BadTcpMessageTooLarge,
+                format!(
+                    "Message size {} exceeds maximum message size {}",
+                    message_size, decoding_options.max_message_size
+                ),
+            ));
+        }
         Ok(MessageHeader {
             message_type: MessageHeader::message_type(&message_type),
             message_size,
@@ -631,5 +649,44 @@ mod tests {
         assert!(!h.is_valid_buffer_sizes());
         h.send_buffer_size = 8192;
         assert!(h.is_valid_buffer_sizes());
+    }
+
+    fn header_bytes(message_type: &[u8; 4], message_size: u32) -> Vec<u8> {
+        let mut data = message_type.to_vec();
+        data.extend_from_slice(&message_size.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn message_header_decode_rejects_size_above_max() {
+        let mut stream = Cursor::new(header_bytes(b"ERRF", 17));
+        let decoding_options = DecodingOptions {
+            max_message_size: 16,
+            ..Default::default()
+        };
+        let err = MessageHeader::decode(&mut stream, &decoding_options).unwrap_err();
+        assert_eq!(err.status(), opcua_types::StatusCode::BadTcpMessageTooLarge);
+    }
+
+    #[test]
+    fn message_header_decode_accepts_size_at_max() {
+        let mut stream = Cursor::new(header_bytes(b"ERRF", 16));
+        let decoding_options = DecodingOptions {
+            max_message_size: 16,
+            ..Default::default()
+        };
+        let header = MessageHeader::decode(&mut stream, &decoding_options).unwrap();
+        assert_eq!(header.message_size, 16);
+    }
+
+    #[test]
+    fn message_header_decode_allows_large_size_when_max_is_unlimited() {
+        let mut stream = Cursor::new(header_bytes(b"ERRF", 4_000_000_000));
+        let decoding_options = DecodingOptions {
+            max_message_size: 0,
+            ..Default::default()
+        };
+        let header = MessageHeader::decode(&mut stream, &decoding_options).unwrap();
+        assert_eq!(header.message_size, 4_000_000_000);
     }
 }


### PR DESCRIPTION
## Summary

Unauthenticated remote DoS surface: `MessageHeader::decode` read the declared `message_size` off the wire but never checked it against the connection's own negotiated `max_message_size` (the `DecodingOptions` parameter was received but ignored, per the leading underscore). This check runs before `OpenSecureChannel`, so it's reachable by any peer that's opened a raw TCP connection, no authentication required.

Reject `message_size > max_message_size` with `Bad_TcpMessageTooLarge` before the rest of the frame is buffered. `max_message_size == 0` continues to mean "unlimited," matching this repo's existing convention for that field.

Found and fixed on a downstream fork of this project ([occamsshavingkit/async-opcua](https://github.com/occamsshavingkit/async-opcua)). This patch was built and verified independently against this repository's own `master`, not carried over wholesale from the fork (which has diverged substantially). Privately disclosed to @einarmo ahead of this PR, at his request.

## Test plan

- [x] New regression tests: rejects a size above the max, accepts a size exactly at the max, and confirms `max_message_size = 0` still means unlimited
- [x] `cargo test -p async-opcua-core` — 0 failures
- [x] `cargo clippy -p async-opcua-core --all-targets` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)